### PR TITLE
Further updates for WG LC preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .refcache
+*.bash

--- a/ietf-layer0-types-tree.txt
+++ b/ietf-layer0-types-tree.txt
@@ -132,6 +132,7 @@ module: ietf-layer0-types
        |     +--ro rx-total-power-max?        power-dbm
        +--:(explicit-mode)
           +--ro explicit-mode
+<<<<<<< HEAD
              +--ro min-central-frequency?    frequency-thz
              +--ro max-central-frequency?    frequency-thz
              +--ro transceiver-tunability?   frequency-ghz
@@ -140,6 +141,49 @@ module: ietf-layer0-types
              +--ro rx-channel-power-min?     power-dbm
              +--ro rx-channel-power-max?     power-dbm
              +--ro rx-total-power-max?       power-dbm
+=======
+             +--ro line-coding-bitrate?                identityref
+             +--ro bitrate?                            uint16
+             +--ro max-diff-group-delay?               uint32
+             +--ro max-chromatic-dispersion?           decimal64
+             +--ro cd-penalty* []
+             |  +--ro cd-value         union
+             |  +--ro penalty-value    union
+             +--ro max-polarization-mode-dispersion?   decimal64
+             +--ro pmd-penalty* []
+             |  +--ro pmd-value        union
+             |  +--ro penalty-value    union
+             +--ro max-polarization-dependant-loss
+             |       power-loss-or-null
+             +--ro pdl-penalty* []
+             |  +--ro pdl-value        power-loss-or-null
+             |  +--ro penalty-value    union
+             +--ro available-modulation-type?          identityref
+             +--ro min-OSNR?                           snr
+             +--ro rx-ref-channel-power?               power-dbm
+             +--ro rx-channel-power-penalty* []
+             |  +--ro rx-channel-power-value    power-dbm-or-null
+             |  +--ro penalty-value             union
+             +--ro min-Q-factor?                       int32
+             +--ro available-baud-rate?                uint32
+             +--ro roll-off?                           decimal64
+             +--ro min-carrier-spacing?                frequency-ghz
+             +--ro available-fec-type?                 identityref
+             +--ro fec-code-rate?                      decimal64
+             +--ro fec-threshold?                      decimal64
+             +--ro in-band-osnr?                       snr
+             +--ro out-of-band-osnr?                   snr
+             +--ro tx-polarization-power-difference?   power-ratio
+             +--ro polarization-skew?                  decimal64
+             +--ro min-central-frequency?              frequency-thz
+             +--ro max-central-frequency?              frequency-thz
+             +--ro transceiver-tunability?             frequency-ghz
+             +--ro tx-channel-power-min?               power-dbm
+             +--ro tx-channel-power-max?               power-dbm
+             +--ro rx-channel-power-min?               power-dbm
+             +--ro rx-channel-power-max?               power-dbm
+             +--ro rx-total-power-max?                 power-dbm
+>>>>>>> Changed name for gsnr-margin: fix #87
              +--ro compatible-modes
   grouping transceiver-capabilities:
     +-- supported-modes!
@@ -173,6 +217,7 @@ module: ietf-layer0-types
              |     +--ro rx-total-power-max?        power-dbm
              +--:(explicit-mode)
                 +--ro explicit-mode
+<<<<<<< HEAD
                    +--ro min-central-frequency?    frequency-thz
                    +--ro max-central-frequency?    frequency-thz
                    +--ro transceiver-tunability?   frequency-ghz
@@ -181,6 +226,70 @@ module: ietf-layer0-types
                    +--ro rx-channel-power-min?     power-dbm
                    +--ro rx-channel-power-max?     power-dbm
                    +--ro rx-total-power-max?       power-dbm
