### PR TITLE
Additional changes for WG LC preparation

### DIFF
--- a/ietf-layer0-types-tree.txt
+++ b/ietf-layer0-types-tree.txt
@@ -329,7 +329,7 @@ module: ietf-layer0-types
     +--ro rx-channel-power-max?     power-dbm
     +--ro rx-total-power-max?       power-dbm
   grouping common-transceiver-configured-param:
-    +--ro line-coding-bitrate?   identityref
+    +-- line-coding-bitrate?   identityref
     +-- tx-channel-power?      power-dbm-or-null
     +--ro rx-channel-power?      power-dbm-or-null
     +--ro rx-total-power?        power-dbm-or-null

--- a/ietf-layer0-types-tree.txt
+++ b/ietf-layer0-types-tree.txt
@@ -163,7 +163,7 @@ module: ietf-layer0-types
              +--ro fec-threshold?                      decimal64
              +--ro in-band-osnr?                       snr
              +--ro out-of-band-osnr?                   snr
-             +--ro tx-polarization-power-difference?   decimal-2
+             +--ro tx-polarization-power-difference?   power-ratio
              +--ro polarization-skew?                  decimal64
              +--ro min-central-frequency?              frequency-thz
              +--ro max-central-frequency?              frequency-thz
@@ -249,7 +249,7 @@ module: ietf-layer0-types
                    +--ro in-band-osnr?                       snr
                    +--ro out-of-band-osnr?                   snr
                    +--ro tx-polarization-power-difference?
-                   |       decimal-2
+                   |       power-ratio
                    +--ro polarization-skew?
                    |       decimal64
                    +--ro min-central-frequency?
@@ -311,7 +311,7 @@ module: ietf-layer0-types
     +--ro fec-threshold?                      decimal64
     +--ro in-band-osnr?                       snr
     +--ro out-of-band-osnr?                   snr
-    +--ro tx-polarization-power-difference?   decimal-2
+    +--ro tx-polarization-power-difference?   power-ratio
     +--ro polarization-skew?                  decimal64
   grouping common-standard-organizational-mode:
     +--ro line-coding-bitrate*   identityref
@@ -340,7 +340,7 @@ module: ietf-layer0-types
     +-- lower-frequency    frequency-thz
     +-- upper-frequency    frequency-thz
   grouping l0-path-constraints:
-    +-- gsnr-margin?   snr
+    +-- gsnr-extra-margin?   snr
   grouping l0-path-properties:
     +--ro estimated-gsnr?          snr
     +--ro estimated-eol-gsnr?      snr

--- a/ietf-layer0-types-tree.txt
+++ b/ietf-layer0-types-tree.txt
@@ -334,7 +334,6 @@ module: ietf-layer0-types
     +--ro rx-channel-power?      power-dbm-or-null
     +--ro rx-total-power?        power-dbm-or-null
   grouping l0-tunnel-attributes:
-    +-- bit-stuffing?            boolean
     +-- wavelength-assignment?   identityref
   grouping frequency-range:
     +-- lower-frequency    frequency-thz

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -329,7 +329,7 @@ module: ietf-layer0-types
     +--ro rx-channel-power-max?     power-dbm
     +--ro rx-total-power-max?       power-dbm
   grouping common-transceiver-configured-param:
-    +--ro line-coding-bitrate?   identityref
+    +-- line-coding-bitrate?   identityref
     +-- tx-channel-power?      power-dbm-or-null
     +--ro rx-channel-power?      power-dbm-or-null
     +--ro rx-total-power?        power-dbm-or-null

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -163,7 +163,7 @@ module: ietf-layer0-types
              +--ro fec-threshold?                      decimal64
              +--ro in-band-osnr?                       snr
              +--ro out-of-band-osnr?                   snr
-             +--ro tx-polarization-power-difference?   decimal-2
+             +--ro tx-polarization-power-difference?   power-ratio
              +--ro polarization-skew?                  decimal64
              +--ro min-central-frequency?              frequency-thz
              +--ro max-central-frequency?              frequency-thz