+=======
+                   +--ro line-coding-bitrate?
+                   |       identityref
+                   +--ro bitrate?                            uint16
+                   +--ro max-diff-group-delay?               uint32
+                   +--ro max-chromatic-dispersion?
+                   |       decimal64
+                   +--ro cd-penalty* []
+                   |  +--ro cd-value         union
+                   |  +--ro penalty-value    union
+                   +--ro max-polarization-mode-dispersion?
+                   |       decimal64
+                   +--ro pmd-penalty* []
+                   |  +--ro pmd-value        union
+                   |  +--ro penalty-value    union
+                   +--ro max-polarization-dependant-loss
+                   |       power-loss-or-null
+                   +--ro pdl-penalty* []
+                   |  +--ro pdl-value        power-loss-or-null
+                   |  +--ro penalty-value    union
+                   +--ro available-modulation-type?
+                   |       identityref
+                   +--ro min-OSNR?                           snr
+                   +--ro rx-ref-channel-power?
+                   |       power-dbm
+                   +--ro rx-channel-power-penalty* []
+                   |  +--ro rx-channel-power-value
+                   |  |       power-dbm-or-null
+                   |  +--ro penalty-value             union
+                   +--ro min-Q-factor?                       int32
+                   +--ro available-baud-rate?                uint32
+                   +--ro roll-off?
+                   |       decimal64
+                   +--ro min-carrier-spacing?
+                   |       frequency-ghz
+                   +--ro available-fec-type?
+                   |       identityref
+                   +--ro fec-code-rate?
+                   |       decimal64
+                   +--ro fec-threshold?
+                   |       decimal64
+                   +--ro in-band-osnr?                       snr
+                   +--ro out-of-band-osnr?                   snr
+                   +--ro tx-polarization-power-difference?
+                   |       power-ratio
+                   +--ro polarization-skew?
+                   |       decimal64
+                   +--ro min-central-frequency?
+                   |       frequency-thz
+                   +--ro max-central-frequency?
+                   |       frequency-thz
+                   +--ro transceiver-tunability?
+                   |       frequency-ghz
+                   +--ro tx-channel-power-min?
+                   |       power-dbm
+                   +--ro tx-channel-power-max?
+                   |       power-dbm
+                   +--ro rx-channel-power-min?
+                   |       power-dbm
+                   +--ro rx-channel-power-max?
+                   |       power-dbm
+                   +--ro rx-total-power-max?
+                   |       power-dbm
+>>>>>>> Changed name for gsnr-margin: fix #87
                    +--ro compatible-modes
                       +--ro supported-application-codes*
                       |       -> ../../../mode-id

--- a/ietf-layer0-types-tree.txt
+++ b/ietf-layer0-types-tree.txt
@@ -132,47 +132,14 @@ module: ietf-layer0-types
        |     +--ro rx-total-power-max?        power-dbm
        +--:(explicit-mode)
           +--ro explicit-mode
-             +--ro line-coding-bitrate?                identityref
-             +--ro bitrate?                            uint16
-             +--ro max-diff-group-delay?               uint32
-             +--ro max-chromatic-dispersion?           decimal64
-             +--ro cd-penalty* []
-             |  +--ro cd-value         union
-             |  +--ro penalty-value    union
-             +--ro max-polarization-mode-dispersion?   decimal64
-             +--ro pmd-penalty* []
-             |  +--ro pmd-value        union
-             |  +--ro penalty-value    union
-             +--ro max-polarization-dependant-loss
-             |       power-loss-or-null
-             +--ro pdl-penalty* []
-             |  +--ro pdl-value        power-loss-or-null
-             |  +--ro penalty-value    union
-             +--ro available-modulation-type?          identityref
-             +--ro min-OSNR?                           snr
-             +--ro rx-ref-channel-power?               power-dbm
-             +--ro rx-channel-power-penalty* []
-             |  +--ro rx-channel-power-value    power-dbm-or-null
-             |  +--ro penalty-value             union
-             +--ro min-Q-factor?                       int32
-             +--ro available-baud-rate?                uint32
-             +--ro roll-off?                           decimal64
-             +--ro min-carrier-spacing?                frequency-ghz
-             +--ro available-fec-type?                 identityref
-             +--ro fec-code-rate?                      decimal64
-             +--ro fec-threshold?                      decimal64
-             +--ro in-band-osnr?                       snr
-             +--ro out-of-band-osnr?                   snr
-             +--ro tx-polarization-power-difference?   power-ratio
-             +--ro polarization-skew?                  decimal64
-             +--ro min-central-frequency?              frequency-thz
-             +--ro max-central-frequency?              frequency-thz
-             +--ro transceiver-tunability?             frequency-ghz
-             +--ro tx-channel-power-min?               power-dbm
-             +--ro tx-channel-power-max?               power-dbm
-             +--ro rx-channel-power-min?               power-dbm
-             +--ro rx-channel-power-max?               power-dbm
-             +--ro rx-total-power-max?                 power-dbm
+             +--ro min-central-frequency?    frequency-thz
+             +--ro max-central-frequency?    frequency-thz
+             +--ro transceiver-tunability?   frequency-ghz
+             +--ro tx-channel-power-min?     power-dbm
+             +--ro tx-channel-power-max?     power-dbm
+             +--ro rx-channel-power-min?     power-dbm
+             +--ro rx-channel-power-max?     power-dbm
+             +--ro rx-total-power-max?       power-dbm
              +--ro compatible-modes
   grouping transceiver-capabilities:
     +-- supported-modes!
@@ -206,68 +173,14 @@ module: ietf-layer0-types
              |     +--ro rx-total-power-max?        power-dbm
              +--:(explicit-mode)
                 +--ro explicit-mode
-                   +--ro line-coding-bitrate?
-                   |       identityref
-                   +--ro bitrate?                            uint16
-                   +--ro max-diff-group-delay?               uint32
-                   +--ro max-chromatic-dispersion?
-                   |       decimal64
-                   +--ro cd-penalty* []
-                   |  +--ro cd-value         union
-                   |  +--ro penalty-value    union
-                   +--ro max-polarization-mode-dispersion?
-                   |       decimal64
-                   +--ro pmd-penalty* []
-                   |  +--ro pmd-value        union
-                   |  +--ro penalty-value    union
-                   +--ro max-polarization-dependant-loss
-                   |       power-loss-or-null
-                   +--ro pdl-penalty* []
-                   |  +--ro pdl-value        power-loss-or-null
-                   |  +--ro penalty-value    union
-                   +--ro available-modulation-type?
-                   |       identityref
-                   +--ro min-OSNR?                           snr
-                   +--ro rx-ref-channel-power?
-                   |       power-dbm
-                   +--ro rx-channel-power-penalty* []
-                   |  +--ro rx-channel-power-value
-                   |  |       power-dbm-or-null
-                   |  +--ro penalty-value             union
-                   +--ro min-Q-factor?                       int32
-                   +--ro available-baud-rate?                uint32
-                   +--ro roll-off?
-                   |       decimal64
-                   +--ro min-carrier-spacing?
-                   |       frequency-ghz
-                   +--ro available-fec-type?
-                   |       identityref
-                   +--ro fec-code-rate?
-                   |       decimal64
-                   +--ro fec-threshold?
-                   |       decimal64
-                   +--ro in-band-osnr?                       snr
-                   +--ro out-of-band-osnr?                   snr
-                   +--ro tx-polarization-power-difference?
-                   |       power-ratio
-                   +--ro polarization-skew?
-                   |       decimal64
-                   +--ro min-central-frequency?
-                   |       frequency-thz
-                   +--ro max-central-frequency?
-                   |       frequency-thz
-                   +--ro transceiver-tunability?
-                   |       frequency-ghz
-                   +--ro tx-channel-power-min?
-                   |       power-dbm
-                   +--ro tx-channel-power-max?
-                   |       power-dbm
-                   +--ro rx-channel-power-min?
-                   |       power-dbm
-                   +--ro rx-channel-power-max?
-                   |       power-dbm
-                   +--ro rx-total-power-max?
-                   |       power-dbm
+                   +--ro min-central-frequency?    frequency-thz
+                   +--ro max-central-frequency?    frequency-thz
+                   +--ro transceiver-tunability?   frequency-ghz
+                   +--ro tx-channel-power-min?     power-dbm
+                   +--ro tx-channel-power-max?     power-dbm
+                   +--ro rx-channel-power-min?     power-dbm
+                   +--ro rx-channel-power-max?     power-dbm
+                   +--ro rx-total-power-max?       power-dbm
                    +--ro compatible-modes
                       +--ro supported-application-codes*
                       |       -> ../../../mode-id