@@ -249,7 +249,7 @@ module: ietf-layer0-types
                    +--ro in-band-osnr?                       snr
                    +--ro out-of-band-osnr?                   snr
                    +--ro tx-polarization-power-difference?
-                   |       decimal-2
+                   |       power-ratio
                    +--ro polarization-skew?
                    |       decimal64
                    +--ro min-central-frequency?
@@ -311,7 +311,7 @@ module: ietf-layer0-types
     +--ro fec-threshold?                      decimal64
     +--ro in-band-osnr?                       snr
     +--ro out-of-band-osnr?                   snr
-    +--ro tx-polarization-power-difference?   decimal-2
+    +--ro tx-polarization-power-difference?   power-ratio
     +--ro polarization-skew?                  decimal64
   grouping common-standard-organizational-mode:
     +--ro line-coding-bitrate*   identityref
@@ -340,7 +340,7 @@ module: ietf-layer0-types
     +-- lower-frequency    frequency-thz
     +-- upper-frequency    frequency-thz
   grouping l0-path-constraints:
-    +-- gsnr-margin?   snr
+    +-- gsnr-extra-margin?   snr
   grouping l0-path-properties:
     +--ro estimated-gsnr?          snr
     +--ro estimated-eol-gsnr?      snr

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -334,7 +334,6 @@ module: ietf-layer0-types
     +--ro rx-channel-power?      power-dbm-or-null
     +--ro rx-total-power?        power-dbm-or-null
   grouping l0-tunnel-attributes:
-    +-- bit-stuffing?            boolean
     +-- wavelength-assignment?   identityref
   grouping frequency-range:
     +-- lower-frequency    frequency-thz

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -2130,11 +2130,10 @@ module ietf-layer0-types {
       type identityref {
         base line-coding;
       }
-      config false;
       description
         "Bit rate/line coding of the optical tributary signal.
         
-        Reporting this attribute is optional when the configured 
+        Support of this attribute is optional when the configured 
         mode supports only one bit rate/line coding.";
       reference 
         "ITU-T G.698.2 section 7.1.2";

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -2212,7 +2212,7 @@ module ietf-layer0-types {
     description
       "Common attribute for Layer 0 path constraints to be used by
       Layer 0 computation.";
-    leaf gsnr-margin {
+    leaf gsnr-extra-margin {
       type snr {
         range 0..max;
       }

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -512,37 +512,6 @@ module ietf-layer0-types {
         Optical Networks";
     }
 
-  identity term-type {
-    description
-      "Termination type";
-    reference
-      "ITU-T G.709: Interfaces for the Optical Transport Network";
-  }
-
-    identity term-phys {
-      base term-type;
-      description
-        "Physical layer termination";
-    }
-
-    identity term-otu {
-      base term-type;
-      description
-        "OTU (Optical Transport Unit) termination";
-    }
-
-    identity term-odu {
-      base term-type;
-      description
-        "ODU (Optical Data Unit) termination";
-    }
-
-    identity term-opu {
-      base term-type;
-      description
-        "OPU (Optical Payload Unit) termination";
-    }
-
   identity otu-type {
     description
       "Base identity from which specific OTU identities are derived";
@@ -2166,11 +2135,7 @@ module ietf-layer0-types {
   grouping l0-tunnel-attributes {
     description
       "Parameters for Layer0 (WSON or Flexi-Grid) Tunnels.";
-    leaf bit-stuffing {
-      type boolean;
-      description
-        "Bit stuffing enabled/disabled.";
-    }
+
     leaf wavelength-assignment {
       type identityref {
         base wavelength-assignment;


### PR DESCRIPTION
Changed name for gsnr-margin: fix #87

Made line-coding-bitrate configurable: fix #85 

Updated l0-tunnel-attributes grouping: fix #84 
- removed bit-stuffing attribute from l0-tunnel-attribute grouping
- removed term-type base identity and all its derived identities

---

Co-authored-by: sergio belotti <sergio.belotti@nokia.com>