@@ -280,7 +193,7 @@ module: ietf-layer0-types
     +--ro organization-identifier?   organization-identifier
   grouping penalty-value:
     +--ro penalty-value    union
-  grouping common-explicit-mode:
+  grouping explicit-mode:
     +--ro line-coding-bitrate?                identityref
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               uint32
@@ -328,11 +241,17 @@ module: ietf-layer0-types
     +--ro rx-channel-power-min?     power-dbm
     +--ro rx-channel-power-max?     power-dbm
     +--ro rx-total-power-max?       power-dbm
-  grouping common-transceiver-configured-param:
+  grouping common-transceiver-param:
     +-- line-coding-bitrate?   identityref
     +-- tx-channel-power?      power-dbm-or-null
     +--ro rx-channel-power?      power-dbm-or-null
     +--ro rx-total-power?        power-dbm-or-null
+  grouping common-transceiver-configured-param:
+    +-- line-coding-bitrate?   identityref
+    +-- tx-channel-power?      power-dbm-or-null
+  grouping common-transceiver-readonly-param:
+    +--ro rx-channel-power?   power-dbm-or-null
+    +--ro rx-total-power?     power-dbm-or-null
   grouping l0-tunnel-attributes:
     +-- wavelength-assignment?   identityref
   grouping frequency-range:

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -132,47 +132,14 @@ module: ietf-layer0-types
        |     +--ro rx-total-power-max?        power-dbm
        +--:(explicit-mode)
           +--ro explicit-mode
-             +--ro line-coding-bitrate?                identityref
-             +--ro bitrate?                            uint16
-             +--ro max-diff-group-delay?               uint32
-             +--ro max-chromatic-dispersion?           decimal64
-             +--ro cd-penalty* []
-             |  +--ro cd-value         union
-             |  +--ro penalty-value    union
-             +--ro max-polarization-mode-dispersion?   decimal64
-             +--ro pmd-penalty* []
-             |  +--ro pmd-value        union
-             |  +--ro penalty-value    union
-             +--ro max-polarization-dependant-loss
-             |       power-loss-or-null
-             +--ro pdl-penalty* []
-             |  +--ro pdl-value        power-loss-or-null
-             |  +--ro penalty-value    union
-             +--ro available-modulation-type?          identityref
-             +--ro min-OSNR?                           snr
-             +--ro rx-ref-channel-power?               power-dbm
-             +--ro rx-channel-power-penalty* []
-             |  +--ro rx-channel-power-value    power-dbm-or-null
-             |  +--ro penalty-value             union
-             +--ro min-Q-factor?                       int32
-             +--ro available-baud-rate?                uint32
-             +--ro roll-off?                           decimal64
-             +--ro min-carrier-spacing?                frequency-ghz
-             +--ro available-fec-type?                 identityref
-             +--ro fec-code-rate?                      decimal64
-             +--ro fec-threshold?                      decimal64
-             +--ro in-band-osnr?                       snr
-             +--ro out-of-band-osnr?                   snr
-             +--ro tx-polarization-power-difference?   power-ratio
-             +--ro polarization-skew?                  decimal64
-             +--ro min-central-frequency?              frequency-thz
-             +--ro max-central-frequency?              frequency-thz
-             +--ro transceiver-tunability?             frequency-ghz
-             +--ro tx-channel-power-min?               power-dbm
-             +--ro tx-channel-power-max?               power-dbm
-             +--ro rx-channel-power-min?               power-dbm
-             +--ro rx-channel-power-max?               power-dbm
-             +--ro rx-total-power-max?                 power-dbm
+             +--ro min-central-frequency?    frequency-thz
+             +--ro max-central-frequency?    frequency-thz
+             +--ro transceiver-tunability?   frequency-ghz
+             +--ro tx-channel-power-min?     power-dbm
+             +--ro tx-channel-power-max?     power-dbm
+             +--ro rx-channel-power-min?     power-dbm
+             +--ro rx-channel-power-max?     power-dbm
+             +--ro rx-total-power-max?       power-dbm
              +--ro compatible-modes
   grouping transceiver-capabilities:
     +-- supported-modes!
@@ -206,68 +173,14 @@ module: ietf-layer0-types
              |     +--ro rx-total-power-max?        power-dbm
              +--:(explicit-mode)
                 +--ro explicit-mode
-                   +--ro line-coding-bitrate?
-                   |       identityref
-                   +--ro bitrate?                            uint16
-                   +--ro max-diff-group-delay?               uint32
-                   +--ro max-chromatic-dispersion?
-                   |       decimal64
-                   +--ro cd-penalty* []
-                   |  +--ro cd-value         union
-                   |  +--ro penalty-value    union
-                   +--ro max-polarization-mode-dispersion?
-                   |       decimal64
-                   +--ro pmd-penalty* []
-                   |  +--ro pmd-value        union
-                   |  +--ro penalty-value    union
-                   +--ro max-polarization-dependant-loss
-                   |       power-loss-or-null
-                   +--ro pdl-penalty* []
-                   |  +--ro pdl-value        power-loss-or-null
-                   |  +--ro penalty-value    union
-                   +--ro available-modulation-type?
-                   |       identityref
-                   +--ro min-OSNR?                           snr
-                   +--ro rx-ref-channel-power?
-                   |       power-dbm
-                   +--ro rx-channel-power-penalty* []
-                   |  +--ro rx-channel-power-value
-                   |  |       power-dbm-or-null
-                   |  +--ro penalty-value             union
-                   +--ro min-Q-factor?                       int32
-                   +--ro available-baud-rate?                uint32
-                   +--ro roll-off?
-                   |       decimal64
-                   +--ro min-carrier-spacing?
-                   |       frequency-ghz
-                   +--ro available-fec-type?
-                   |       identityref
-                   +--ro fec-code-rate?
-                   |       decimal64
-                   +--ro fec-threshold?
-                   |       decimal64
-                   +--ro in-band-osnr?                       snr
-                   +--ro out-of-band-osnr?                   snr
-                   +--ro tx-polarization-power-difference?
-                   |       power-ratio
-                   +--ro polarization-skew?
-                   |       decimal64
-                   +--ro min-central-frequency?
-                   |       frequency-thz
-                   +--ro max-central-frequency?
-                   |       frequency-thz
-                   +--ro transceiver-tunability?
-                   |       frequency-ghz
-                   +--ro tx-channel-power-min?
-                   |       power-dbm
-                   +--ro tx-channel-power-max?
-                   |       power-dbm
-                   +--ro rx-channel-power-min?
-                   |       power-dbm
-                   +--ro rx-channel-power-max?
-                   |       power-dbm
-                   +--ro rx-total-power-max?
-                   |       power-dbm
+                   +--ro min-central-frequency?    frequency-thz
+                   +--ro max-central-frequency?    frequency-thz
+                   +--ro transceiver-tunability?   frequency-ghz
+                   +--ro tx-channel-power-min?     power-dbm
+                   +--ro tx-channel-power-max?     power-dbm
+                   +--ro rx-channel-power-min?     power-dbm
+                   +--ro rx-channel-power-max?     power-dbm
+                   +--ro rx-total-power-max?       power-dbm
                    +--ro compatible-modes
                       +--ro supported-application-codes*
                       |       -> ../../../mode-id
@@ -280,7 +193,7 @@ module: ietf-layer0-types
     +--ro organization-identifier?   organization-identifier
   grouping penalty-value:
     +--ro penalty-value    union
-  grouping common-explicit-mode:
+  grouping explicit-mode:
     +--ro line-coding-bitrate?                identityref
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               uint32

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -328,11 +328,17 @@ module: ietf-layer0-types
     +--ro rx-channel-power-min?     power-dbm
     +--ro rx-channel-power-max?     power-dbm
     +--ro rx-total-power-max?       power-dbm
-  grouping common-transceiver-configured-param:
+  grouping common-transceiver-param:
     +-- line-coding-bitrate?   identityref
     +-- tx-channel-power?      power-dbm-or-null
     +--ro rx-channel-power?      power-dbm-or-null
     +--ro rx-total-power?        power-dbm-or-null
+  grouping common-transceiver-configured-param:
+    +-- line-coding-bitrate?   identityref
+    +-- tx-channel-power?      power-dbm-or-null
+  grouping common-transceiver-readonly-param:
+    +--ro rx-channel-power?   power-dbm-or-null
+    +--ro rx-total-power?     power-dbm-or-null
   grouping l0-tunnel-attributes:
     +-- wavelength-assignment?   identityref
   grouping frequency-range:

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -51,7 +51,7 @@ module ietf-layer0-types {
 
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-01-23 {
+  revision 2024-02-14 {
     description
       "To be updated";
     reference

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -2090,6 +2090,15 @@ module ietf-layer0-types {
     }
   } // grouping common-all-modes
 
+  grouping common-transceiver-param {
+    description
+      "The common parameters of an optical transceiver,
+      that supplement the configured mode.";
+
+    uses common-transceiver-configured-param;
+    uses common-transceiver-readonly-param;
+  }
+
   grouping common-transceiver-configured-param {
     description
       "The configured parameters of an optical transceiver,
@@ -2116,6 +2125,13 @@ module ietf-layer0-types {
         The empty value MUST NOT be used when this attribute is 
         configured.";
     }
+  } // grouping for configured transceiver attributes out of mode
+
+  grouping common-transceiver-readonly-param {
+    description
+      "The common read-only parameters of an optical transceiver,
+      that supplement the configured mode.";
+
     leaf rx-channel-power {
       type power-dbm-or-null;
       config false;
@@ -2130,7 +2146,7 @@ module ietf-layer0-types {
         "The current total received power, when the value is known 
         or an empty value when the value is not known.";
     }
-  } // grouping for configured attributes out of mode
+  } // grouping for read-only transceiver attributes out of mode
 
   grouping l0-tunnel-attributes {
     description

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -1533,11 +1533,18 @@ module ietf-layer0-types {
   grouping transceiver-mode {
     description
       "This grouping is intended to be used for reporting the
-       information of a transceiver's mode.
-       
-       The compatible-modes container shall be augmented with the 
-       proper leafrefs when used: see for example the 
-       transceiver-capabilities grouping below.";
+      information of a transceiver's mode.
+
+      The attributes for the explicit mode shall be augmented when
+      used with either:
+      - the proper leafrefs, when explicit mode templates are used;
+        or,
+      - the explicit-mode grouping, when explicit mode templates
+        are not used.
+
+      The compatible-modes container shall be augmented with the 
+      proper leafrefs when used: see for example the 
+      transceiver-capabilities grouping below.";
     choice mode {
       mandatory true;
       description
@@ -1563,7 +1570,7 @@ module ietf-layer0-types {
           config false;
           description
             "The set of attributes for an explicit mode";
-          uses common-explicit-mode;
+          // uses explicit-mode;
           uses common-all-modes;
           container compatible-modes {
             description
@@ -1579,7 +1586,14 @@ module ietf-layer0-types {
   grouping transceiver-capabilities {
     description
       "This grouping is intended to be used for reporting the
-       capabilities of a transceiver.";
+      capabilities of a transceiver.
+      
+      The attributes for the explicit mode shall be augmented when
+      used with either:
+      - the proper leafrefs, when explicit mode templates are used;
+        or,
+      - the explicit-mode grouping, when explicit mode templates
+        are not used.";
 
     container supported-modes {
       presence
@@ -1700,7 +1714,7 @@ module ietf-layer0-types {
     }
   }
 
-  grouping common-explicit-mode {
+  grouping explicit-mode {
     description
       "Attributes capabilities related to explicit transceiver's
       mode.
@@ -2007,7 +2021,7 @@ module ietf-layer0-types {
       reference
         "OIF-400ZR-01.0: Implementation Agreement 400ZR";
     }
-  } // grouping common-explicit-mode    
+  } // grouping explicit-mode    
 
   grouping common-standard-organizational-mode {
     description


### PR DESCRIPTION
Further updates for WG LC preparation:

- Split rw and ro attributes for common-transceiver-param grouping: fix  #86 
- Fix https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/164

---

Co-authored-by: sergio belotti <sergio.belotti@nokia.com>
Co-authored-by: agva123 <agva123@gmail.com>
