### PR TITLE
WG LC preparation (step 4)

### DIFF
--- a/draft-ietf-ccamp-rfc9093-bis.md
+++ b/draft-ietf-ccamp-rfc9093-bis.md
@@ -4,7 +4,7 @@ coding: utf-8
 title: A YANG Data Model for Layer 0 Types
 
 abbrev: Yang for Layer 0 Types
-docname: draft-ietf-ccamp-rfc9093-bis-09
+docname: draft-ietf-ccamp-rfc9093-bis-latest
 obsoletes: 9093
 submissiontype: IETF
 workgroup: CCAMP Working Group
@@ -94,6 +94,24 @@ normative:
       org: ITU-T Recommendation G.709
     date: March 2020
     seriesinfo: ITU-T G.709
+  ITU-T_G.977.1:
+    title: "Transverse compatible dense wavelength division multiplexing applications for repeatered optical fibre submarine cable systems"
+    author:
+      org: ITU-T Recommendation G.977.1
+    date: February 2021
+    seriesinfo: ITU-T G.977.1
+  ITU-T_G.9700:
+    title: "Fast access to subscriber terminals (G.fast) - Power spectral density specification"
+    author:
+      org: ITU-T Recommendation G.9700
+    date: July 2019
+    seriesinfo: ITU-T G.9700
+  ITU-T_G.666:
+    title: "Characteristics of polarization mode dispersion compensators and of receivers that compensate for polarization mode dispersion"
+    author:
+      org: ITU-T Recommendation G.666
+    date: February 2011
+    seriesinfo: ITU-T G.666
 
 informative:
   ITU-T_G.694.1:
@@ -114,6 +132,12 @@ informative:
       org: ITU-T Supplement G.Sup43
     date: December 2003
     seriesinfo: ITU-T G.Sup43
+  ITU-T_G.Sup39:
+    title: "Optical system design and engineering considerations"
+    author:
+      org: ITU-T Supplement G.Sup39
+    date: February 2016
+    seriesinfo: ITU-T G.Sup39
 
 --- abstract
 
@@ -351,6 +375,22 @@ otu-type:
    optional penalty associated with a given accumulated CD and PMD.
    This list of triplet cd, pmd, penalty can be used to sample the
    function penalty = f(CD, PMD).
+
+   modulation-format:
+
+   > TBD: add a description and informative reference to {{ITU-T_G.Sup39}}
+
+   snr:
+
+   > TBD: add a description and reference to {{ITU-T_G.977.1}}
+
+   psd:
+
+   > TBD: add a description and reference to {{ITU-T_G.9700}}
+
+   pmd:
+
+   > TBD: add a description and reference to {{ITU-T_G.666}}
 
 ## WDM Label and Label Range
 

--- a/draft-ietf-ccamp-rfc9093-bis.md
+++ b/draft-ietf-ccamp-rfc9093-bis.md
@@ -142,12 +142,13 @@ informative:
 --- abstract
 
 This document defines a collection of common data types, identities, and groupings
-in the YANG data modeling language. These derived common data types, identities,
+in the YANG data modeling language. 
+These common types and groupings, derived from the built-in YANG data types, identities,
 and groupings are intended to be imported by modules that model Layer 0
 configuration and state capabilities, such as Wavelength Switched Optical Networks (WSONs) and
 flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.
 
-   This document obsoletes RFC 9093.
+This document obsoletes RFC 9093 by replacing the YANG module it contained with a new revision that includes additional YANG data types, identities and groupings.
 
 --- middle
 
@@ -176,6 +177,12 @@ flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.
    statements of the YANG module in {{yang-code}} or the summary in
    {{changes-bis}}.
 
+This document obsoletes {{?RFC9093}} by replacing it in its entirety. It
+provides a new revision of the YANG module contained in that RFC,
+and retains the data types previously defined, but also adds new type
+definitions to the YANG module.
+For further details, see {{changes-bis}}.
+
    The YANG data model in this document conforms to the Network
    Management Datastore Architecture defined in {{!RFC8342}}.
 
@@ -191,14 +198,14 @@ flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.
 
    In this document, names of data nodes and other data model objects
    are prefixed using the standard prefix associated with the
-   corresponding YANG imported modules.
+   corresponding YANG imported module.
 
 | Prefix       | YANG module                      | Reference
 | l0-types     | ietf-layer0-types                | RFC XXXX
-{: #tab-prefixes title="Prefixes and corresponding YANG modules"}
+{: #tab-prefixes title="Prefixes and corresponding YANG module"}
 
 RFC Editor Note:
-Please replace XXXX with the RFC number assigned to this document.
+Please replace XXXX with the RFC number assigned to this document and remove this note.
 
 # Layer 0 Types Module Contents
 
@@ -335,65 +342,62 @@ otu-type:
     to support optical network scenarios that contain both fixed- and flexi-grid
     links.
 
-   transceiver-capabilities:
+transceiver-capabilities:
 
-   > a YANG grouping to define the transceiver capabilities (also called
-   "modes") needed to determine optical signal compatibility.
+> A YANG grouping to define the transceiver capabilities (also called
+"modes") needed to determine optical signal compatibility.
 
-   standard-mode:
+standard-mode:
 
-   > a YANG grouping for the standard modes defined in {{ITU-T_G.698.2}}.
+> A YANG grouping for the standard modes defined in {{ITU-T_G.698.2}}.
 
-   organizational-mode:
+organizational-mode:
 
-   > a YANG grouping to define transponder operational mode supported by
-   organizations or vendors.
+> A YANG grouping to define transponder operational mode supported by
+organizations or vendors, as defined in {{!I-D.ietf-ccamp-optical-impairment-topology-yang}}.
 
-   common-explicit-mode:
+common-explicit-mode:
 
-   > a YANG grouping to define the list of attributes related to optical
-   impairments limits in case of transceiver explicit mode.  This
-   grouping should be the same used in
-   {{?I-D.ietf-ccamp-dwdm-if-param-yang}}.
+> A YANG grouping to define the list of attributes related to optical
+impairments limits in case of transceiver explicit mode, as defined in {{!I-D.ietf-ccamp-optical-impairment-topology-yang}}.
 
-   transmitter-tuning-range:
+transmitter-tuning-range:
 
-   > a YANG grouping that defines the transmitter tuning range, which
-   includes the minimum and maximum tuning frequency, as well as the
-   frequency tuning steps.
+> A YANG grouping that defines the transmitter tuning range, which
+includes the minimum and maximum tuning frequency, as well as the
+frequency tuning steps.
 
-   common-organizational-explicit-mode:
+common-organizational-explicit-mode:
 
-   > a YANG grouping to define the common capabilities attributes limit
-   range in case of operational mode and explicit mode.  Also this
-   grouping should be used in {{?I-D.ietf-ccamp-dwdm-if-param-yang}}.
+> A YANG grouping to define the common capabilities attributes limit
+range in case of operational mode and explicit mode.
 
-   cd-pmd-penalty:
-   
-   > a YANG grouping to define the triplet used as entries in the list
-   optional penalty associated with a given accumulated CD and PMD.
-   This list of triplet cd, pmd, penalty can be used to sample the
-   function penalty = f(CD, PMD).
+cd-pmd-penalty:
 
-   modulation-format:
+> A YANG grouping to define the triplet used as entries in the list
+optional penalty associated with a given accumulated CD and PMD.
+This list of triplet cd, pmd, penalty can be used to sample the
+function penalty = f(CD, PMD).
 
-   > TBD: add a description and informative reference to {{ITU-T_G.Sup39}}
+modulation-format:
 
-   snr:
+> TBD: add a description and informative reference to {{ITU-T_G.Sup39}}
 
-   > TBD: add a description and reference to {{ITU-T_G.977.1}}
+snr:
 
-   psd:
+> TBD: add a description and reference to {{ITU-T_G.977.1}}
 
-   > TBD: add a description and reference to {{ITU-T_G.9700}}
+psd:
 
-   pmd:
+> TBD: add a description and reference to {{ITU-T_G.9700}}
 
-   > TBD: add a description and reference to {{ITU-T_G.666}}
+pmd:
+
+> TBD: add a description and reference to {{ITU-T_G.666}}
 
 ## WDM Label and Label Range
 
-As described in {{!RFC6205}} and {{!RFC7699}}, the WDM label represents the frequency slot assigned to a WDM LSP on a given WDM Link (which models an OMS MCG).
+As described in {{!RFC6205}} and {{!RFC7699}}, the WDM label represents the frequency slot assigned to a WDM Label Switched Path (LSP) on a given WDM Link, which models an Optical Multiplex Section (OMS) Media Channel Group (MCG) as described in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}}.
 
 The same WDM label shall be assigned to the same WDM LSP on all the WDM Links on a regen-free LSP path or path segment.
 

--- a/draft-ietf-ccamp-rfc9093-bis.md
+++ b/draft-ietf-ccamp-rfc9093-bis.md
@@ -1,9 +1,9 @@
 ---
 coding: utf-8
 
-title: A YANG Data Model for Layer 0 Types
+title: Common YANG Data Types for Layer 0 Networks
 
-abbrev: Yang for Layer 0 Types
+abbrev: L0 Common YANG Types
 docname: draft-ietf-ccamp-rfc9093-bis-latest
 obsoletes: 9093
 submissiontype: IETF
@@ -141,12 +141,11 @@ informative:
 
 --- abstract
 
-   This document defines a collection of common data types and groupings
-   in the YANG data modeling language.  These derived common types and
-   groupings are intended to be imported by modules that model Layer 0
-   optical Traffic Engineering (TE) configuration and state capabilities
-   such as Wavelength Switched Optical Networks (WSONs) and flexi-grid
-   Dense Wavelength Division Multiplexing (DWDM) networks.
+This document defines a collection of common data types, identities, and groupings
+in the YANG data modeling language. These derived common data types, identities,
+and groupings are intended to be imported by modules that model Layer 0
+configuration and state capabilities, such as Wavelength Switched Optical Networks (WSONs) and
+flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.
 
    This document obsoletes RFC 9093.
 

--- a/draft-ietf-ccamp-rfc9093-bis.md
+++ b/draft-ietf-ccamp-rfc9093-bis.md
@@ -372,13 +372,6 @@ common-organizational-explicit-mode:
 > A YANG grouping to define the common capabilities attributes limit
 range in case of operational mode and explicit mode.
 
-cd-pmd-penalty:
-
-> A YANG grouping to define the triplet used as entries in the list
-optional penalty associated with a given accumulated CD and PMD.
-This list of triplet cd, pmd, penalty can be used to sample the
-function penalty = f(CD, PMD).
-
 modulation-format:
 
 > TBD: add a description and informative reference to {{ITU-T_G.Sup39}}

--- a/draft-ietf-ccamp-rfc9093-bis.txt
+++ b/draft-ietf-ccamp-rfc9093-bis.txt
@@ -6,13 +6,13 @@ CCAMP Working Group                                      S. Belotti, Ed.
 Internet-Draft                                                     Nokia
 Obsoletes: 9093 (if approved)                               I. Busi, Ed.
 Intended status: Standards Track                                  Huawei
-Expires: 1 November 2024                                  D. Beller, Ed.
+Expires: 22 November 2024                                 D. Beller, Ed.
                                                                    Nokia
                                                             E. Le Rouzic
                                                                   Orange
                                                                   A. Guo
                                                   Futurewei Technologies
-                                                           30 April 2024
+                                                             21 May 2024
 
 
               Common YANG Data Types for Layer 0 Networks
@@ -47,15 +47,15 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 1 November 2024.
+   This Internet-Draft will expire on 22 November 2024.
 
 
 
 
 
-Belotti, et al.          Expires 1 November 2024                [Page 1]
+Belotti, et al.         Expires 22 November 2024                [Page 1]
 
-Internet-Draft            L0 Common YANG Types                April 2024
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
 Copyright Notice
@@ -80,16 +80,16 @@ Table of Contents
    2.  Layer 0 Types Module Contents . . . . . . . . . . . . . . . .   4
      2.1.  WDM Label and Label Range . . . . . . . . . . . . . . . .   8
    3.  YANG Tree for Layer 0 Types Groupings . . . . . . . . . . . .  10
-   4.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  16
-   5.  Security Considerations . . . . . . . . . . . . . . . . . . .  63
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  64
-   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  64
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  64
-     7.2.  Informative References  . . . . . . . . . . . . . . . . .  66
-   Appendix A.  Changes from RFC 9093  . . . . . . . . . . . . . . .  68
-   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  68
-   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  68
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  69
+   4.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  15
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .  62
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  62
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  63
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  63
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  65
+   Appendix A.  Changes from RFC 9093  . . . . . . . . . . . . . . .  66
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  66
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  67
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  68
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Belotti, et al.          Expires 1 November 2024                [Page 2]
+Belotti, et al.         Expires 22 November 2024                [Page 2]
 
-Internet-Draft            L0 Common YANG Types                April 2024
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
    Layer 0 types specified in this document includes Wavelength Switched
@@ -165,9 +165,9 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024                [Page 3]
+Belotti, et al.         Expires 22 November 2024                [Page 3]
 
-Internet-Draft            L0 Common YANG Types                April 2024
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
 2.  Layer 0 Types Module Contents
@@ -221,9 +221,9 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024                [Page 4]
+Belotti, et al.         Expires 22 November 2024                [Page 4]
 
-Internet-Draft            L0 Common YANG Types                April 2024
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
       This specifies the type of OTU, including the types specified in
@@ -277,9 +277,9 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024                [Page 5]
+Belotti, et al.         Expires 22 November 2024                [Page 5]
 
-Internet-Draft            L0 Common YANG Types                April 2024
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
       As described in section 3.1 of [RFC8363], the range of available
@@ -333,9 +333,9 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024                [Page 6]
+Belotti, et al.         Expires 22 November 2024                [Page 6]
 
-Internet-Draft            L0 Common YANG Types                April 2024
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
    transceiver-capabilities:
@@ -370,13 +370,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
       A YANG grouping to define the common capabilities attributes limit
       range in case of operational mode and explicit mode.
 
-   cd-pmd-penalty:
-
-      A YANG grouping to define the triplet used as entries in the list
-      optional penalty associated with a given accumulated CD and PMD.
-      This list of triplet cd, pmd, penalty can be used to sample the
-      function penalty = f(CD, PMD).
-
    modulation-format:
 
       TBD: add a description and informative reference to
@@ -386,14 +379,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
       TBD: add a description and reference to [ITU-T_G.977.1]
 
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 7]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    psd:
 
       TBD: add a description and reference to [ITU-T_G.9700]
@@ -401,6 +386,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
    pmd:
 
       TBD: add a description and reference to [ITU-T_G.666]
+
+
+
+Belotti, et al.         Expires 22 November 2024                [Page 7]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
 2.1.  WDM Label and Label Range
 
@@ -441,15 +433,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
       nominal central frequency granularity (NCFG, fixed at 6.25GHz in
       [ITU-T_G.694.1]) respectively, as described in [RFC7699]:
 
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 8]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          SW = M x SWG (measured in GHz)
          f = 193100.000 GHz + N x NCFG (measured in GHz)
 
@@ -459,6 +442,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
    The WDM Label Range represents the frequency slots that are available
    for WDM LSPs to be set up over a given WDM Link.
+
+
+
+Belotti, et al.         Expires 22 November 2024                [Page 8]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    The WDM Label Range is defined by the label-restriction list, defined
    in [I-D.ietf-teas-rfc8776-update], which, for WDM, should be
@@ -498,14 +488,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
    models) or the wdm-label-start-end grouping (for models that supports
    both WSON and DWDM flexible-grid).
 
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 9]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    The label-step definition for WDM should be augmented using the wson-
    label-step grouping (for WSON only models) or the flexi-grid-label-
    step grouping (for DWDM flexible-grid only models) or the wdm-label-
@@ -515,6 +497,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
    *  For CWDM and DWDM fixed grids, it describes the channel spacing,
       as defined in [RFC6205];
+
+
+
+
+Belotti, et al.         Expires 22 November 2024                [Page 9]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    *  For DWDM flexible grids, it describes the nominal central
       frequency granularity (e.g., 6,25 GHz) as well as the multiplier
@@ -554,14 +544,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           |  +-- cwdm-n?                     l0-types:cwdm-n
           +--:(flexi-grid)
              +-- (single-or-super-channel)?
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 10]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
                 +--:(single)
                 |  +-- flexi-n?              l0-types:flexi-n
                 |  +-- flexi-m?              l0-types:flexi-m
@@ -572,6 +554,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
                 +--:(multi)
                    +-- frequency-slots
                       +-- frequency-slot* [flexi-n]
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 10]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
                          +-- flexi-n?   l0-types:flexi-n
                          +-- flexi-m?   l0-types:flexi-m
      grouping wdm-label-range-info:
@@ -610,14 +600,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        +-- flexi-n?   l0-types:flexi-n
      grouping flexi-grid-frequency-slot:
        +-- flexi-n?   l0-types:flexi-n
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 11]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        +-- flexi-m?   l0-types:flexi-m
      grouping flexi-grid-label-hop:
        +-- (single-or-super-channel)?
@@ -628,6 +610,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
           |  x-- subcarrier-flexi-n* [flexi-n]
           |     +-- flexi-n?   l0-types:flexi-n
           |     +-- flexi-m?   l0-types:flexi-m
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 11]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
           +--:(multi)
              +-- frequency-slots
                 +-- frequency-slot* [flexi-n]
@@ -666,14 +656,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           |     +--ro max-central-frequency?     frequency-thz
           |     +--ro transceiver-tunability?    frequency-ghz
           |     +--ro tx-channel-power-min?      power-dbm
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 12]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
           |     +--ro tx-channel-power-max?      power-dbm
           |     +--ro rx-channel-power-min?      power-dbm
           |     +--ro rx-channel-power-max?      power-dbm
@@ -684,6 +666,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
                 +--ro max-central-frequency?    frequency-thz
                 +--ro transceiver-tunability?   frequency-ghz
                 +--ro tx-channel-power-min?     power-dbm
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 12]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
                 +--ro tx-channel-power-max?     power-dbm
                 +--ro rx-channel-power-min?     power-dbm
                 +--ro rx-channel-power-max?     power-dbm
@@ -722,14 +712,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
                 +--:(explicit-mode)
                    +--ro explicit-mode
                       +--ro min-central-frequency?    frequency-thz
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 13]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
                       +--ro max-central-frequency?    frequency-thz
                       +--ro transceiver-tunability?   frequency-ghz
                       +--ro tx-channel-power-min?     power-dbm
@@ -740,6 +722,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
                       +--ro compatible-modes
                          +--ro supported-application-codes*
                          |       -> ../../../../supported-mode/mode-id
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 13]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
                          +--ro supported-organizational-modes*
                                  -> ../../../../supported-mode/mode-id
      grouping standard-mode:
@@ -754,38 +744,26 @@ Internet-Draft            L0 Common YANG Types                April 2024
        +--ro bitrate?                            uint16
        +--ro max-diff-group-delay?               decimal-2
        +--ro max-chromatic-dispersion?           decimal-2
-       +--ro cd-penalty* [cd-index]
-       |  +--ro cd-index?        decimal-2
-       |  +--ro cd-value         union
+       +--ro cd-penalty* [cd-value]
+       |  +--ro cd-value         decimal-2
        |  +--ro penalty-value    union
        +--ro max-polarization-mode-dispersion?   decimal-2
-       +--ro pmd-penalty* [pmd-index]
-       |  +--ro pmd-index?       decimal-2
-       |  +--ro pmd-value        union
+       +--ro pmd-penalty* [pmd-value]
+       |  +--ro pmd-value        decimal-2
        |  +--ro penalty-value    union
        +--ro max-polarization-dependant-loss     power-loss-or-null
-       +--ro pdl-penalty* [pdl-index]
-       |  +--ro pdl-index?       decimal-2
-       |  +--ro pdl-value        power-loss-or-null
+       +--ro pdl-penalty* [pdl-value]
+       |  +--ro pdl-value        power-loss
        |  +--ro penalty-value    union
        +--ro available-modulation-type?          identityref
        +--ro min-OSNR?                           snr
        +--ro rx-ref-channel-power?               power-dbm
-       +--ro rx-channel-power-penalty* [rx-channel-power-index]
-       |  +--ro rx-channel-power-index?   decimal-2
-       |  +--ro rx-channel-power-value    power-dbm-or-null
+       +--ro rx-channel-power-penalty* [rx-channel-power-value]
+       |  +--ro rx-channel-power-value    power-dbm
        |  +--ro penalty-value             union
        +--ro min-Q-factor?                       decimal-2
        +--ro available-baud-rate?                decimal64
        +--ro roll-off?                           decimal64
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 14]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        +--ro min-carrier-spacing?                frequency-ghz
        +--ro available-fec-type?                 identityref
        +--ro fec-code-rate?                      decimal64
@@ -800,6 +778,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
        +-- min-central-frequency?    frequency-thz
        +-- max-central-frequency?    frequency-thz
        +-- transceiver-tunability?   frequency-ghz
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 14]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
      grouping common-all-modes:
        +-- min-central-frequency?    frequency-thz
        +-- max-central-frequency?    frequency-thz
@@ -834,14 +820,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
                                   Figure 1
 
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 15]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
 4.  YANG Module for Layer 0 Types
 
    <CODE BEGINS> file "ietf-layer0-types@2024-03-04.yang"
@@ -855,6 +833,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
      contact
        "WG Web:  <https://datatracker.ietf.org/wg/ccamp/>
         WG List: <mailto:ccamp@ietf.org>
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 15]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
         Editor:  Dieter Beller
                  <mailto:Dieter.Beller@nokia.com>
@@ -890,14 +876,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
         The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
         NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
         'MAY', and 'OPTIONAL' in this document are to be interpreted as
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 16]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
         described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
         they appear in all capitals, as shown here.";
 
@@ -906,12 +884,19 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
    // replace the revision date with the module publication date
    // the format is (year-month-day)
-     revision 2024-04-30 {
+     revision 2024-05-21 {
        description
          "To be updated";
        reference
          "RFC XXXX: A YANG Data Model for Layer 0 Types";
      }
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 16]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
      revision 2021-08-13 {
        description
@@ -947,13 +932,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            CWDM wavelength grid";
        }
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 17]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        identity wson-grid-dwdm {
          base l0-grid-type;
          description
@@ -968,6 +946,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        identity flexi-grid-dwdm {
          base l0-grid-type;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 17]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          description
            "Flexi-grid";
          reference
@@ -1002,14 +988,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
 
      identity dwdm-ch-spc-type {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 18]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        description
          "DWDM channel-spacing type";
        reference
@@ -1024,6 +1002,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          base dwdm-ch-spc-type;
          description
            "100 GHz channel spacing";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 18]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          reference
            "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
            Label Switching Routers,
@@ -1058,14 +1044,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        identity dwdm-12p5ghz {
          base dwdm-ch-spc-type;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 19]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          description
            "12.5 GHz channel spacing";
          reference
@@ -1080,6 +1058,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
        status deprecated;
        description
          "Flexi-grid channel-spacing type";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 19]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
      }
 
        identity flexi-ch-spc-6p25ghz {
@@ -1114,14 +1100,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
 
      identity flexi-slot-width-granularity {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 20]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        description
          "Flexi-grid slot width granularity";
        reference
@@ -1136,6 +1114,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          base flexi-slot-width-granularity;
          description
            "12.5 GHz slot width granularity";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 20]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          reference
            "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
            Switch Capable (LSC) Label Switching Routers,
@@ -1170,14 +1156,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        identity QAM8 {
          base modulation;
          description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 21]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            "8QAM (8 symbols Quadrature Amplitude Modulation)";
        }
 
@@ -1192,6 +1170,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          base modulation;
          description
            "QAM16 (16 symbols Quadrature Amplitude Modulation)";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 21]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
        }
 
        identity DP-QAM16 {
@@ -1227,13 +1213,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            Modulation)";
        }
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 22]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
      identity fec-type {
        description
          "Base identity from which specific FEC
@@ -1247,6 +1226,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          reference
            "ITU-T G.975 v2.0 (10/2000): Forward error correction for
            submarine systems.";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 22]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
        }
 
        identity super-fec {
@@ -1282,14 +1269,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            "Clause 16.4.4 of ITU-T G.709.3 v2.1 (11/2022): Flexible OTN
            long-reach interfaces;
 
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 23]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            Annex E of ITU-T G.709.3 v2.1 (11/2022): Flexible OTN
            long-reach interfaces.";
        }
@@ -1303,6 +1282,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
            More details are provided in clause 15/G.709.3 where it is
            called DSH instead of concatenated FEC.";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 23]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          reference
            "Annex A of ITU-T G.709.2 v1.1 (09/2020):OTU4 long-reach
            interface;
@@ -1338,14 +1325,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            the Optical channel Transport Unit order 1 (OTU1) optical
            tributary signals";
          reference
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 24]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            "Section 7.2.1.2 of ITU-T G.959.1 v8.0 (07/2018).";
        }
 
@@ -1359,6 +1338,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        identity line-coding-NRZ-OTU2 {
          base line-coding;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 24]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          description
            "The non return to zero (NRZ) bit rate/line coding used by
            the Optical channel Transport Unit order 2 (OTU2) optical
@@ -1394,14 +1381,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          "Wavelength selection base";
        reference
          "RFC 7689: Signaling Extensions for Wavelength Switched
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 25]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          Optical Networks";
      }
 
@@ -1415,6 +1394,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
            "RFC 7689: Signaling Extensions for Wavelength Switched
            Optical Networks";
        }
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 25]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
        identity random-wavelength-assignment {
          base wavelength-assignment;
@@ -1450,14 +1436,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          description
            "Allocate wavelengths in decending order, beginning from the
            highest frequency and progressing toward the lowest frequency
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 26]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            within the permissible frequency range.";
        }
 
@@ -1472,6 +1450,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          base otu-type;
          description
            "OTU1 (2.66 Gb/s)";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 26]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          reference
            "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
            Transport Network (OTN)";
@@ -1506,14 +1492,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        identity OTUCn {
          base otu-type;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 27]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          description
            "OTUCn (n x 105.25 Gb/s)";
          reference
@@ -1528,6 +1506,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
      }
 
        identity power-spectral-density {
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 27]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          base type-power-mode;
          description
            "all elements must use power spectral density (W/Hz)";
@@ -1563,13 +1549,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           DWDM frequency grid";
      }
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 28]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
      typedef cwdm-n {
        type int16;
        description
@@ -1583,6 +1562,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
           transmission over the CWDM grid, and where 'channel spacing'
           is defined by the cwdm-ch-spc-type.";
        reference
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 28]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
 
@@ -1619,13 +1606,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           A slot width is defined by:
             slot width = M x SWG (measured in GHz),
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 29]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
           where SWG is defined by the flexi-slot-width-granularity.";
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
@@ -1638,6 +1618,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
      typedef standard-mode {
        type string;
        description
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 29]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          "Identifies an ITU-T G.698.2 standard application code.
 
          It MUST be a string with a format that follows the
@@ -1675,13 +1663,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
    // this note after draft-ietf-ccamp-optical-impairment-topology-yang
    // is published as an RFC
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 30]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
      typedef frequency-thz {
        type decimal64 {
          fraction-digits 9;
@@ -1693,6 +1674,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
      typedef frequency-ghz {
        type decimal64 {
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 30]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          fraction-digits 6;
        }
        units "GHz";
@@ -1730,14 +1719,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
              "G.652 Standard Singlemode Fiber";
          }
          enum G.654 {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 31]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            description
              "G.654 Cutoff Shifted Fiber";
          }
@@ -1749,6 +1730,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          }
          enum G.656 {
            description
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 31]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
              "G.656 Non-Zero Dispersion for Wideband Optical Transport";
          }
          enum G.657 {
@@ -1787,13 +1776,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          "The gain in dB.";
      }
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 32]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
      typedef power-gain-or-null {
        type union {
          type power-gain;
@@ -1803,6 +1785,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          "The gain in dB, when it is known or an empty
          value when the power gain/loss is not known.";
      }
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 32]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
      typedef power-loss {
        type decimal-2 {
@@ -1842,14 +1832,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
      typedef power-dbm {
        type decimal-2;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 33]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        units "dBm";
        description
          "The power in dBm.";
@@ -1860,6 +1842,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          type power-dbm;
          type empty;
        }
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 33]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
        description
          "The power in dBm, when it is known or an empty value when the
          power is not known.";
@@ -1898,14 +1888,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
      }
 
      typedef psd-or-null {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 34]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        type union {
          type psd;
          type empty;
@@ -1916,6 +1898,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
      }
 
    /*
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 34]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
     * Groupings
     */
 
@@ -1954,14 +1944,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
              description
                "The given value 'N' is used to determine the nominal
                 central wavelength.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 35]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
              reference
                "RFC 6205: Generalized Labels for Lambda-Switch-Capable
                 (LSC) Label Switching Routers";
@@ -1972,6 +1954,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          }
        }
        reference
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 35]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers";
      }
@@ -2010,14 +2000,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
              type identityref {
                base cwdm-ch-spc-type;
              }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 36]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
              description
                "Label-step is the channel spacing (nm), i.e., 20 nm
                 for CWDM, which is the only value defined for CWDM.";
@@ -2028,6 +2010,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          }
          case flexi-grid {
            uses flexi-grid-label-step;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 36]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          }
        }
        reference
@@ -2066,14 +2056,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
                    "The given values 'N' are used to determine the
                     nominal central frequency for each subcarrier
                     channel.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 37]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
                  reference
                    "ITU-T G.694.1 (10/2020): Spectral grids for WDM
                    applications: DWDM frequency grid";
@@ -2084,6 +2066,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          case cwdm {
            leaf cwdm-n {
              type l0-types:cwdm-n;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 37]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
              description
                "The given value 'N' is used to determine the nominal
                 central wavelength.";
@@ -2122,14 +2112,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
              "Minimum space between slot widths. Default is 12.500
               GHz.";
            reference
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 38]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
              "RFC 7698: Framework and Requirements for GMPLS-Based
               Control of Flexi-Grid Dense Wavelength Division
               Multiplexing (DWDM) Networks";
@@ -2140,6 +2122,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
            }
            default "1";
            description
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 38]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
              "A multiplier of the slot width granularity, indicating
               the minimum slot width supported by an optical port.
 
@@ -2179,13 +2169,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
      }
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 39]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
      grouping wson-label-start-end {
        description
          "The WSON label-start or label-end used to specify WSON label
@@ -2195,6 +2178,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
            "Label for DWDM or CWDM grid";
          case dwdm {
            leaf dwdm-n {
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 39]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
              when "derived-from-or-self(../../../grid-type,
                    \"wson-grid-dwdm\")" {
                description
@@ -2234,14 +2225,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          "Generic label-hop information for WSON";
        choice grid-type {
          description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 40]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            "Label for DWDM or CWDM grid";
          case dwdm {
            choice single-or-super-channel {
@@ -2251,6 +2234,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
                leaf dwdm-n {
                  type l0-types:dwdm-n;
                  description
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 40]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
                    "The given value 'N' is used to determine the
                     nominal central frequency.";
                }
@@ -2290,14 +2281,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        description
          "Information about Layer 0 label range.";
        leaf grid-type {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 41]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          type identityref {
            base l0-grid-type;
          }
@@ -2307,6 +2290,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
        leaf priority {
          type uint8;
          description
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 41]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
            "Priority in Interface Switching Capability Descriptor
             (ISCD).";
          reference
@@ -2346,14 +2337,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            leaf wson-cwdm-channel-spacing {
              when "derived-from-or-self(../../grid-type,
                    \"wson-grid-cwdm\")" {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 42]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
                description
                  "Valid only when grid type is CWDM.";
              }
@@ -2363,6 +2346,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
              description
                "Label-step is the channel spacing (nm), i.e., 20 nm
                 for CWDM, which is the only value defined for CWDM.";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 42]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
              reference
                "RFC 6205: Generalized Labels for Lambda-Switch-Capable
                 (LSC) Label Switching Routers";
@@ -2402,14 +2393,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
      }
 
      grouping flexi-grid-frequency-slot {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 43]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        description
          "Flexi-grid frequency slot grouping.";
        uses flexi-grid-label-start-end;
@@ -2419,6 +2402,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
            "The given value 'M' is used to determine the slot width.";
        }
        reference
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 43]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers";
      }
@@ -2458,14 +2449,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
                  "List of frequency slots used for flexi-grid super
                  channel.";
              }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 44]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            }
          }
        }
@@ -2475,6 +2458,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
      }
 
      grouping flexi-grid-label-range-info {
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 44]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
        description
          "Flexi-grid-specific label range related information";
        uses l0-label-range-info;
@@ -2514,14 +2505,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          leaf max-slot-width-factor {
            type uint16 {
              range "1..max";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 45]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            }
            must '. >= ../min-slot-width-factor' {
              error-message
@@ -2531,6 +2514,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
            description
              "A multiplier of the slot width granularity, indicating
               the maximum slot width supported by an optical port.
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 45]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
               Maximum slot width is calculated by:
                 Maximum slot width (GHz) =
@@ -2570,14 +2560,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          default "flexi-ncfg-6p25ghz";
          description
            "Label-step is the nominal central frequency granularity
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 46]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
             (GHz), e.g., 6.25 GHz.";
          reference
            "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
@@ -2588,6 +2570,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
          description
            "This attribute defines the multiplier for the supported
             values of 'N'.
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 46]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
             For example, given a grid with a nominal central frequency
             granularity of 6.25 GHz, the granularity of the supported
@@ -2626,14 +2615,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          case G.698.2 {
            uses standard-mode;
            uses common-standard-organizational-mode;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 47]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            uses common-all-modes;
          }
          case organizational-mode {
@@ -2645,6 +2626,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
              uses common-standard-organizational-mode;
              uses common-all-modes;
            }  // container organizational-mode
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 47]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          }
          case explicit-mode {
            container explicit-mode {
@@ -2682,14 +2671,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            transceiver are reported.";
          description
            "The top level container for the list supported
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 48]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            transceiver's modes.";
          list supported-mode {
            key "mode-id";
@@ -2701,6 +2682,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
                length "1..255";
              }
              description "ID for the supported transceiver's mode.";
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 48]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
            }
            uses transceiver-mode {
              augment "mode/explicit-mode/explicit-mode/"
@@ -2738,14 +2727,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
                    "List of pointers to the organizational modes
                      supported by the transceiver's explicit mode.";
                }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 49]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
              }
            }
          }  // list supported-modes
@@ -2757,6 +2738,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          "ITU-T G.698.2 standard mode that guarantees interoperability.
           It must be an string with the following format:
           B-DScW-ytz(v) where all these attributes are conformant
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 49]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
           to the ITU-T recomendation";
 
        leaf standard-mode {
@@ -2794,14 +2783,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          multiple penalty types (.e.g, CD, PMD, PDL).";
 
        leaf penalty-value {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 50]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          type union {
            type decimal-2 {
              range "0..max";
@@ -2813,6 +2794,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          mandatory true;
          description
            "The OSNR penalty associated with the related optical
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 50]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
            impairment at the receiver, when the value is known or an
            empty value when the value is not known.";
        }
@@ -2850,14 +2839,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        leaf max-diff-group-delay  {
          type decimal-2;
          units "ps";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 51]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          config false;
          description
            "Maximum Differential group delay of this mode for this
@@ -2869,51 +2850,35 @@ Internet-Draft            L0 Common YANG Types                April 2024
          }
          units "ps/nm";
          config false;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 51]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          description
            "Maximum acceptable accumulated chromatic dispersion (CD)
            on the receiver";
        }
        list cd-penalty {
-         key cd-index;
+         key cd-value;
          config false;
          description
            "Optional penalty associated with a given accumulated
            chromatic dispersion (CD) value.
 
-           This list of pair cd and penalty values can be used to
+           This list of pair CD and penalty values can be used to
            sample the function penalty = f(CD).";
-         leaf cd-index {
-           type decimal-2 {
-             range "0..max";
-           }
-           description
-             "The identifier of one entry of the cd-penalty list.
-
-             It may be equal to the cd-value attribute, when the
-             cd-value attribute is present.";
-         }
          leaf cd-value {
-           type union {
-             type decimal-2 {
-               range "0..max";
-             }
-             type empty;
-           }
+           type decimal-2;
            units "ps/nm";
            config false;
            mandatory true;
            description
-             "The Chromatic Dispersion (CD), when the value is known
-             or an empty value when the value is not known.";
+             "The Chromatic Dispersion (CD).";
          }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 52]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          uses penalty-value;
        }
        leaf max-polarization-mode-dispersion {
@@ -2931,45 +2896,31 @@ Internet-Draft            L0 Common YANG Types                April 2024
            compensate for polarization mode dispersion";
        }
        list pmd-penalty {
-         key pmd-index;
+         key pmd-value;
          config false;
          description
            "Optional penalty associated with a given accumulated
            polarization mode dispersion (PMD) value.
 
-           This list of pair pmd and penalty can be used to
+           This list of pair PMD and penalty can be used to
            sample the function penalty = f(PMD).";
-         leaf pmd-index {
-           type decimal-2 {
-             range "0..max";
-           }
-           description
-             "The identifier of one entry of the pmd-penalty list.
-
-             It may be equal to the pmd-value attribute, when the
-             pmd-value attribute is present.";
-         }
          leaf pmd-value {
-           type union {
-             type decimal-2 {
-               range "0..max";
-             }
-             type empty;
+           type decimal-2 {
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 52]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
+             range "0..max";
            }
            units "ps";
            config false;
            mandatory true;
            description
-             "The Polarization Mode Dispersion (PMD), when the value
-             is known or an empty value when the value is not known.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 53]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
+             "The Polarization Mode Dispersion (PMD).";
          }
          uses penalty-value;
        }
@@ -2982,31 +2933,21 @@ Internet-Draft            L0 Common YANG Types                April 2024
            dependent loss (PDL) on the receiver";
        }
        list pdl-penalty {
-         key pdl-index;
+         key pdl-value;
          config false;
          description
            "Optional penalty associated with a given accumulated
            polarization dependent loss (PDL) value.
 
-           This list of pair pdl and penalty values can be used to
+           This list of pair PDL and penalty values can be used to
            sample the function PDL = f(penalty).";
-         leaf pdl-index {
-           type decimal-2 {
-             range "0..max";
-           }
-           description
-             "The identifier of one entry of the pdl-penalty list.
-
-             It may be equal to the pdl-value attribute, when the
-             pdl-value attribute is present.";
-         }
          leaf pdl-value {
-           type power-loss-or-null;
+           type power-loss;
            config false;
            mandatory true;
            description
              "Maximum acceptable accumulated polarization dependent
-             loss.";
+             loss (PDL).";
          }
          uses penalty-value;
        }
@@ -3018,17 +2959,17 @@ Internet-Draft            L0 Common YANG Types                April 2024
          description
            "Modulation type the specific transceiver in the list
             can support";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 54]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        }
        leaf min-OSNR {
          type snr;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 53]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          units "dBm";
          config false;
          description
@@ -3045,43 +2986,24 @@ Internet-Draft            L0 Common YANG Types                April 2024
            and min-OSNR";
        }
        list rx-channel-power-penalty {
-         key rx-channel-power-index;
+         key rx-channel-power-value;
          config false;
          description
            "Optional penalty associated with a received power
-             lower than rx-ref-channel-power.
-             This list of pair power and penalty can be used to
-             sample the function penalty = f(rx-channel-power).";
-         leaf rx-channel-power-index {
-           type decimal-2 {
-             range "0..max";
-           }
-           description
-             "The identifier of one entry of the
-             rx-channel-power-penalty list.
+           lower than rx-ref-channel-power.
 
-             It may be equal to the rx-channel-power-value attribute,
-             when the rx-channel-power-value attribute is present.";
-         }
+           This list of pair power and penalty can be used to
+           sample the function penalty = f(rx-channel-power).";
          leaf rx-channel-power-value {
-           type power-dbm-or-null;
+           type power-dbm;
            units "dBm";
            config false;
            mandatory true;
            description
-             "The Received Power, when the value is known or an empty
-             value when the value is not known.";
+             "The Received Power.";
          }
          uses penalty-value;
        }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 55]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
        leaf min-Q-factor {
          type decimal-2;
          units "dB";
@@ -3096,6 +3018,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
          config false;
          description
            "Baud-rate the specific transceiver in
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 54]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
            the list can support.
             Baud-rate is the unit for
             symbol rate or modulation rate
@@ -3131,13 +3061,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            the interference due to spectrum overlap between them can be
            considered negligible.
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 56]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            In case of heterogeneous OTSi it is up to path computation
            engine to determine the minimum distance between the carrier
            frequency of the two adjacent OTSi.";
@@ -3151,6 +3074,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
        leaf fec-code-rate {
          type decimal64 {
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 55]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
            fraction-digits 8;
            range "0..max";
          }
@@ -3186,14 +3117,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          type snr;
          config false;
          description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 57]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            "The ratio of the peak transmitter power to the integrated
            power outside the transmitter spectral excursion.
 
@@ -3207,6 +3130,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
        leaf tx-polarization-power-difference {
          type power-ratio;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 56]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          config false;
          description
            "The transmitter polarization dependent power difference
@@ -3242,14 +3173,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            tributary signal supported by the transceiver.
 
            Reporting this list is optional when the standard or
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 58]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            organization mode supports only one bit rate/line coding.";
          reference
            "ITU-T G.698.2 section 7.1.2";
@@ -3263,6 +3186,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
        leaf min-central-frequency {
          type frequency-thz;
          description
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 57]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
            "This parameter indicates the minimum frequency for the
            transmitter tuning range.";
        }
@@ -3298,14 +3229,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
        leaf rx-channel-power-min {
          type power-dbm;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 59]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          config false;
          description "The minimum input power of this interface";
        }
@@ -3319,6 +3242,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
          config false;
          description
            "Maximum rx optical power for all the channels.
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 58]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
            It is applicable only to multi-channel modes.";
        }
@@ -3354,14 +3284,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          type power-dbm-or-null;
          description
            "The current channel transmit power, when the value is
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 60]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
            known or an empty value when the value is not known.
 
            The empty value MUST NOT be used when this attribute is
@@ -3376,6 +3298,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        leaf rx-channel-power {
          type power-dbm-or-null;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 59]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          config false;
          description
            "The current channel received power, when the value is
@@ -3410,14 +3340,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          This grouping SHOULD NOT be used to define a frequency slot,
          which SHOULD be defined using the n and m values instead.";
        leaf lower-frequency {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 61]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          type frequency-thz;
          mandatory true;
          description
@@ -3432,6 +3354,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
              frequency.";
          }
          mandatory true;
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 60]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
          description
            "The upper frequency boundary of the
            frequency range.";
@@ -3466,14 +3396,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
        leaf estimated-eol-gsnr {
          type snr;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 62]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
          config false;
          description
            "The estimate received GSNR for the computed path
@@ -3488,6 +3410,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
             path.";
        }
      }
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 61]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
+
    }
    <CODE ENDS>
 
@@ -3523,13 +3453,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
    is important to manage access to resultant data nodes that are
    considered sensitive or vulnerable in some network environments.
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 63]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    The security considerations spelled out in the YANG 1.1 specification
    [RFC7950] apply for this document as well.
 
@@ -3541,6 +3464,15 @@ Internet-Draft            L0 Common YANG Types                April 2024
       URI:  urn:ietf:params:xml:ns:yang:ietf-layer0-types
       Registrant Contact:  The IESG
       XML:  N/A; the requested URI is an XML namespace.
+
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 62]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    This document also adds an updated YANG module to the "YANG Module
    Names" registry [RFC7950]:
@@ -3579,13 +3511,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
               that compensate for polarization mode dispersion", ITU-T
               G.666 , February 2011.
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 64]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    [ITU-T_G.698.2]
               ITU-T Recommendation G.698.2, "Amplified multichannel
               dense wavelength division multiplexing applications with
@@ -3595,6 +3520,15 @@ Internet-Draft            L0 Common YANG Types                April 2024
    [ITU-T_G.709]
               ITU-T Recommendation G.709, "Interfaces for the optical
               transport network", ITU-T G.709 , March 2020.
+
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 63]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    [ITU-T_G.9700]
               ITU-T Recommendation G.9700, "Fast access to subscriber
@@ -3631,17 +3565,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
               <https://www.rfc-editor.org/info/rfc6242>.
 
-
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 65]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    [RFC7699]  Farrel, A., King, D., Li, Y., and F. Zhang, "Generalized
               Labels for the Flexi-Grid in Lambda Switch Capable (LSC)
               Label Switching Routers", RFC 7699, DOI 10.17487/RFC7699,
@@ -3654,6 +3577,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
               <https://www.rfc-editor.org/info/rfc8040>.
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 64]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
@@ -3687,17 +3618,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
 7.2.  Informative References
 
-
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 66]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    [ITU-T_G.694.1]
               ITU-T Recommendation G.694.1, "Spectral grids for WDM
               applications: DWDM frequency grid", ITU-T G.694.1 ,
@@ -3712,6 +3632,15 @@ Internet-Draft            L0 Common YANG Types                April 2024
               ITU-T Supplement G.Sup39, "Optical system design and
               engineering considerations", ITU-T G.Sup39 , February
               2016.
+
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 65]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    [ITU-T_G.Sup43]
               ITU-T Supplement G.Sup43, "Transport of IEEE 10GBASE-R in
@@ -3747,13 +3676,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
               RFC 7698, DOI 10.17487/RFC7698, November 2015,
               <https://www.rfc-editor.org/info/rfc7698>.
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 67]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    [RFC9093]  Zheng, H., Lee, Y., Guo, A., Lopez, V., and D. King, "A
               YANG Data Model for Layer 0 Types", RFC 9093,
               DOI 10.17487/RFC9093, August 2021,
@@ -3768,6 +3690,13 @@ Acknowledgments
    The authors and the working group give their sincere thanks to Robert
    Wilton for the YANG doctor review and Tom Petch for his comments
    during the model and document development.
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 66]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
+
 
    This document was prepared using kramdown.
 
@@ -3803,13 +3732,6 @@ Contributors
    Email: byyun@etri.re.kr
 
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 68]
-
-Internet-Draft            L0 Common YANG Types                April 2024
-
-
    Ricard Vilalta
    CTTC
    Email: ricard.vilalta@cttc.es
@@ -3823,6 +3745,13 @@ Internet-Draft            L0 Common YANG Types                April 2024
    Victor Lopez
    Nokia
    Email: victor.lopez@nokia.com
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 67]
+
+Internet-Draft            L0 Common YANG Types                  May 2024
 
 
 Authors' Addresses
@@ -3861,4 +3790,19 @@ Authors' Addresses
 
 
 
-Belotti, et al.          Expires 1 November 2024               [Page 69]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Belotti, et al.         Expires 22 November 2024               [Page 68]

--- a/draft-ietf-ccamp-rfc9093-bis.txt
+++ b/draft-ietf-ccamp-rfc9093-bis.txt
@@ -21,14 +21,16 @@ Expires: 1 November 2024                                  D. Beller, Ed.
 Abstract
 
    This document defines a collection of common data types, identities,
-   and groupings in the YANG data modeling language.  These derived
-   common data types, identities, and groupings are intended to be
-   imported by modules that model Layer 0 configuration and state
-   capabilities, such as Wavelength Switched Optical Networks (WSONs)
-   and flexi-grid Dense Wavelength Division Multiplexing (DWDM)
-   networks.
+   and groupings in the YANG data modeling language.  These common types
+   and groupings, derived from the built-in YANG data types, identities,
+   and groupings are intended to be imported by modules that model Layer
+   0 configuration and state capabilities, such as Wavelength Switched
+   Optical Networks (WSONs) and flexi-grid Dense Wavelength Division
+   Multiplexing (DWDM) networks.
 
-   This document obsoletes RFC 9093.
+   This document obsoletes RFC 9093 by replacing the YANG module it
+   contained with a new revision that includes additional YANG data
+   types, identities and groupings.
 
 Status of This Memo
 
@@ -46,8 +48,6 @@ Status of This Memo
    material or to cite them other than as "work in progress."
 
    This Internet-Draft will expire on 1 November 2024.
-
-
 
 
 
@@ -80,7 +80,7 @@ Table of Contents
    2.  Layer 0 Types Module Contents . . . . . . . . . . . . . . . .   4
      2.1.  WDM Label and Label Range . . . . . . . . . . . . . . . .   8
    3.  YANG Tree for Layer 0 Types Groupings . . . . . . . . . . . .  10
-   4.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  15
+   4.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  16
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .  63
    6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  64
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  64
@@ -124,6 +124,11 @@ Internet-Draft            L0 Common YANG Types                April 2024
    statements of the YANG module in Section 4 or the summary in
    Appendix A.
 
+   This document obsoletes [RFC9093] by replacing it in its entirety.
+   It provides a new revision of the YANG module contained in that RFC,
+   and retains the data types previously defined, but also adds new type
+   definitions to the YANG module.  For further details, see Appendix A.
+
    The YANG data model in this document conforms to the Network
    Management Datastore Architecture defined in [RFC8342].
 
@@ -143,7 +148,7 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
    In this document, names of data nodes and other data model objects
    are prefixed using the standard prefix associated with the
-   corresponding YANG imported modules.
+   corresponding YANG imported module.
 
                +==========+===================+===========+
                | Prefix   | YANG module       | Reference |
@@ -152,15 +157,10 @@ Internet-Draft            L0 Common YANG Types                April 2024
                +----------+-------------------+-----------+
 
                  Table 1: Prefixes and corresponding YANG
-                                 modules
+                                  module
 
    RFC Editor Note: Please replace XXXX with the RFC number assigned to
-   this document.
-
-
-
-
-
+   this document and remove this note.
 
 
 
@@ -340,40 +340,39 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
    transceiver-capabilities:
 
-      a YANG grouping to define the transceiver capabilities (also
+      A YANG grouping to define the transceiver capabilities (also
       called "modes") needed to determine optical signal compatibility.
 
    standard-mode:
 
-      a YANG grouping for the standard modes defined in [ITU-T_G.698.2].
+      A YANG grouping for the standard modes defined in [ITU-T_G.698.2].
 
    organizational-mode:
 
-      a YANG grouping to define transponder operational mode supported
-      by organizations or vendors.
+      A YANG grouping to define transponder operational mode supported
+      by organizations or vendors, as defined in
+      [I-D.ietf-ccamp-optical-impairment-topology-yang].
 
    common-explicit-mode:
 
-      a YANG grouping to define the list of attributes related to
-      optical impairments limits in case of transceiver explicit mode.
-      This grouping should be the same used in
-      [I-D.ietf-ccamp-dwdm-if-param-yang].
+      A YANG grouping to define the list of attributes related to
+      optical impairments limits in case of transceiver explicit mode,
+      as defined in [I-D.ietf-ccamp-optical-impairment-topology-yang].
 
    transmitter-tuning-range:
 
-      a YANG grouping that defines the transmitter tuning range, which
+      A YANG grouping that defines the transmitter tuning range, which
       includes the minimum and maximum tuning frequency, as well as the
       frequency tuning steps.
 
    common-organizational-explicit-mode:
 
-      a YANG grouping to define the common capabilities attributes limit
-      range in case of operational mode and explicit mode.  Also this
-      grouping should be used in [I-D.ietf-ccamp-dwdm-if-param-yang].
+      A YANG grouping to define the common capabilities attributes limit
+      range in case of operational mode and explicit mode.
 
    cd-pmd-penalty:
 
-      a YANG grouping to define the triplet used as entries in the list
+      A YANG grouping to define the triplet used as entries in the list
       optional penalty associated with a given accumulated CD and PMD.
       This list of triplet cd, pmd, penalty can be used to sample the
       function penalty = f(CD, PMD).
@@ -386,6 +385,7 @@ Internet-Draft            L0 Common YANG Types                April 2024
    snr:
 
       TBD: add a description and reference to [ITU-T_G.977.1]
+
 
 
 
@@ -405,8 +405,10 @@ Internet-Draft            L0 Common YANG Types                April 2024
 2.1.  WDM Label and Label Range
 
    As described in [RFC6205] and [RFC7699], the WDM label represents the
-   frequency slot assigned to a WDM LSP on a given WDM Link (which
-   models an OMS MCG).
+   frequency slot assigned to a WDM Label Switched Path (LSP) on a given
+   WDM Link, which models an Optical Multiplex Section (OMS) Media
+   Channel Group (MCG) as described in
+   [I-D.ietf-ccamp-optical-impairment-topology-yang].
 
    The same WDM label shall be assigned to the same WDM LSP on all the
    WDM Links on a regen-free LSP path or path segment.
@@ -439,8 +441,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
       nominal central frequency granularity (NCFG, fixed at 6.25GHz in
       [ITU-T_G.694.1]) respectively, as described in [RFC7699]:
 
-         SW = M x SWG (measured in GHz)
-         f = 193100.000 GHz + N x NCFG (measured in GHz)
 
 
 
@@ -449,6 +449,9 @@ Belotti, et al.          Expires 1 November 2024                [Page 8]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+         SW = M x SWG (measured in GHz)
+         f = 193100.000 GHz + N x NCFG (measured in GHz)
 
    The definition of the channel spacing, NCFG and SWG in the YANG model
    are defined to support modelling of vendor-specific values (e.g.,
@@ -495,9 +498,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
    models) or the wdm-label-start-end grouping (for models that supports
    both WSON and DWDM flexible-grid).
 
-   The label-step definition for WDM should be augmented using the wson-
-   label-step grouping (for WSON only models) or the flexi-grid-label-
-   step grouping (for DWDM flexible-grid only models) or the wdm-label-
 
 
 
@@ -506,6 +506,9 @@ Belotti, et al.          Expires 1 November 2024                [Page 9]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+   The label-step definition for WDM should be augmented using the wson-
+   label-step grouping (for WSON only models) or the flexi-grid-label-
+   step grouping (for DWDM flexible-grid only models) or the wdm-label-
    step grouping (for models that supports both WSON and DWDM flexible-
    grid).  The label-step definition for WDM depends on the WDM grid
    type:
@@ -551,9 +554,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           |  +-- cwdm-n?                     l0-types:cwdm-n
           +--:(flexi-grid)
              +-- (single-or-super-channel)?
-                +--:(single)
-                |  +-- flexi-n?              l0-types:flexi-n
-                |  +-- flexi-m?              l0-types:flexi-m
 
 
 
@@ -562,6 +562,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 10]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+                +--:(single)
+                |  +-- flexi-n?              l0-types:flexi-n
+                |  +-- flexi-m?              l0-types:flexi-m
                 x--:(super)
                 |  x-- subcarrier-flexi-n* [flexi-n]
                 |     +-- flexi-n?   l0-types:flexi-n
@@ -607,9 +610,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        +-- flexi-n?   l0-types:flexi-n
      grouping flexi-grid-frequency-slot:
        +-- flexi-n?   l0-types:flexi-n
-       +-- flexi-m?   l0-types:flexi-m
-     grouping flexi-grid-label-hop:
-       +-- (single-or-super-channel)?
 
 
 
@@ -618,6 +618,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 11]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+       +-- flexi-m?   l0-types:flexi-m
+     grouping flexi-grid-label-hop:
+       +-- (single-or-super-channel)?
           +--:(single)
           |  +-- flexi-n?              l0-types:flexi-n
           |  +-- flexi-m?              l0-types:flexi-m
@@ -663,9 +666,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           |     +--ro max-central-frequency?     frequency-thz
           |     +--ro transceiver-tunability?    frequency-ghz
           |     +--ro tx-channel-power-min?      power-dbm
-          |     +--ro tx-channel-power-max?      power-dbm
-          |     +--ro rx-channel-power-min?      power-dbm
-          |     +--ro rx-channel-power-max?      power-dbm
 
 
 
@@ -674,6 +674,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 12]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+          |     +--ro tx-channel-power-max?      power-dbm
+          |     +--ro rx-channel-power-min?      power-dbm
+          |     +--ro rx-channel-power-max?      power-dbm
           |     +--ro rx-total-power-max?        power-dbm
           +--:(explicit-mode)
              +--ro explicit-mode
@@ -719,9 +722,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
                 +--:(explicit-mode)
                    +--ro explicit-mode
                       +--ro min-central-frequency?    frequency-thz
-                      +--ro max-central-frequency?    frequency-thz
-                      +--ro transceiver-tunability?   frequency-ghz
-                      +--ro tx-channel-power-min?     power-dbm
 
 
 
@@ -730,6 +730,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 13]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+                      +--ro max-central-frequency?    frequency-thz
+                      +--ro transceiver-tunability?   frequency-ghz
+                      +--ro tx-channel-power-min?     power-dbm
                       +--ro tx-channel-power-max?     power-dbm
                       +--ro rx-channel-power-min?     power-dbm
                       +--ro rx-channel-power-max?     power-dbm
@@ -775,9 +778,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        +--ro min-Q-factor?                       decimal-2
        +--ro available-baud-rate?                decimal64
        +--ro roll-off?                           decimal64
-       +--ro min-carrier-spacing?                frequency-ghz
-       +--ro available-fec-type?                 identityref
-       +--ro fec-code-rate?                      decimal64
 
 
 
@@ -786,6 +786,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 14]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+       +--ro min-carrier-spacing?                frequency-ghz
+       +--ro available-fec-type?                 identityref
+       +--ro fec-code-rate?                      decimal64
        +--ro fec-threshold?                      decimal64
        +--ro in-band-osnr?                       snr
        +--ro out-of-band-osnr?                   snr
@@ -831,9 +834,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
                                   Figure 1
 
-4.  YANG Module for Layer 0 Types
-
-
 
 
 
@@ -841,6 +841,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 15]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+4.  YANG Module for Layer 0 Types
 
    <CODE BEGINS> file "ietf-layer0-types@2024-03-04.yang"
    module ietf-layer0-types {
@@ -888,8 +890,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
         The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
         NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
         'MAY', and 'OPTIONAL' in this document are to be interpreted as
-        described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-        they appear in all capitals, as shown here.";
 
 
 
@@ -897,6 +897,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 16]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+        described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+        they appear in all capitals, as shown here.";
 
    // RFC Ed.: replace XXXX with actual RFC number and remove
    // this note
@@ -944,9 +947,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            CWDM wavelength grid";
        }
 
-       identity wson-grid-dwdm {
-         base l0-grid-type;
-
 
 
 Belotti, et al.          Expires 1 November 2024               [Page 17]
@@ -954,6 +954,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 17]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+       identity wson-grid-dwdm {
+         base l0-grid-type;
          description
            "DWDM grid";
          reference
@@ -1000,8 +1002,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
 
      identity dwdm-ch-spc-type {
-       description
-         "DWDM channel-spacing type";
 
 
 
@@ -1010,6 +1010,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 18]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+       description
+         "DWDM channel-spacing type";
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
@@ -1056,8 +1058,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        identity dwdm-12p5ghz {
          base dwdm-ch-spc-type;
-         description
-           "12.5 GHz channel spacing";
 
 
 
@@ -1066,6 +1066,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 19]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+         description
+           "12.5 GHz channel spacing";
          reference
            "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
            Label Switching Routers,
@@ -1112,8 +1114,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        }
 
      identity flexi-slot-width-granularity {
-       description
-         "Flexi-grid slot width granularity";
 
 
 
@@ -1122,6 +1122,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 20]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+       description
+         "Flexi-grid slot width granularity";
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers,
@@ -1168,8 +1170,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
        identity QAM8 {
          base modulation;
          description
-           "8QAM (8 symbols Quadrature Amplitude Modulation)";
-       }
 
 
 
@@ -1177,6 +1177,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 21]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+           "8QAM (8 symbols Quadrature Amplitude Modulation)";
+       }
 
        identity DP-QAM8 {
          base modulation;
@@ -1224,9 +1227,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            Modulation)";
        }
 
-     identity fec-type {
-       description
-
 
 
 Belotti, et al.          Expires 1 November 2024               [Page 22]
@@ -1234,6 +1234,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 22]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+     identity fec-type {
+       description
          "Base identity from which specific FEC
          (Forward Error Correction) type identities are derived.";
      }
@@ -1280,8 +1282,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            "Clause 16.4.4 of ITU-T G.709.3 v2.1 (11/2022): Flexible OTN
            long-reach interfaces;
 
-           Annex E of ITU-T G.709.3 v2.1 (11/2022): Flexible OTN
-           long-reach interfaces.";
 
 
 
@@ -1290,6 +1290,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 23]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+           Annex E of ITU-T G.709.3 v2.1 (11/2022): Flexible OTN
+           long-reach interfaces.";
        }
 
        identity c-fec {
@@ -1336,8 +1338,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
            the Optical channel Transport Unit order 1 (OTU1) optical
            tributary signals";
          reference
-           "Section 7.2.1.2 of ITU-T G.959.1 v8.0 (07/2018).";
-       }
 
 
 
@@ -1345,6 +1345,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 24]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+           "Section 7.2.1.2 of ITU-T G.959.1 v8.0 (07/2018).";
+       }
 
        identity line-coding-NRZ-10G {
          description
@@ -1391,9 +1394,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          "Wavelength selection base";
        reference
          "RFC 7689: Signaling Extensions for Wavelength Switched
-         Optical Networks";
-     }
-
 
 
 
@@ -1401,6 +1401,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 25]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+         Optical Networks";
+     }
 
        identity first-fit-wavelength-assignment {
          base wavelength-assignment;
@@ -1447,9 +1450,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
          description
            "Allocate wavelengths in decending order, beginning from the
            highest frequency and progressing toward the lowest frequency
-           within the permissible frequency range.";
-       }
-
 
 
 
@@ -1457,6 +1457,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 26]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+           within the permissible frequency range.";
+       }
 
      identity otu-type {
        description
@@ -1503,9 +1506,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
        identity OTUCn {
          base otu-type;
-         description
-           "OTUCn (n x 105.25 Gb/s)";
-         reference
 
 
 
@@ -1514,6 +1514,9 @@ Belotti, et al.          Expires 1 November 2024               [Page 27]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+         description
+           "OTUCn (n x 105.25 Gb/s)";
+         reference
            "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
            Transport Network (OTN)";
        }
@@ -1560,9 +1563,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           DWDM frequency grid";
      }
 
-     typedef cwdm-n {
-       type int16;
-
 
 
 Belotti, et al.          Expires 1 November 2024               [Page 28]
@@ -1570,6 +1570,8 @@ Belotti, et al.          Expires 1 November 2024               [Page 28]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+     typedef cwdm-n {
+       type int16;
        description
          "The given value 'N' is used to determine the nominal central
           wavelength.
@@ -1617,8 +1619,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
           A slot width is defined by:
             slot width = M x SWG (measured in GHz),
 
-          where SWG is defined by the flexi-slot-width-granularity.";
-
 
 
 Belotti, et al.          Expires 1 November 2024               [Page 29]
@@ -1626,6 +1626,7 @@ Belotti, et al.          Expires 1 November 2024               [Page 29]
 Internet-Draft            L0 Common YANG Types                April 2024
 
 
+          where SWG is defined by the flexi-slot-width-granularity.";
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers,
@@ -1673,7 +1674,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
    // RFC Ed.: replace YYYY with actual RFC number and remove
    // this note after draft-ietf-ccamp-optical-impairment-topology-yang
    // is published as an RFC
-
 
 
 
@@ -3557,6 +3557,14 @@ Internet-Draft            L0 Common YANG Types                April 2024
 
 7.1.  Normative References
 
+   [I-D.ietf-ccamp-optical-impairment-topology-yang]
+              Beller, D., Le Rouzic, E., Belotti, S., Galimberti, G.,
+              and I. Busi, "A YANG Data Model for Optical Impairment-
+              aware Topology", Work in Progress, Internet-Draft, draft-
+              ietf-ccamp-optical-impairment-topology-yang-15, 4 March
+              2024, <https://datatracker.ietf.org/doc/html/draft-ietf-
+              ccamp-optical-impairment-topology-yang-15>.
+
    [I-D.ietf-teas-rfc8776-update]
               Busi, I., Guo, A., Liu, X., Saad, T., and I. Bryskin,
               "Common YANG Data Types for Traffic Engineering", Work in
@@ -3571,20 +3579,18 @@ Internet-Draft            L0 Common YANG Types                April 2024
               that compensate for polarization mode dispersion", ITU-T
               G.666 , February 2011.
 
-   [ITU-T_G.698.2]
-              ITU-T Recommendation G.698.2, "Amplified multichannel
-              dense wavelength division multiplexing applications with
-              single channel optical interfaces", ITU-T G.698.2 ,
-              November 2018.
-
-
-
 
 
 Belotti, et al.          Expires 1 November 2024               [Page 64]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+   [ITU-T_G.698.2]
+              ITU-T Recommendation G.698.2, "Amplified multichannel
+              dense wavelength division multiplexing applications with
+              single channel optical interfaces", ITU-T G.698.2 ,
+              November 2018.
 
    [ITU-T_G.709]
               ITU-T Recommendation G.709, "Interfaces for the optical
@@ -3625,14 +3631,8 @@ Internet-Draft            L0 Common YANG Types                April 2024
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
               <https://www.rfc-editor.org/info/rfc6242>.
 
-   [RFC7699]  Farrel, A., King, D., Li, Y., and F. Zhang, "Generalized
-              Labels for the Flexi-Grid in Lambda Switch Capable (LSC)
-              Label Switching Routers", RFC 7699, DOI 10.17487/RFC7699,
-              November 2015, <https://www.rfc-editor.org/info/rfc7699>.
 
-   [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
-              RFC 7950, DOI 10.17487/RFC7950, August 2016,
-              <https://www.rfc-editor.org/info/rfc7950>.
+
 
 
 
@@ -3641,6 +3641,15 @@ Belotti, et al.          Expires 1 November 2024               [Page 65]
 
 Internet-Draft            L0 Common YANG Types                April 2024
 
+
+   [RFC7699]  Farrel, A., King, D., Li, Y., and F. Zhang, "Generalized
+              Labels for the Flexi-Grid in Lambda Switch Capable (LSC)
+              Label Switching Routers", RFC 7699, DOI 10.17487/RFC7699,
+              November 2015, <https://www.rfc-editor.org/info/rfc7699>.
+
+   [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
+              RFC 7950, DOI 10.17487/RFC7950, August 2016,
+              <https://www.rfc-editor.org/info/rfc7950>.
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
@@ -3677,15 +3686,6 @@ Internet-Draft            L0 Common YANG Types                April 2024
               <https://www.rfc-editor.org/info/rfc8795>.
 
 7.2.  Informative References
-
-   [I-D.ietf-ccamp-dwdm-if-param-yang]
-              Galimberti, G., Hiremagalur, D., Grammel, G., Manzotti,
-              R., and D. Breuer, "A YANG model to manage the optical
-              interface parameters for an external transponder in a WDM
-              network", Work in Progress, Internet-Draft, draft-ietf-
-              ccamp-dwdm-if-param-yang-10, 23 October 2023,
-              <https://datatracker.ietf.org/doc/html/draft-ietf-ccamp-
-              dwdm-if-param-yang-10>.
 
 
 

--- a/draft-ietf-ccamp-rfc9093-bis.txt
+++ b/draft-ietf-ccamp-rfc9093-bis.txt
@@ -15,17 +15,18 @@ Expires: 1 November 2024                                  D. Beller, Ed.
                                                            30 April 2024
 
 
-                  A YANG Data Model for Layer 0 Types
+              Common YANG Data Types for Layer 0 Networks
                   draft-ietf-ccamp-rfc9093-bis-latest
 
 Abstract
 
-   This document defines a collection of common data types and groupings
-   in the YANG data modeling language.  These derived common types and
-   groupings are intended to be imported by modules that model Layer 0
-   optical Traffic Engineering (TE) configuration and state capabilities
-   such as Wavelength Switched Optical Networks (WSONs) and flexi-grid
-   Dense Wavelength Division Multiplexing (DWDM) networks.
+   This document defines a collection of common data types, identities,
+   and groupings in the YANG data modeling language.  These derived
+   common data types, identities, and groupings are intended to be
+   imported by modules that model Layer 0 configuration and state
+   capabilities, such as Wavelength Switched Optical Networks (WSONs)
+   and flexi-grid Dense Wavelength Division Multiplexing (DWDM)
+   networks.
 
    This document obsoletes RFC 9093.
 
@@ -46,17 +47,21 @@ Status of This Memo
 
    This Internet-Draft will expire on 1 November 2024.
 
-Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
-   document authors.  All rights reserved.
+
+
 
 
 
 Belotti, et al.          Expires 1 November 2024                [Page 1]
 
-Internet-Draft           Yang for Layer 0 Types               April 2024
+Internet-Draft            L0 Common YANG Types                April 2024
 
+
+Copyright Notice
+
+   Copyright (c) 2024 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents (https://trustee.ietf.org/
@@ -72,19 +77,19 @@ Table of Contents
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
      1.1.  Terminology and Notations . . . . . . . . . . . . . . . .   3
      1.2.  Prefix in Data Node Names . . . . . . . . . . . . . . . .   3
-   2.  Layer 0 Types Module Contents . . . . . . . . . . . . . . . .   3
+   2.  Layer 0 Types Module Contents . . . . . . . . . . . . . . . .   4
      2.1.  WDM Label and Label Range . . . . . . . . . . . . . . . .   8
    3.  YANG Tree for Layer 0 Types Groupings . . . . . . . . . . . .  10
    4.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  15
-   5.  Security Considerations . . . . . . . . . . . . . . . . . . .  62
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  63
-   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  63
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  63
-     7.2.  Informative References  . . . . . . . . . . . . . . . . .  65
-   Appendix A.  Changes from RFC 9093  . . . . . . . . . . . . . . .  67
-   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  67
-   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  67
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  68
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .  63
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  64
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  64
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  64
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  66
+   Appendix A.  Changes from RFC 9093  . . . . . . . . . . . . . . .  68
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  68
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  68
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  69
 
 1.  Introduction
 
@@ -101,18 +106,18 @@ Table of Contents
    Engineering (TE) features as well as non-TE features (e.g., physical
    network configuration aspects) for Layer 0 optical networks in
    model(s) defined outside of this document.  The applicability of
-   Layer 0 types specified in this document includes Wavelength Switched
-   Optical Networks (WSONs) [RFC6163] [ITU-T_G.694.1] and
-   [ITU-T_G.694.2], and flexi-grid Dense Wavelength Division
-   Multiplexing (DWDM) networks [RFC7698] [ITU-T_G.694.1].
-
 
 
 
 Belotti, et al.          Expires 1 November 2024                [Page 2]
 
-Internet-Draft           Yang for Layer 0 Types               April 2024
+Internet-Draft            L0 Common YANG Types                April 2024
 
+
+   Layer 0 types specified in this document includes Wavelength Switched
+   Optical Networks (WSONs) [RFC6163] [ITU-T_G.694.1] and
+   [ITU-T_G.694.2], and flexi-grid Dense Wavelength Division
+   Multiplexing (DWDM) networks [RFC7698] [ITU-T_G.694.1].
 
    This document adds new type definitions to the YANG modules and
    obsoletes [RFC9093].  For further details, see the revision
@@ -152,6 +157,19 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    RFC Editor Note: Please replace XXXX with the RFC number assigned to
    this document.
 
+
+
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 3]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
 2.  Layer 0 Types Module Contents
 
    This document defines a YANG module for common Layer 0 types, ietf-
@@ -160,15 +178,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    reusable types and groupings:
 
    l0-grid-type:
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 3]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
       A base YANG identity for the grid type as defined in [RFC6205] and
       [RFC7699].
@@ -210,6 +219,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
    otu-type:
 
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 4]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
       This specifies the type of OTU, including the types specified in
       [ITU-T_G.709].
 
@@ -217,14 +233,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
       data plane, the type of OTUk defined in [ITU-T_G.Sup43] can be
       defined in vendor-specific YANG modules using the otu-type
       identity, defined in this document, as the base.
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 4]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
    operational-mode:
 
@@ -263,6 +271,17 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
       start and label-end information which is used to describe the
       range of available nominal central frequencies.
 
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 5]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
       As described in section 3.1 of [RFC8363], the range of available
       nominal central frequencies are advertised for m=1, which means
       that for an available central frequency n, the frequency slot from
@@ -273,14 +292,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
       The flexi-grid label range was defined in [RFC8363], and the
       generic topology model defines the label-hop in [RFC8795].  This
       grouping shows the WSON-specific label-hop information.
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 5]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
    flexi-grid-label-range-info:
 
@@ -320,6 +331,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
       label-step, to support optical network scenarios that contain both
       fixed- and flexi-grid links.
 
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 6]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
    transceiver-capabilities:
 
       a YANG grouping to define the transceiver capabilities (also
@@ -330,13 +348,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
       a YANG grouping for the standard modes defined in [ITU-T_G.698.2].
 
    organizational-mode:
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 6]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
       a YANG grouping to define transponder operational mode supported
       by organizations or vendors.
@@ -376,6 +387,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
       TBD: add a description and reference to [ITU-T_G.977.1]
 
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 7]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
    psd:
 
       TBD: add a description and reference to [ITU-T_G.9700]
@@ -383,16 +401,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    pmd:
 
       TBD: add a description and reference to [ITU-T_G.666]
-
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 7]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
 2.1.  WDM Label and Label Range
 
@@ -434,21 +442,20 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          SW = M x SWG (measured in GHz)
          f = 193100.000 GHz + N x NCFG (measured in GHz)
 
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 8]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
    The definition of the channel spacing, NCFG and SWG in the YANG model
    are defined to support modelling of vendor-specific values (e.g.,
    finer vendor-specific granularity for NCFG and SWG).
 
    The WDM Label Range represents the frequency slots that are available
    for WDM LSPs to be set up over a given WDM Link.
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 8]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
    The WDM Label Range is defined by the label-restriction list, defined
    in [I-D.ietf-teas-rfc8776-update], which, for WDM, should be
@@ -491,20 +498,20 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    The label-step definition for WDM should be augmented using the wson-
    label-step grouping (for WSON only models) or the flexi-grid-label-
    step grouping (for DWDM flexible-grid only models) or the wdm-label-
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 9]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
    step grouping (for models that supports both WSON and DWDM flexible-
    grid).  The label-step definition for WDM depends on the WDM grid
    type:
 
    *  For CWDM and DWDM fixed grids, it describes the channel spacing,
       as defined in [RFC6205];
-
-
-
-
-Belotti, et al.          Expires 1 November 2024                [Page 9]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
    *  For DWDM flexible grids, it describes the nominal central
       frequency granularity (e.g., 6,25 GHz) as well as the multiplier
@@ -547,6 +554,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                 +--:(single)
                 |  +-- flexi-n?              l0-types:flexi-n
                 |  +-- flexi-m?              l0-types:flexi-m
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 10]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
                 x--:(super)
                 |  x-- subcarrier-flexi-n* [flexi-n]
                 |     +-- flexi-n?   l0-types:flexi-n
@@ -554,14 +569,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                 +--:(multi)
                    +-- frequency-slots
                       +-- frequency-slot* [flexi-n]
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 10]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
                          +-- flexi-n?   l0-types:flexi-n
                          +-- flexi-m?   l0-types:flexi-m
      grouping wdm-label-range-info:
@@ -603,6 +610,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        +-- flexi-m?   l0-types:flexi-m
      grouping flexi-grid-label-hop:
        +-- (single-or-super-channel)?
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 11]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
           +--:(single)
           |  +-- flexi-n?              l0-types:flexi-n
           |  +-- flexi-m?              l0-types:flexi-m
@@ -610,14 +625,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
           |  x-- subcarrier-flexi-n* [flexi-n]
           |     +-- flexi-n?   l0-types:flexi-n
           |     +-- flexi-m?   l0-types:flexi-m
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 11]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
           +--:(multi)
              +-- frequency-slots
                 +-- frequency-slot* [flexi-n]
@@ -659,6 +666,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
           |     +--ro tx-channel-power-max?      power-dbm
           |     +--ro rx-channel-power-min?      power-dbm
           |     +--ro rx-channel-power-max?      power-dbm
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 12]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
           |     +--ro rx-total-power-max?        power-dbm
           +--:(explicit-mode)
              +--ro explicit-mode
@@ -666,14 +681,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                 +--ro max-central-frequency?    frequency-thz
                 +--ro transceiver-tunability?   frequency-ghz
                 +--ro tx-channel-power-min?     power-dbm
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 12]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
                 +--ro tx-channel-power-max?     power-dbm
                 +--ro rx-channel-power-min?     power-dbm
                 +--ro rx-channel-power-max?     power-dbm
@@ -715,6 +722,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                       +--ro max-central-frequency?    frequency-thz
                       +--ro transceiver-tunability?   frequency-ghz
                       +--ro tx-channel-power-min?     power-dbm
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 13]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
                       +--ro tx-channel-power-max?     power-dbm
                       +--ro rx-channel-power-min?     power-dbm
                       +--ro rx-channel-power-max?     power-dbm
@@ -722,14 +737,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                       +--ro compatible-modes
                          +--ro supported-application-codes*
                          |       -> ../../../../supported-mode/mode-id
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 13]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
                          +--ro supported-organizational-modes*
                                  -> ../../../../supported-mode/mode-id
      grouping standard-mode:
@@ -743,22 +750,26 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        +--ro line-coding-bitrate?                identityref
        +--ro bitrate?                            uint16
        +--ro max-diff-group-delay?               decimal-2
-       +--ro max-chromatic-dispersion?           decimal64
-       +--ro cd-penalty* []
+       +--ro max-chromatic-dispersion?           decimal-2
+       +--ro cd-penalty* [cd-index]
+       |  +--ro cd-index?        decimal-2
        |  +--ro cd-value         union
        |  +--ro penalty-value    union
-       +--ro max-polarization-mode-dispersion?   decimal64
-       +--ro pmd-penalty* []
+       +--ro max-polarization-mode-dispersion?   decimal-2
+       +--ro pmd-penalty* [pmd-index]
+       |  +--ro pmd-index?       decimal-2
        |  +--ro pmd-value        union
        |  +--ro penalty-value    union
        +--ro max-polarization-dependant-loss     power-loss-or-null
-       +--ro pdl-penalty* []
+       +--ro pdl-penalty* [pdl-index]
+       |  +--ro pdl-index?       decimal-2
        |  +--ro pdl-value        power-loss-or-null
        |  +--ro penalty-value    union
        +--ro available-modulation-type?          identityref
        +--ro min-OSNR?                           snr
        +--ro rx-ref-channel-power?               power-dbm
-       +--ro rx-channel-power-penalty* []
+       +--ro rx-channel-power-penalty* [rx-channel-power-index]
+       |  +--ro rx-channel-power-index?   decimal-2
        |  +--ro rx-channel-power-value    power-dbm-or-null
        |  +--ro penalty-value             union
        +--ro min-Q-factor?                       decimal-2
@@ -767,25 +778,25 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        +--ro min-carrier-spacing?                frequency-ghz
        +--ro available-fec-type?                 identityref
        +--ro fec-code-rate?                      decimal64
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 14]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        +--ro fec-threshold?                      decimal64
        +--ro in-band-osnr?                       snr
        +--ro out-of-band-osnr?                   snr
        +--ro tx-polarization-power-difference?   power-ratio
-       +--ro polarization-skew?                  decimal64
+       +--ro polarization-skew?                  decimal-2
      grouping common-standard-organizational-mode:
        +--ro line-coding-bitrate*   identityref
      grouping transmitter-tuning-range:
        +-- min-central-frequency?    frequency-thz
        +-- max-central-frequency?    frequency-thz
        +-- transceiver-tunability?   frequency-ghz
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 14]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
      grouping common-all-modes:
        +-- min-central-frequency?    frequency-thz
        +-- max-central-frequency?    frequency-thz
@@ -822,6 +833,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
 4.  YANG Module for Layer 0 Types
 
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 15]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
    <CODE BEGINS> file "ietf-layer0-types@2024-03-04.yang"
    module ietf-layer0-types {
      yang-version 1.1;
@@ -833,14 +853,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      contact
        "WG Web:  <https://datatracker.ietf.org/wg/ccamp/>
         WG List: <mailto:ccamp@ietf.org>
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 15]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
         Editor:  Dieter Beller
                  <mailto:Dieter.Beller@nokia.com>
@@ -879,6 +891,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
         described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
         they appear in all capitals, as shown here.";
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 16]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
    // RFC Ed.: replace XXXX with actual RFC number and remove
    // this note
 
@@ -890,13 +909,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        reference
          "RFC XXXX: A YANG Data Model for Layer 0 Types";
      }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 16]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
      revision 2021-08-13 {
        description
@@ -934,6 +946,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
        identity wson-grid-dwdm {
          base l0-grid-type;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 17]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          description
            "DWDM grid";
          reference
@@ -946,14 +966,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
        identity flexi-grid-dwdm {
          base l0-grid-type;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 17]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          description
            "Flexi-grid";
          reference
@@ -990,6 +1002,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      identity dwdm-ch-spc-type {
        description
          "DWDM channel-spacing type";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 18]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
@@ -1002,14 +1022,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          base dwdm-ch-spc-type;
          description
            "100 GHz channel spacing";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 18]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          reference
            "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
            Label Switching Routers,
@@ -1046,6 +1058,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          base dwdm-ch-spc-type;
          description
            "12.5 GHz channel spacing";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 19]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          reference
            "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
            Label Switching Routers,
@@ -1058,14 +1078,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        status deprecated;
        description
          "Flexi-grid channel-spacing type";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 19]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
      }
 
        identity flexi-ch-spc-6p25ghz {
@@ -1102,6 +1114,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      identity flexi-slot-width-granularity {
        description
          "Flexi-grid slot width granularity";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 20]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers,
@@ -1114,14 +1134,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          base flexi-slot-width-granularity;
          description
            "12.5 GHz slot width granularity";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 20]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          reference
            "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
            Switch Capable (LSC) Label Switching Routers,
@@ -1159,6 +1171,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "8QAM (8 symbols Quadrature Amplitude Modulation)";
        }
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 21]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        identity DP-QAM8 {
          base modulation;
          description
@@ -1170,14 +1189,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          base modulation;
          description
            "QAM16 (16 symbols Quadrature Amplitude Modulation)";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 21]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
        }
 
        identity DP-QAM16 {
@@ -1215,6 +1226,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
      identity fec-type {
        description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 22]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          "Base identity from which specific FEC
          (Forward Error Correction) type identities are derived.";
      }
@@ -1226,14 +1245,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          reference
            "ITU-T G.975 v2.0 (10/2000): Forward error correction for
            submarine systems.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 22]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
        }
 
        identity super-fec {
@@ -1271,6 +1282,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
            Annex E of ITU-T G.709.3 v2.1 (11/2022): Flexible OTN
            long-reach interfaces.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 23]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        }
 
        identity c-fec {
@@ -1282,14 +1301,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
            More details are provided in clause 15/G.709.3 where it is
            called DSH instead of concatenated FEC.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 23]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          reference
            "Annex A of ITU-T G.709.2 v1.1 (09/2020):OTU4 long-reach
            interface;
@@ -1328,6 +1339,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "Section 7.2.1.2 of ITU-T G.959.1 v8.0 (07/2018).";
        }
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 24]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        identity line-coding-NRZ-10G {
          description
            "The non return to zero (NRZ) bit rate/line coding used by
@@ -1338,14 +1356,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
        identity line-coding-NRZ-OTU2 {
          base line-coding;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 24]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          description
            "The non return to zero (NRZ) bit rate/line coding used by
            the Optical channel Transport Unit order 2 (OTU2) optical
@@ -1384,6 +1394,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          Optical Networks";
      }
 
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 25]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        identity first-fit-wavelength-assignment {
          base wavelength-assignment;
          description
@@ -1394,13 +1412,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "RFC 7689: Signaling Extensions for Wavelength Switched
            Optical Networks";
        }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 25]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
        identity random-wavelength-assignment {
          base wavelength-assignment;
@@ -1439,6 +1450,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            within the permissible frequency range.";
        }
 
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 26]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
      identity otu-type {
        description
          "Base identity from which specific OTU identities are derived";
@@ -1450,14 +1469,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          base otu-type;
          description
            "OTU1 (2.66 Gb/s)";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 26]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          reference
            "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
            Transport Network (OTN)";
@@ -1495,6 +1506,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          description
            "OTUCn (n x 105.25 Gb/s)";
          reference
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 27]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
            Transport Network (OTN)";
        }
@@ -1506,14 +1525,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      }
 
        identity power-spectral-density {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 27]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          base type-power-mode;
          description
            "all elements must use power spectral density (W/Hz)";
@@ -1551,6 +1562,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
      typedef cwdm-n {
        type int16;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 28]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        description
          "The given value 'N' is used to determine the nominal central
           wavelength.
@@ -1562,14 +1581,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
           transmission over the CWDM grid, and where 'channel spacing'
           is defined by the cwdm-ch-spc-type.";
        reference
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 28]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
 
@@ -1607,6 +1618,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
             slot width = M x SWG (measured in GHz),
 
           where SWG is defined by the flexi-slot-width-granularity.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 29]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers,
@@ -1618,14 +1637,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      typedef standard-mode {
        type string;
        description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 29]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          "Identifies an ITU-T G.698.2 standard application code.
 
          It MUST be a string with a format that follows the
@@ -1663,6 +1674,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    // this note after draft-ietf-ccamp-optical-impairment-topology-yang
    // is published as an RFC
 
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 30]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
      typedef frequency-thz {
        type decimal64 {
          fraction-digits 9;
@@ -1674,14 +1693,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
      typedef frequency-ghz {
        type decimal64 {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 30]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          fraction-digits 6;
        }
        units "GHz";
@@ -1690,9 +1701,7 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      }
 
      typedef snr {
-       type decimal64 {
-         fraction-digits 2;
-       }
+       type decimal-2;
        units "dB@0.1nm";
        description
          "(Optical) Signal to Noise Ratio measured over 0.1 nm
@@ -1721,6 +1730,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              "G.652 Standard Singlemode Fiber";
          }
          enum G.654 {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 31]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            description
              "G.654 Cutoff Shifted Fiber";
          }
@@ -1730,14 +1747,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          enum G.655 {
            description "G.655 Non-Zero Dispersion Shifted Fiber";
          }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 31]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          enum G.656 {
            description
              "G.656 Non-Zero Dispersion for Wideband Optical Transport";
@@ -1778,6 +1787,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          "The gain in dB.";
      }
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 32]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
      typedef power-gain-or-null {
        type union {
          type power-gain;
@@ -1786,14 +1802,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        description
          "The gain in dB, when it is known or an empty
          value when the power gain/loss is not known.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 32]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
      }
 
      typedef power-loss {
@@ -1834,6 +1842,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
      typedef power-dbm {
        type decimal-2;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 33]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        units "dBm";
        description
          "The power in dBm.";
@@ -1842,14 +1858,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      typedef power-dbm-or-null {
        type union {
          type power-dbm;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 33]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          type empty;
        }
        description
@@ -1890,6 +1898,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      }
 
      typedef psd-or-null {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 34]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        type union {
          type psd;
          type empty;
@@ -1898,13 +1914,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          "The power spectral density (PSD), when it is known or an
          empty value when the PSD is not known.";
      }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 34]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
    /*
     * Groupings
@@ -1945,6 +1954,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              description
                "The given value 'N' is used to determine the nominal
                 central wavelength.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 35]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
              reference
                "RFC 6205: Generalized Labels for Lambda-Switch-Capable
                 (LSC) Label Switching Routers";
@@ -1954,14 +1971,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            uses l0-types:flexi-grid-label-start-end;
          }
        }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 35]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers";
@@ -2001,6 +2010,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              type identityref {
                base cwdm-ch-spc-type;
              }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 36]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
              description
                "Label-step is the channel spacing (nm), i.e., 20 nm
                 for CWDM, which is the only value defined for CWDM.";
@@ -2010,14 +2027,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            }
          }
          case flexi-grid {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 36]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
            uses flexi-grid-label-step;
          }
        }
@@ -2057,6 +2066,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                    "The given values 'N' are used to determine the
                     nominal central frequency for each subcarrier
                     channel.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 37]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
                  reference
                    "ITU-T G.694.1 (10/2020): Spectral grids for WDM
                    applications: DWDM frequency grid";
@@ -2066,14 +2083,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          }
          case cwdm {
            leaf cwdm-n {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 37]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
              type l0-types:cwdm-n;
              description
                "The given value 'N' is used to determine the nominal
@@ -2113,6 +2122,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              "Minimum space between slot widths. Default is 12.500
               GHz.";
            reference
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 38]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
              "RFC 7698: Framework and Requirements for GMPLS-Based
               Control of Flexi-Grid Dense Wavelength Division
               Multiplexing (DWDM) Networks";
@@ -2122,14 +2139,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              range "1..max";
            }
            default "1";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 38]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
            description
              "A multiplier of the slot width granularity, indicating
               the minimum slot width supported by an optical port.
@@ -2170,6 +2179,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        }
      }
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 39]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
      grouping wson-label-start-end {
        description
          "The WSON label-start or label-end used to specify WSON label
@@ -2178,14 +2194,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          description
            "Label for DWDM or CWDM grid";
          case dwdm {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 39]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
            leaf dwdm-n {
              when "derived-from-or-self(../../../grid-type,
                    \"wson-grid-dwdm\")" {
@@ -2226,6 +2234,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          "Generic label-hop information for WSON";
        choice grid-type {
          description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 40]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            "Label for DWDM or CWDM grid";
          case dwdm {
            choice single-or-super-channel {
@@ -2234,14 +2250,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              case single {
                leaf dwdm-n {
                  type l0-types:dwdm-n;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 40]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
                  description
                    "The given value 'N' is used to determine the
                     nominal central frequency.";
@@ -2282,6 +2290,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        description
          "Information about Layer 0 label range.";
        leaf grid-type {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 41]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          type identityref {
            base l0-grid-type;
          }
@@ -2290,14 +2306,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        }
        leaf priority {
          type uint8;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 41]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          description
            "Priority in Interface Switching Capability Descriptor
             (ISCD).";
@@ -2338,6 +2346,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            leaf wson-cwdm-channel-spacing {
              when "derived-from-or-self(../../grid-type,
                    \"wson-grid-cwdm\")" {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 42]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
                description
                  "Valid only when grid type is CWDM.";
              }
@@ -2346,14 +2362,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              }
              description
                "Label-step is the channel spacing (nm), i.e., 20 nm
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 42]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
                 for CWDM, which is the only value defined for CWDM.";
              reference
                "RFC 6205: Generalized Labels for Lambda-Switch-Capable
@@ -2394,6 +2402,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
      }
 
      grouping flexi-grid-frequency-slot {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 43]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        description
          "Flexi-grid frequency slot grouping.";
        uses flexi-grid-label-start-end;
@@ -2402,14 +2418,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          description
            "The given value 'M' is used to determine the slot width.";
        }
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 43]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers";
@@ -2450,6 +2458,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                  "List of frequency slots used for flexi-grid super
                  channel.";
              }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 44]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            }
          }
        }
@@ -2457,14 +2473,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-Grid
          Dense Wavelength Division Multiplexing (DWDM) Networks";
      }
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 44]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
 
      grouping flexi-grid-label-range-info {
        description
@@ -2506,6 +2514,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          leaf max-slot-width-factor {
            type uint16 {
              range "1..max";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 45]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            }
            must '. >= ../min-slot-width-factor' {
              error-message
@@ -2514,14 +2530,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            }
            description
              "A multiplier of the slot width granularity, indicating
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 45]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
               the maximum slot width supported by an optical port.
 
               Maximum slot width is calculated by:
@@ -2562,6 +2570,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          default "flexi-ncfg-6p25ghz";
          description
            "Label-step is the nominal central frequency granularity
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 46]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
             (GHz), e.g., 6.25 GHz.";
          reference
            "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
@@ -2570,14 +2586,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        leaf flexi-n-step {
          type uint8;
          description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 46]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
            "This attribute defines the multiplier for the supported
             values of 'N'.
 
@@ -2618,6 +2626,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          case G.698.2 {
            uses standard-mode;
            uses common-standard-organizational-mode;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 47]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            uses common-all-modes;
          }
          case organizational-mode {
@@ -2626,14 +2642,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              description
                "The set of attributes for an organizational mode";
              uses organizational-mode;
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 47]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
              uses common-standard-organizational-mode;
              uses common-all-modes;
            }  // container organizational-mode
@@ -2674,6 +2682,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            transceiver are reported.";
          description
            "The top level container for the list supported
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 48]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            transceiver's modes.";
          list supported-mode {
            key "mode-id";
@@ -2682,14 +2698,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            description "The list of supported transceiver's modes.";
            leaf mode-id {
              type string {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 48]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
                length "1..255";
              }
              description "ID for the supported transceiver's mode.";
@@ -2730,6 +2738,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
                    "List of pointers to the organizational modes
                      supported by the transceiver's explicit mode.";
                }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 49]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
              }
            }
          }  // list supported-modes
@@ -2738,14 +2754,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
      grouping standard-mode {
        description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 49]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          "ITU-T G.698.2 standard mode that guarantees interoperability.
           It must be an string with the following format:
           B-DScW-ytz(v) where all these attributes are conformant
@@ -2786,22 +2794,21 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          multiple penalty types (.e.g, CD, PMD, PDL).";
 
        leaf penalty-value {
-         type union {
-           type decimal64 {
-             fraction-digits 2;
-             range "0..max";
-           }
-           type empty;
-         }
-         units "dB";
 
 
 
 Belotti, et al.          Expires 1 November 2024               [Page 50]
 
-Internet-Draft           Yang for Layer 0 Types               April 2024
+Internet-Draft            L0 Common YANG Types                April 2024
 
 
+         type union {
+           type decimal-2 {
+             range "0..max";
+           }
+           type empty;
+         }
+         units "dB";
          config false;
          mandatory true;
          description
@@ -2843,22 +2850,21 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        leaf max-diff-group-delay  {
          type decimal-2;
          units "ps";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 51]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          config false;
          description
            "Maximum Differential group delay of this mode for this
            lane";
        }
        leaf max-chromatic-dispersion {
-         type decimal64 {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 51]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
-           fraction-digits 2;
+         type decimal-2 {
            range "0..max";
          }
          units "ps/nm";
@@ -2868,6 +2874,7 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            on the receiver";
        }
        list cd-penalty {
+         key cd-index;
          config false;
          description
            "Optional penalty associated with a given accumulated
@@ -2875,10 +2882,19 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
            This list of pair cd and penalty values can be used to
            sample the function penalty = f(CD).";
+         leaf cd-index {
+           type decimal-2 {
+             range "0..max";
+           }
+           description
+             "The identifier of one entry of the cd-penalty list.
+
+             It may be equal to the cd-value attribute, when the
+             cd-value attribute is present.";
+         }
          leaf cd-value {
            type union {
-             type decimal64 {
-               fraction-digits 2;
+             type decimal-2 {
                range "0..max";
              }
              type empty;
@@ -2890,11 +2906,18 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
              "The Chromatic Dispersion (CD), when the value is known
              or an empty value when the value is not known.";
          }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 52]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          uses penalty-value;
        }
        leaf max-polarization-mode-dispersion {
-         type decimal64 {
-           fraction-digits 2;
+         type decimal-2 {
            range "0..max";
          }
          units "ps";
@@ -2906,16 +2929,9 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "ITU-T G.666 (02/2011): Characteristics of polarization
            mode dispersion compensators and of receivers that
            compensate for polarization mode dispersion";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 52]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
        }
        list pmd-penalty {
+         key pmd-index;
          config false;
          description
            "Optional penalty associated with a given accumulated
@@ -2923,10 +2939,19 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
            This list of pair pmd and penalty can be used to
            sample the function penalty = f(PMD).";
+         leaf pmd-index {
+           type decimal-2 {
+             range "0..max";
+           }
+           description
+             "The identifier of one entry of the pmd-penalty list.
+
+             It may be equal to the pmd-value attribute, when the
+             pmd-value attribute is present.";
+         }
          leaf pmd-value {
            type union {
-             type decimal64 {
-               fraction-digits 2;
+             type decimal-2 {
                range "0..max";
              }
              type empty;
@@ -2937,6 +2962,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            description
              "The Polarization Mode Dispersion (PMD), when the value
              is known or an empty value when the value is not known.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 53]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          }
          uses penalty-value;
        }
@@ -2949,6 +2982,7 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            dependent loss (PDL) on the receiver";
        }
        list pdl-penalty {
+         key pdl-index;
          config false;
          description
            "Optional penalty associated with a given accumulated
@@ -2956,20 +2990,22 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
            This list of pair pdl and penalty values can be used to
            sample the function PDL = f(penalty).";
+         leaf pdl-index {
+           type decimal-2 {
+             range "0..max";
+           }
+           description
+             "The identifier of one entry of the pdl-penalty list.
+
+             It may be equal to the pdl-value attribute, when the
+             pdl-value attribute is present.";
+         }
          leaf pdl-value {
            type power-loss-or-null;
            config false;
            mandatory true;
            description
              "Maximum acceptable accumulated polarization dependent
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 53]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
              loss.";
          }
          uses penalty-value;
@@ -2982,6 +3018,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          description
            "Modulation type the specific transceiver in the list
             can support";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 54]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
        }
        leaf min-OSNR {
          type snr;
@@ -3001,12 +3045,24 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            and min-OSNR";
        }
        list rx-channel-power-penalty {
+         key rx-channel-power-index;
          config false;
          description
            "Optional penalty associated with a received power
              lower than rx-ref-channel-power.
              This list of pair power and penalty can be used to
              sample the function penalty = f(rx-channel-power).";
+         leaf rx-channel-power-index {
+           type decimal-2 {
+             range "0..max";
+           }
+           description
+             "The identifier of one entry of the
+             rx-channel-power-penalty list.
+
+             It may be equal to the rx-channel-power-value attribute,
+             when the rx-channel-power-value attribute is present.";
+         }
          leaf rx-channel-power-value {
            type power-dbm-or-null;
            units "dBm";
@@ -3021,9 +3077,9 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024               [Page 54]
+Belotti, et al.          Expires 1 November 2024               [Page 55]
 
-Internet-Draft           Yang for Layer 0 Types               April 2024
+Internet-Draft            L0 Common YANG Types                April 2024
 
 
        leaf min-Q-factor {
@@ -3077,9 +3133,9 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024               [Page 55]
+Belotti, et al.          Expires 1 November 2024               [Page 56]
 
-Internet-Draft           Yang for Layer 0 Types               April 2024
+Internet-Draft            L0 Common YANG Types                April 2024
 
 
            In case of heterogeneous OTSi it is up to path computation
@@ -3133,9 +3189,9 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
 
-Belotti, et al.          Expires 1 November 2024               [Page 56]
+Belotti, et al.          Expires 1 November 2024               [Page 57]
 
-Internet-Draft           Yang for Layer 0 Types               April 2024
+Internet-Draft            L0 Common YANG Types                April 2024
 
 
            "The ratio of the peak transmitter power to the integrated
@@ -3160,9 +3216,7 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "OIF-400ZR-01.0: Implementation Agreement 400ZR";
        }
        leaf polarization-skew {
-         type decimal64 {
-           fraction-digits 2;
-         }
+         type decimal-2;
          units "ps";
          config false;
          description
@@ -3187,14 +3241,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "The list of the bit rate/line coding of the optical
            tributary signal supported by the transceiver.
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 57]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
            Reporting this list is optional when the standard or
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 58]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            organization mode supports only one bit rate/line coding.";
          reference
            "ITU-T G.698.2 section 7.1.2";
@@ -3242,15 +3297,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
          description "The maximum output power of this interface";
        }
        leaf rx-channel-power-min {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 58]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          type power-dbm;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 59]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          config false;
          description "The minimum input power of this interface";
        }
@@ -3298,15 +3353,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
        leaf tx-channel-power {
          type power-dbm-or-null;
          description
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 59]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
            "The current channel transmit power, when the value is
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 60]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
            known or an empty value when the value is not known.
 
            The empty value MUST NOT be used when this attribute is
@@ -3354,15 +3409,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
          This grouping SHOULD NOT be used to define a frequency slot,
          which SHOULD be defined using the n and m values instead.";
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 60]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
        leaf lower-frequency {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 61]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          type frequency-thz;
          mandatory true;
          description
@@ -3410,15 +3465,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
            "The estimate received GSNR for the computed path.";
        }
        leaf estimated-eol-gsnr {
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 61]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
          type snr;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 62]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
+
          config false;
          description
            "The estimate received GSNR for the computed path
@@ -3456,24 +3511,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    invoking and running NETCONF within a Secure Shell (SSH) session as
    an SSH subsystem.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 62]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    The objects in this YANG module are common data types and groupings.
    No object in this module can be read or written to.  These
    definitions can be imported and used by other Layer 0 specific
@@ -3485,6 +3522,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    defines the modules that import from this YANG module.  Therefore, it
    is important to manage access to resultant data nodes that are
    considered sensitive or vulnerable in some network environments.
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 63]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
 
    The security considerations spelled out in the YANG 1.1 specification
    [RFC7950] apply for this document as well.
@@ -3521,15 +3565,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
               <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
               rfc8776-update-10>.
 
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 63]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    [ITU-T_G.666]
               ITU-T Recommendation G.666, "Characteristics of
               polarization mode dispersion compensators and of receivers
@@ -3541,6 +3576,15 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
               dense wavelength division multiplexing applications with
               single channel optical interfaces", ITU-T G.698.2 ,
               November 2018.
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 64]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
 
    [ITU-T_G.709]
               ITU-T Recommendation G.709, "Interfaces for the optical
@@ -3577,15 +3621,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
               <https://www.rfc-editor.org/info/rfc6241>.
 
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 64]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    [RFC6242]  Wasserman, M., "Using the NETCONF Protocol over Secure
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
               <https://www.rfc-editor.org/info/rfc6242>.
@@ -3598,6 +3633,14 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
               <https://www.rfc-editor.org/info/rfc7950>.
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 65]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
@@ -3635,13 +3678,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
 
 7.2.  Informative References
 
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 65]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    [I-D.ietf-ccamp-dwdm-if-param-yang]
               Galimberti, G., Hiremagalur, D., Grammel, G., Manzotti,
               R., and D. Breuer, "A YANG model to manage the optical
@@ -3650,6 +3686,17 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
               ccamp-dwdm-if-param-yang-10, 23 October 2023,
               <https://datatracker.ietf.org/doc/html/draft-ietf-ccamp-
               dwdm-if-param-yang-10>.
+
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 66]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
 
    [ITU-T_G.694.1]
               ITU-T Recommendation G.694.1, "Spectral grids for WDM
@@ -3687,17 +3734,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
               DOI 10.17487/RFC7446, February 2015,
               <https://www.rfc-editor.org/info/rfc7446>.
 
-
-
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 66]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    [RFC7581]  Bernstein, G., Ed., Lee, Y., Ed., Li, D., Imajuku, W., and
               J. Han, "Routing and Wavelength Assignment Information
               Encoding for Wavelength Switched Optical Networks",
@@ -3710,6 +3746,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
               Wavelength Division Multiplexing (DWDM) Networks",
               RFC 7698, DOI 10.17487/RFC7698, November 2015,
               <https://www.rfc-editor.org/info/rfc7698>.
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 67]
+
+Internet-Draft            L0 Common YANG Types                April 2024
+
 
    [RFC9093]  Zheng, H., Lee, Y., Guo, A., Lopez, V., and D. King, "A
               YANG Data Model for Layer 0 Types", RFC 9093,
@@ -3745,15 +3788,6 @@ Contributors
    Email: ggalimbe@cisco.com
 
 
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 67]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    Enrico Griseri
    Nokia
    Email: Enrico.Griseri@nokia.com
@@ -3767,6 +3801,13 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    Bin Yeong Yoon
    ETRI
    Email: byyun@etri.re.kr
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 68]
+
+Internet-Draft            L0 Common YANG Types                April 2024
 
 
    Ricard Vilalta
@@ -3801,15 +3842,6 @@ Authors' Addresses
    Email: dieter.beller@nokia.com
 
 
-
-
-
-
-Belotti, et al.          Expires 1 November 2024               [Page 68]
-
-Internet-Draft           Yang for Layer 0 Types               April 2024
-
-
    Esther Le Rouzic
    Orange
    Email: esther.lerouzic@orange.com
@@ -3818,38 +3850,6 @@ Internet-Draft           Yang for Layer 0 Types               April 2024
    Aihua Guo
    Futurewei Technologies
    Email: aihuaguo.ietf@gmail.com
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/draft-ietf-ccamp-rfc9093-bis.txt
+++ b/draft-ietf-ccamp-rfc9093-bis.txt
@@ -6,17 +6,17 @@ CCAMP Working Group                                      S. Belotti, Ed.
 Internet-Draft                                                     Nokia
 Obsoletes: 9093 (if approved)                               I. Busi, Ed.
 Intended status: Standards Track                                  Huawei
-Expires: 5 September 2024                                 D. Beller, Ed.
+Expires: 1 November 2024                                  D. Beller, Ed.
                                                                    Nokia
                                                             E. Le Rouzic
                                                                   Orange
                                                                   A. Guo
                                                   Futurewei Technologies
-                                                            4 March 2024
+                                                           30 April 2024
 
 
                   A YANG Data Model for Layer 0 Types
-                    draft-ietf-ccamp-rfc9093-bis-09
+                  draft-ietf-ccamp-rfc9093-bis-latest
 
 Abstract
 
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 5 September 2024.
+   This Internet-Draft will expire on 1 November 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Belotti, et al.         Expires 5 September 2024                [Page 1]
+Belotti, et al.          Expires 1 November 2024                [Page 1]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -73,18 +73,18 @@ Table of Contents
      1.1.  Terminology and Notations . . . . . . . . . . . . . . . .   3
      1.2.  Prefix in Data Node Names . . . . . . . . . . . . . . . .   3
    2.  Layer 0 Types Module Contents . . . . . . . . . . . . . . . .   3
-     2.1.  WDM Label and Label Range . . . . . . . . . . . . . . . .   7
-   3.  YANG Tree for Layer 0 Types Groupings . . . . . . . . . . . .   9
+     2.1.  WDM Label and Label Range . . . . . . . . . . . . . . . .   8
+   3.  YANG Tree for Layer 0 Types Groupings . . . . . . . . . . . .  10
    4.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  15
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .  62
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  62
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  63
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  63
      7.1.  Normative References  . . . . . . . . . . . . . . . . . .  63
      7.2.  Informative References  . . . . . . . . . . . . . . . . .  65
-   Appendix A.  Changes from RFC 9093  . . . . . . . . . . . . . . .  66
-   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  66
-   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  66
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  67
+   Appendix A.  Changes from RFC 9093  . . . . . . . . . . . . . . .  67
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  67
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  67
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  68
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Belotti, et al.         Expires 5 September 2024                [Page 2]
+Belotti, et al.          Expires 1 November 2024                [Page 2]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
    This document adds new type definitions to the YANG modules and
@@ -165,9 +165,9 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
 
 
-Belotti, et al.         Expires 5 September 2024                [Page 3]
+Belotti, et al.          Expires 1 November 2024                [Page 3]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
       A base YANG identity for the grid type as defined in [RFC6205] and
@@ -221,9 +221,9 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
 
 
-Belotti, et al.         Expires 5 September 2024                [Page 4]
+Belotti, et al.          Expires 1 November 2024                [Page 4]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
    operational-mode:
@@ -277,9 +277,9 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
 
 
-Belotti, et al.         Expires 5 September 2024                [Page 5]
+Belotti, et al.          Expires 1 November 2024                [Page 5]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
    flexi-grid-label-range-info:
@@ -333,9 +333,9 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
 
 
-Belotti, et al.         Expires 5 September 2024                [Page 6]
+Belotti, et al.          Expires 1 November 2024                [Page 6]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
       a YANG grouping to define transponder operational mode supported
@@ -367,6 +367,33 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
       This list of triplet cd, pmd, penalty can be used to sample the
       function penalty = f(CD, PMD).
 
+   modulation-format:
+
+      TBD: add a description and informative reference to
+      [ITU-T_G.Sup39]
+
+   snr:
+
+      TBD: add a description and reference to [ITU-T_G.977.1]
+
+   psd:
+
+      TBD: add a description and reference to [ITU-T_G.9700]
+
+   pmd:
+
+      TBD: add a description and reference to [ITU-T_G.666]
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 7]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
 2.1.  WDM Label and Label Range
 
    As described in [RFC6205] and [RFC7699], the WDM label represents the
@@ -382,17 +409,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    unavailable to other frequency slots.
 
    The definition of the frequency slot depends on the WDM grid type:
-
-
-
-
-
-
-
-Belotti, et al.         Expires 5 September 2024                [Page 7]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
    *  In case of CWDM fixed-grid, defined in [ITU-T_G.694.2], the
       frequency slot is defined by a fixed CWDM channel spacing (cwdm-
@@ -425,6 +441,15 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    The WDM Label Range represents the frequency slots that are available
    for WDM LSPs to be set up over a given WDM Link.
 
+
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 8]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
    The WDM Label Range is defined by the label-restriction list, defined
    in [I-D.ietf-teas-rfc8776-update], which, for WDM, should be
    augmented using the l0-label-range-info grouping (for WSON only
@@ -441,14 +466,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    In case of DWDM flexible grid, each entry in the label-restriction
    list represents also the range of the supported slot width values
    based on the following attributes, defined in [RFC7699]:
-
-
-
-
-Belotti, et al.         Expires 5 September 2024                [Page 8]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
    *  slot-width-granularity, which represents the minimum space between
       slot widths;
@@ -481,6 +498,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    *  For CWDM and DWDM fixed grids, it describes the channel spacing,
       as defined in [RFC6205];
 
+
+
+
+Belotti, et al.          Expires 1 November 2024                [Page 9]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
    *  For DWDM flexible grids, it describes the nominal central
       frequency granularity (e.g., 6,25 GHz) as well as the multiplier
       for the supported values of n, as defined in [RFC7699].
@@ -498,14 +523,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
           +--:(flexi-grid)
              +-- flexi-n?   l0-types:flexi-n
      grouping wdm-label-step:
-
-
-
-Belotti, et al.         Expires 5 September 2024                [Page 9]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        +-- (l0-grid-type)?
           +--:(fixed-dwdm)
           |  +-- wson-dwdm-channel-spacing?    identityref
@@ -537,6 +554,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
                 +--:(multi)
                    +-- frequency-slots
                       +-- frequency-slot* [flexi-n]
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 10]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
                          +-- flexi-n?   l0-types:flexi-n
                          +-- flexi-m?   l0-types:flexi-m
      grouping wdm-label-range-info:
@@ -554,14 +579,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              +-- cwdm-n?   l0-types:cwdm-n
      grouping wson-label-hop:
        +-- (grid-type)?
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 10]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
           +--:(dwdm)
           |  +-- (single-or-super-channel)?
           |     +--:(single)
@@ -593,6 +610,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
           |  x-- subcarrier-flexi-n* [flexi-n]
           |     +-- flexi-n?   l0-types:flexi-n
           |     +-- flexi-m?   l0-types:flexi-m
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 11]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
           +--:(multi)
              +-- frequency-slots
                 +-- frequency-slot* [flexi-n]
@@ -610,14 +635,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        +-- flexi-ncfg?                   identityref
        +-- flexi-n-step?                 uint8
      grouping transceiver-mode:
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 11]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        +-- (mode)
           +--:(G.698.2)
           |  +--ro standard-mode?            standard-mode
@@ -649,6 +666,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
                 +--ro max-central-frequency?    frequency-thz
                 +--ro transceiver-tunability?   frequency-ghz
                 +--ro tx-channel-power-min?     power-dbm
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 12]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
                 +--ro tx-channel-power-max?     power-dbm
                 +--ro rx-channel-power-min?     power-dbm
                 +--ro rx-channel-power-max?     power-dbm
@@ -666,14 +691,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
                 |  +--ro max-central-frequency?    frequency-thz
                 |  +--ro transceiver-tunability?   frequency-ghz
                 |  +--ro tx-channel-power-min?     power-dbm
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 12]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
                 |  +--ro tx-channel-power-max?     power-dbm
                 |  +--ro rx-channel-power-min?     power-dbm
                 |  +--ro rx-channel-power-max?     power-dbm
@@ -705,6 +722,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
                       +--ro compatible-modes
                          +--ro supported-application-codes*
                          |       -> ../../../../supported-mode/mode-id
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 13]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
                          +--ro supported-organizational-modes*
                                  -> ../../../../supported-mode/mode-id
      grouping standard-mode:
@@ -722,14 +747,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        +--ro cd-penalty* []
        |  +--ro cd-value         union
        |  +--ro penalty-value    union
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 13]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        +--ro max-polarization-mode-dispersion?   decimal64
        +--ro pmd-penalty* []
        |  +--ro pmd-value        union
@@ -761,6 +778,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        +-- min-central-frequency?    frequency-thz
        +-- max-central-frequency?    frequency-thz
        +-- transceiver-tunability?   frequency-ghz
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 14]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
      grouping common-all-modes:
        +-- min-central-frequency?    frequency-thz
        +-- max-central-frequency?    frequency-thz
@@ -778,14 +803,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
      grouping common-transceiver-configured-param:
        +-- line-coding-bitrate?   identityref
        +-- tx-channel-power?      power-dbm-or-null
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 14]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
      grouping common-transceiver-readonly-param:
        +--ro rx-channel-power?   power-dbm-or-null
        +--ro rx-total-power?     power-dbm-or-null
@@ -817,6 +834,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        "WG Web:  <https://datatracker.ietf.org/wg/ccamp/>
         WG List: <mailto:ccamp@ietf.org>
 
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 15]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
         Editor:  Dieter Beller
                  <mailto:Dieter.Beller@nokia.com>
 
@@ -834,13 +859,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
         Fixed Optical Networks (e.g., CWDM (Coarse Wavelength
         Division Multiplexing) and DWDM (Dense Wavelength Division
         Multiplexing)) and flexi-grid optical networks.
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 15]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
         Copyright (c) 2024 IETF Trust and the persons identified
         as authors of the code.  All rights reserved.
@@ -866,12 +884,19 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
    // replace the revision date with the module publication date
    // the format is (year-month-day)
-     revision 2024-03-04 {
+     revision 2024-04-30 {
        description
          "To be updated";
        reference
          "RFC XXXX: A YANG Data Model for Layer 0 Types";
      }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 16]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
 
      revision 2021-08-13 {
        description
@@ -890,13 +915,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
          (LSC), Label Switching Routers,
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 16]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
           ITU-T G.694.2 (12/2003): Spectral grids for WDM applications:
           CWDM wavelength grid";
@@ -928,6 +946,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
        identity flexi-grid-dwdm {
          base l0-grid-type;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 17]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          description
            "Flexi-grid";
          reference
@@ -946,14 +972,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
           Label Switching Routers,
 
           ITU-T G.694.2 (12/2003): Spectral grids for WDM applications:
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 17]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
           CWDM wavelength grid";
      }
 
@@ -984,6 +1002,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          base dwdm-ch-spc-type;
          description
            "100 GHz channel spacing";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 18]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          reference
            "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
            Label Switching Routers,
@@ -1002,14 +1028,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
            ITU-T G.694.1 (10/2020): Spectral grids for WDM applications:
            DWDM frequency grid";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 18]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        }
 
        identity dwdm-25ghz {
@@ -1040,6 +1058,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        status deprecated;
        description
          "Flexi-grid channel-spacing type";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 19]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
      }
 
        identity flexi-ch-spc-6p25ghz {
@@ -1058,14 +1084,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          Switch Capable (LSC) Label Switching Routers,
 
          ITU-T G.694.1 (10/2020): Spectral grids for WDM applications:
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 19]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          DWDM frequency grid";
      }
 
@@ -1096,6 +1114,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          base flexi-slot-width-granularity;
          description
            "12.5 GHz slot width granularity";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 20]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          reference
            "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
            Switch Capable (LSC) Label Switching Routers,
@@ -1113,14 +1139,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          description
            "DPSK (Differential Phase Shift Keying) modulation";
        }
-
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 20]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
        identity QPSK {
          base modulation;
@@ -1152,6 +1170,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          base modulation;
          description
            "QAM16 (16 symbols Quadrature Amplitude Modulation)";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 21]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        }
 
        identity DP-QAM16 {
@@ -1170,14 +1196,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        identity DP-QAM32 {
          base modulation;
          description
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 21]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
            "DP-QAM32 (32 symbols Dual Polarization Quadrature Amplitude
            Modulation)";
        }
@@ -1208,6 +1226,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          reference
            "ITU-T G.975 v2.0 (10/2000): Forward error correction for
            submarine systems.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 22]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        }
 
        identity super-fec {
@@ -1226,14 +1252,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        }
 
        identity sc-fec {
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 22]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          base fec-type;
          description
            "Staircase Forward Error Correction (SC-FEC).";
@@ -1264,6 +1282,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
            More details are provided in clause 15/G.709.3 where it is
            called DSH instead of concatenated FEC.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 23]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          reference
            "Annex A of ITU-T G.709.2 v1.1 (09/2020):OTU4 long-reach
            interface;
@@ -1282,13 +1308,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        reference
          "Section 7.1.2 of ITU-T G.698.2 v3.0 (11/2018).";
      }
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 23]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
        identity line-coding-NRZ-2p5G {
          base line-coding;
@@ -1319,6 +1338,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
        identity line-coding-NRZ-OTU2 {
          base line-coding;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 24]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          description
            "The non return to zero (NRZ) bit rate/line coding used by
            the Optical channel Transport Unit order 2 (OTU2) optical
@@ -1337,14 +1364,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          reference
            "Section 3.2.1 of ITU-T G.698.2 v3.0 (11/2018).";
        }
-
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 24]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
        identity line-coding-FOIC1.4-SC {
          base line-coding;
@@ -1376,6 +1395,13 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            Optical Networks";
        }
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 25]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        identity random-wavelength-assignment {
          base wavelength-assignment;
          description
@@ -1394,14 +1420,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            link along the route (in multi-fiber networks)";
          reference
            "RFC 7689: Signaling Extensions for Wavelength Switched
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 25]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
            Optical Networks";
        }
 
@@ -1432,6 +1450,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          base otu-type;
          description
            "OTU1 (2.66 Gb/s)";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 26]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          reference
            "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
            Transport Network (OTN)";
@@ -1450,14 +1476,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          base otu-type;
          description
            "OTU3 (43.01 Gb/s)";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 26]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          reference
            "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
            Transport Network (OTN)";
@@ -1488,6 +1506,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
      }
 
        identity power-spectral-density {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 27]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          base type-power-mode;
          description
            "all elements must use power spectral density (W/Hz)";
@@ -1498,30 +1524,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          description
            "all elements must use power (dBm)";
        }
-
-     identity operational-mode {
-       description
-         "Base identity to be used when defining organization/vendor
-         specific modes.
-
-         The format of the derived identities has to be defined by the
-         organization which is responsible for defining the
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 27]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
-         corresponding optical interface specification.";
-       reference
-         "Section 2.5.2 of RFC YYYY: A YANG Data Model for Optical
-         Impairment-aware Topology.";
-     }
-   // RFC Ed.: replace YYYY with actual RFC number and remove
-   // this note after draft-ietf-ccamp-optical-impairment-topology-yang
-   // is published as an RFC
 
    /*
     * Typedefs
@@ -1560,15 +1562,16 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
           transmission over the CWDM grid, and where 'channel spacing'
           is defined by the cwdm-ch-spc-type.";
        reference
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 28]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 28]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
           ITU-T G.694.2 (12/2003): Spectral grids for WDM applications:
           CWDM wavelength grid";
@@ -1615,17 +1618,17 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
      typedef standard-mode {
        type string;
        description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 29]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          "Identifies an ITU-T G.698.2 standard application code.
 
          It MUST be a string with a format that follows the
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 29]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          nomenclature defined in section 5.3 of ITU-T G.698.2.";
        reference
          "ITU-T G.698.2 (11/2018)";
@@ -1645,13 +1648,11 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    // is published as an RFC
 
      typedef operational-mode {
-       type identityref {
-         base operational-mode;
-       }
+       type string;
        description
          "Identifies an organization (e.g., vendor) specific mode.
 
-         The format of these identities has to be defined by the
+         The format of the string has to be defined by the
          organization which is responsible for defining the
          corresponding optical interface specification.";
        reference
@@ -1673,15 +1674,15 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
      typedef frequency-ghz {
        type decimal64 {
-         fraction-digits 6;
 
 
 
-Belotti, et al.         Expires 5 September 2024               [Page 30]
+Belotti, et al.          Expires 1 November 2024               [Page 30]
 
-Internet-Draft           Yang for Layer 0 Types               March 2024
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
+         fraction-digits 6;
        }
        units "GHz";
        description
@@ -1696,6 +1697,10 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        description
          "(Optical) Signal to Noise Ratio measured over 0.1 nm
          resolution bandwidth";
+       reference
+         "ITU-T G.977.1 (02/2021): Transverse compatible dense
+         wavelength division multiplexing applications for repeatered
+         optical fibre submarine cable systems";
      }
 
      typedef snr-or-null {
@@ -1725,19 +1730,19 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          enum G.655 {
            description "G.655 Non-Zero Dispersion Shifted Fiber";
          }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 31]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          enum G.656 {
            description
              "G.656 Non-Zero Dispersion for Wideband Optical Transport";
          }
          enum G.657 {
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 31]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
            description
              "G.657 Bend-Insensitive Fiber";
          }
@@ -1781,19 +1786,19 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        description
          "The gain in dB, when it is known or an empty
          value when the power gain/loss is not known.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 32]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
      }
 
      typedef power-loss {
        type decimal-2 {
          range "0..max";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 32]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        }
        units "dB";
        description
@@ -1837,19 +1842,19 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
      typedef power-dbm-or-null {
        type union {
          type power-dbm;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 33]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          type empty;
        }
        description
          "The power in dBm, when it is known or an empty value when the
          power is not known.";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 33]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
      }
 
      typedef decimal-5 {
@@ -1879,6 +1884,9 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          "The power spectral density (PSD).
 
          Typical value : 3.9 E-14, resolution 0.1nW/MHz.";
+       reference
+         "ITU-T G.9700 (07/2019): Fast access to subscriber terminals
+         (G.fast) - Power spectral density specification";
      }
 
      typedef psd-or-null {
@@ -1891,6 +1899,13 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          empty value when the PSD is not known.";
      }
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 34]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
    /*
     * Groupings
     */
@@ -1898,14 +1913,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
      grouping wdm-label-start-end {
        description
          "The WDM label-start or label-end used to specify DWDM and
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 34]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
           CWDM label range.";
 
        choice grid-type {
@@ -1947,6 +1954,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            uses l0-types:flexi-grid-label-start-end;
          }
        }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 35]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers";
@@ -1954,14 +1969,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
      grouping wdm-label-step {
        description
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 35]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          "Label step information for fixed & flexi-DWDM or CWDM grid";
        choice l0-grid-type {
          description
@@ -2003,6 +2010,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            }
          }
          case flexi-grid {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 36]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            uses flexi-grid-label-step;
          }
        }
@@ -2010,14 +2025,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
           ITU-T G.694.2 (12/2003): Spectral grids for WDM applications:
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 36]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
           CWDM wavelength grid,
           RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-Grid
           Dense Wavelength Division Multiplexing (DWDM) Networks";
@@ -2059,6 +2066,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          }
          case cwdm {
            leaf cwdm-n {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 37]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
              type l0-types:cwdm-n;
              description
                "The given value 'N' is used to determine the nominal
@@ -2066,14 +2081,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              reference
                "RFC 6205: Generalized Labels for Lambda-Switch-Capable
                 (LSC) Label Switching Routers";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 37]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
            }
          }
          case flexi-grid {
@@ -2115,6 +2122,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              range "1..max";
            }
            default "1";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 38]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            description
              "A multiplier of the slot width granularity, indicating
               the minimum slot width supported by an optical port.
@@ -2122,14 +2137,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               Minimum slot width is calculated by:
                 Minimum slot width (GHz) =
                   min-slot-width-factor * slot-width-granularity.";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 38]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
            reference
              "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
               Grid Dense Wavelength Division Multiplexing (DWDM)
@@ -2171,6 +2178,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          description
            "Label for DWDM or CWDM grid";
          case dwdm {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 39]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            leaf dwdm-n {
              when "derived-from-or-self(../../../grid-type,
                    \"wson-grid-dwdm\")" {
@@ -2178,14 +2193,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
                  "Valid only when grid type is DWDM.";
              }
              type l0-types:dwdm-n;
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 39]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
              description
                "The central frequency of DWDM.";
              reference
@@ -2227,6 +2234,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              case single {
                leaf dwdm-n {
                  type l0-types:dwdm-n;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 40]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
                  description
                    "The given value 'N' is used to determine the
                     nominal central frequency.";
@@ -2234,14 +2249,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              }
              case super {
                leaf-list subcarrier-dwdm-n {
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 40]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
                  type l0-types:dwdm-n;
                  description
                    "The given values 'N' are used to determine the
@@ -2283,6 +2290,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        }
        leaf priority {
          type uint8;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 41]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          description
            "Priority in Interface Switching Capability Descriptor
             (ISCD).";
@@ -2290,14 +2305,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            "RFC 4203: OSPF Extensions in Support of Generalized
             Multi-Protocol Label Switching (GMPLS)";
        }
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 41]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers";
@@ -2339,6 +2346,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              }
              description
                "Label-step is the channel spacing (nm), i.e., 20 nm
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 42]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
                 for CWDM, which is the only value defined for CWDM.";
              reference
                "RFC 6205: Generalized Labels for Lambda-Switch-Capable
@@ -2346,14 +2361,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            }
          }
        }
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 42]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        reference
          "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
           Label Switching Routers,
@@ -2395,6 +2402,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          description
            "The given value 'M' is used to determine the slot width.";
        }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 43]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        reference
          "RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
          Switch Capable (LSC) Label Switching Routers";
@@ -2402,14 +2417,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
      grouping flexi-grid-label-hop {
        description
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 43]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          "Generic label-hop information for flexi-grid";
        choice single-or-super-channel {
          description
@@ -2451,6 +2458,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          Dense Wavelength Division Multiplexing (DWDM) Networks";
      }
 
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 44]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
      grouping flexi-grid-label-range-info {
        description
          "Flexi-grid-specific label range related information";
@@ -2458,14 +2473,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        container flexi-grid {
          description
            "flexi-grid definition";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 44]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          leaf slot-width-granularity {
            type identityref {
              base flexi-slot-width-granularity;
@@ -2507,6 +2514,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            }
            description
              "A multiplier of the slot width granularity, indicating
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 45]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
               the maximum slot width supported by an optical port.
 
               Maximum slot width is calculated by:
@@ -2514,14 +2529,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
                   max-slot-width-factor * slot-width-granularity
 
               If specified, maximum slot width must be greater than or
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 45]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
               equal to minimum slot width.  If not specified, maximum
               slot width is equal to minimum slot width.";
            reference
@@ -2563,6 +2570,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        leaf flexi-n-step {
          type uint8;
          description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 46]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            "This attribute defines the multiplier for the supported
             values of 'N'.
 
@@ -2570,14 +2585,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
             granularity of 6.25 GHz, the granularity of the supported
             values of the nominal central frequency could be 12.5 GHz.
             In this case, the values of flexi-n should be even and this
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 46]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
             constraint is reported by setting the flexi-n-step to 2.
 
             This attribute is also known as central frequency
@@ -2619,6 +2626,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
              description
                "The set of attributes for an organizational mode";
              uses organizational-mode;
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 47]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
              uses common-standard-organizational-mode;
              uses common-all-modes;
            }  // container organizational-mode
@@ -2626,14 +2641,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          case explicit-mode {
            container explicit-mode {
              config false;
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 47]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
              description
                "The set of attributes for an explicit mode";
              // uses explicit-mode;
@@ -2675,6 +2682,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            description "The list of supported transceiver's modes.";
            leaf mode-id {
              type string {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 48]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
                length "1..255";
              }
              description "ID for the supported transceiver's mode.";
@@ -2682,14 +2697,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            uses transceiver-mode {
              augment "mode/explicit-mode/explicit-mode/"
                    + "compatible-modes" {
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 48]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
                description
                  "Augments the compatible modes with the proper
                  leafrefs.";
@@ -2731,6 +2738,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
      grouping standard-mode {
        description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 49]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          "ITU-T G.698.2 standard mode that guarantees interoperability.
           It must be an string with the following format:
           B-DScW-ytz(v) where all these attributes are conformant
@@ -2738,14 +2753,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
        leaf standard-mode {
          type standard-mode;
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 49]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          config false;
          description
            "G.698.2 standard mode";
@@ -2787,6 +2794,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            type empty;
          }
          units "dB";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 50]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          config false;
          mandatory true;
          description
@@ -2794,14 +2809,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            impairment at the receiver, when the value is known or an
            empty value when the value is not known.";
        }
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 50]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
      }
 
      grouping explicit-mode {
@@ -2843,6 +2850,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        }
        leaf max-chromatic-dispersion {
          type decimal64 {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 51]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            fraction-digits 2;
            range "0..max";
          }
@@ -2850,14 +2865,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          config false;
          description
            "Maximum acceptable accumulated chromatic dispersion (CD)
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 51]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
            on the receiver";
        }
        list cd-penalty {
@@ -2895,6 +2902,18 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          description
            "Maximum acceptable accumulated polarization mode
             dispersion (PMD) on the receiver";
+         reference
+           "ITU-T G.666 (02/2011): Characteristics of polarization
+           mode dispersion compensators and of receivers that
+           compensate for polarization mode dispersion";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 52]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        }
        list pmd-penalty {
          config false;
@@ -2906,14 +2925,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            sample the function penalty = f(PMD).";
          leaf pmd-value {
            type union {
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 52]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
              type decimal64 {
                fraction-digits 2;
                range "0..max";
@@ -2951,6 +2962,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            mandatory true;
            description
              "Maximum acceptable accumulated polarization dependent
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 53]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
              loss.";
          }
          uses penalty-value;
@@ -2962,14 +2981,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          config false;
          description
            "Modulation type the specific transceiver in the list
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 53]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
             can support";
        }
        leaf min-OSNR {
@@ -3007,6 +3018,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          }
          uses penalty-value;
        }
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 54]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        leaf min-Q-factor {
          type decimal-2;
          units "dB";
@@ -3018,14 +3037,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            fraction-digits 1;
          }
          units "Bd";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 54]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          config false;
          description
            "Baud-rate the specific transceiver in
@@ -3064,6 +3075,13 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            the interference due to spectrum overlap between them can be
            considered negligible.
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 55]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            In case of heterogeneous OTSi it is up to path computation
            engine to determine the minimum distance between the carrier
            frequency of the two adjacent OTSi.";
@@ -3074,14 +3092,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          }
          config false;
          description "Available FEC";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 55]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        }
        leaf fec-code-rate {
          type decimal64 {
@@ -3120,6 +3130,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          type snr;
          config false;
          description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 56]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            "The ratio of the peak transmitter power to the integrated
            power outside the transmitter spectral excursion.
 
@@ -3130,14 +3148,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            of 0.1nm @ 193.7 THz or 12.5 GHz";
          reference
            "OIF-400ZR-01.0: Implementation Agreement 400ZR";
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 56]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        }
        leaf tx-polarization-power-difference {
          type power-ratio;
@@ -3177,6 +3187,13 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            "The list of the bit rate/line coding of the optical
            tributary signal supported by the transceiver.
 
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 57]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            Reporting this list is optional when the standard or
            organization mode supports only one bit rate/line coding.";
          reference
@@ -3186,14 +3203,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
      grouping transmitter-tuning-range {
        description
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 57]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          "Transmitter tuning range (f_tx-min, f_tx-max)";
 
        leaf min-central-frequency {
@@ -3233,6 +3242,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          description "The maximum output power of this interface";
        }
        leaf rx-channel-power-min {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 58]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          type power-dbm;
          config false;
          description "The minimum input power of this interface";
@@ -3242,14 +3259,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
          config false;
          description "The maximum input power of this interface";
        }
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 58]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        leaf rx-total-power-max {
          type power-dbm;
          config false;
@@ -3289,6 +3298,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        leaf tx-channel-power {
          type power-dbm-or-null;
          description
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 59]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
            "The current channel transmit power, when the value is
            known or an empty value when the value is not known.
 
@@ -3298,14 +3315,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
      } // grouping for configured transceiver attributes out of mode
 
      grouping common-transceiver-readonly-param {
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 59]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
        description
          "The common read-only parameters of an optical transceiver,
          that supplement the configured mode.";
@@ -3345,6 +3354,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
          This grouping SHOULD NOT be used to define a frequency slot,
          which SHOULD be defined using the n and m values instead.";
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 60]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
        leaf lower-frequency {
          type frequency-thz;
          mandatory true;
@@ -3354,14 +3371,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        }
        leaf upper-frequency {
          type frequency-thz;
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 60]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          must '. > ../lower-frequency' {
            error-message
              "The upper frequency must be greater than the lower
@@ -3401,6 +3410,14 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
            "The estimate received GSNR for the computed path.";
        }
        leaf estimated-eol-gsnr {
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 61]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
          type snr;
          config false;
          description
@@ -3410,14 +3427,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
        leaf estimated-lowest-gsnr {
          type snr;
          config false;
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 61]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
          description
            "The estimate lowest received GSNR for the computed path
             among all possible wavelength channels along the same
@@ -3447,6 +3456,24 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    invoking and running NETCONF within a Secure Shell (SSH) session as
    an SSH subsystem.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 62]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
    The objects in this YANG module are common data types and groupings.
    No object in this module can be read or written to.  These
    definitions can be imported and used by other Layer 0 specific
@@ -3466,13 +3493,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
    For the following URI in the "IETF XML Registry" [RFC3688], IANA has
    updated the reference field to refer to this document:
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 62]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
 
       URI:  urn:ietf:params:xml:ns:yang:ietf-layer0-types
       Registrant Contact:  The IESG
@@ -3501,6 +3521,21 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
               rfc8776-update-10>.
 
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 63]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
+
+   [ITU-T_G.666]
+              ITU-T Recommendation G.666, "Characteristics of
+              polarization mode dispersion compensators and of receivers
+              that compensate for polarization mode dispersion", ITU-T
+              G.666 , February 2011.
+
    [ITU-T_G.698.2]
               ITU-T Recommendation G.698.2, "Amplified multichannel
               dense wavelength division multiplexing applications with
@@ -3510,6 +3545,17 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
    [ITU-T_G.709]
               ITU-T Recommendation G.709, "Interfaces for the optical
               transport network", ITU-T G.709 , March 2020.
+
+   [ITU-T_G.9700]
+              ITU-T Recommendation G.9700, "Fast access to subscriber
+              terminals (G.fast) - Power spectral density
+              specification", ITU-T G.9700 , July 2019.
+
+   [ITU-T_G.977.1]
+              ITU-T Recommendation G.977.1, "Transverse compatible dense
+              wavelength division multiplexing applications for
+              repeatered optical fibre submarine cable systems", ITU-T
+              G.977.1 , February 2021.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -3521,15 +3567,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               (GMPLS)", RFC 4203, DOI 10.17487/RFC4203, October 2005,
               <https://www.rfc-editor.org/info/rfc4203>.
 
-
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 63]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
    [RFC6205]  Otani, T., Ed. and D. Li, Ed., "Generalized Labels for
               Lambda-Switch-Capable (LSC) Label Switching Routers",
               RFC 6205, DOI 10.17487/RFC6205, March 2011,
@@ -3539,6 +3576,15 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               and A. Bierman, Ed., "Network Configuration Protocol
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
               <https://www.rfc-editor.org/info/rfc6241>.
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 64]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
 
    [RFC6242]  Wasserman, M., "Using the NETCONF Protocol over Secure
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
@@ -3577,15 +3623,6 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               Networks", RFC 8363, DOI 10.17487/RFC8363, May 2018,
               <https://www.rfc-editor.org/info/rfc8363>.
 
-
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 64]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
    [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
               Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
               <https://www.rfc-editor.org/info/rfc8446>.
@@ -3597,6 +3634,13 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               <https://www.rfc-editor.org/info/rfc8795>.
 
 7.2.  Informative References
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 65]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
 
    [I-D.ietf-ccamp-dwdm-if-param-yang]
               Galimberti, G., Hiremagalur, D., Grammel, G., Manzotti,
@@ -3617,6 +3661,11 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               applications: CWDM wavelength grid", ITU-T G.694.2 ,
               December 2003.
 
+   [ITU-T_G.Sup39]
+              ITU-T Supplement G.Sup39, "Optical system design and
+              engineering considerations", ITU-T G.Sup39 , February
+              2016.
+
    [ITU-T_G.Sup43]
               ITU-T Supplement G.Sup43, "Transport of IEEE 10GBASE-R in
               optical transport networks (OTN)", ITU-T G.Sup43 ,
@@ -3632,21 +3681,22 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
               RFC 6163, DOI 10.17487/RFC6163, April 2011,
               <https://www.rfc-editor.org/info/rfc6163>.
 
-
-
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 65]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
    [RFC7446]  Lee, Y., Ed., Bernstein, G., Ed., Li, D., and W. Imajuku,
               "Routing and Wavelength Assignment Information Model for
               Wavelength Switched Optical Networks", RFC 7446,
               DOI 10.17487/RFC7446, February 2015,
               <https://www.rfc-editor.org/info/rfc7446>.
+
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 66]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
+
 
    [RFC7581]  Bernstein, G., Ed., Lee, Y., Ed., Li, D., Imajuku, W., and
               J. Han, "Routing and Wavelength Assignment Information
@@ -3690,17 +3740,18 @@ Contributors
    Email: d.king@lancaster.ac.uk
 
 
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 66]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
    Gabriele Galimberti
    Cisco
    Email: ggalimbe@cisco.com
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 67]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
    Enrico Griseri
@@ -3745,18 +3796,18 @@ Authors' Addresses
    Email: italo.busi@huawei.com
 
 
-
-
-
-
-Belotti, et al.         Expires 5 September 2024               [Page 67]
-
-Internet-Draft           Yang for Layer 0 Types               March 2024
-
-
    Dieter Beller (editor)
    Nokia
    Email: dieter.beller@nokia.com
+
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 68]
+
+Internet-Draft           Yang for Layer 0 Types               April 2024
 
 
    Esther Le Rouzic
@@ -3805,4 +3856,9 @@ Internet-Draft           Yang for Layer 0 Types               March 2024
 
 
 
-Belotti, et al.         Expires 5 September 2024               [Page 68]
+
+
+
+
+
+Belotti, et al.          Expires 1 November 2024               [Page 69]

--- a/draft-ietf-ccamp-rfc9093-bis.xml
+++ b/draft-ietf-ccamp-rfc9093-bis.xml
@@ -15,7 +15,7 @@
 
 <rfc ipr="trust200902" docName="draft-ietf-ccamp-rfc9093-bis-latest" category="std" consensus="true" submissionType="IETF" obsoletes="9093" tocInclude="true" sortRefs="true" symRefs="true">
   <front>
-    <title abbrev="Yang for Layer 0 Types">A YANG Data Model for Layer 0 Types</title>
+    <title abbrev="L0 Common YANG Types">Common YANG Data Types for Layer 0 Networks</title>
 
     <author initials="S." surname="Belotti" fullname="Sergio Belotti" role="editor">
       <organization>Nokia</organization>
@@ -57,12 +57,11 @@
     <abstract>
 
 
-<t>This document defines a collection of common data types and groupings
-   in the YANG data modeling language.  These derived common types and
-   groupings are intended to be imported by modules that model Layer 0
-   optical Traffic Engineering (TE) configuration and state capabilities
-   such as Wavelength Switched Optical Networks (WSONs) and flexi-grid
-   Dense Wavelength Division Multiplexing (DWDM) networks.</t>
+<t>This document defines a collection of common data types, identities, and groupings
+in the YANG data modeling language. These derived common data types, identities,
+and groupings are intended to be imported by modules that model Layer 0
+configuration and state capabilities, such as Wavelength Switched Optical Networks (WSONs) and
+flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.</t>
 
 <t>This document obsoletes RFC 9093.</t>
 
@@ -667,22 +666,26 @@ module: ietf-layer0-types
     +--ro line-coding-bitrate?                identityref
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               decimal-2
-    +--ro max-chromatic-dispersion?           decimal64
-    +--ro cd-penalty* []
+    +--ro max-chromatic-dispersion?           decimal-2
+    +--ro cd-penalty* [cd-index]
+    |  +--ro cd-index?        decimal-2
     |  +--ro cd-value         union
     |  +--ro penalty-value    union
-    +--ro max-polarization-mode-dispersion?   decimal64
-    +--ro pmd-penalty* []
+    +--ro max-polarization-mode-dispersion?   decimal-2
+    +--ro pmd-penalty* [pmd-index]
+    |  +--ro pmd-index?       decimal-2
     |  +--ro pmd-value        union
     |  +--ro penalty-value    union
     +--ro max-polarization-dependant-loss     power-loss-or-null
-    +--ro pdl-penalty* []
+    +--ro pdl-penalty* [pdl-index]
+    |  +--ro pdl-index?       decimal-2
     |  +--ro pdl-value        power-loss-or-null
     |  +--ro penalty-value    union
     +--ro available-modulation-type?          identityref
     +--ro min-OSNR?                           snr
     +--ro rx-ref-channel-power?               power-dbm
-    +--ro rx-channel-power-penalty* []
+    +--ro rx-channel-power-penalty* [rx-channel-power-index]
+    |  +--ro rx-channel-power-index?   decimal-2
     |  +--ro rx-channel-power-value    power-dbm-or-null
     |  +--ro penalty-value             union
     +--ro min-Q-factor?                       decimal-2
@@ -695,7 +698,7 @@ module: ietf-layer0-types
     +--ro in-band-osnr?                       snr
     +--ro out-of-band-osnr?                   snr
     +--ro tx-polarization-power-difference?   power-ratio
-    +--ro polarization-skew?                  decimal64
+    +--ro polarization-skew?                  decimal-2
   grouping common-standard-organizational-mode:
     +--ro line-coding-bitrate*   identityref
   grouping transmitter-tuning-range:
@@ -1480,9 +1483,7 @@ module ietf-layer0-types {
   }    
 
   typedef snr {
-    type decimal64 {
-      fraction-digits 2;
-    }
+    type decimal-2;
     units "dB@0.1nm";
     description
       "(Optical) Signal to Noise Ratio measured over 0.1 nm
@@ -2426,8 +2427,7 @@ module ietf-layer0-types {
 
     leaf penalty-value {
       type union {
-        type decimal64 {
-          fraction-digits 2;
+        type decimal-2 {
           range "0..max";
         }
         type empty;
@@ -2480,8 +2480,7 @@ module ietf-layer0-types {
         lane";
     }
     leaf max-chromatic-dispersion {
-      type decimal64 {
-        fraction-digits 2;
+      type decimal-2 {
         range "0..max";
       }
       units "ps/nm";
@@ -2491,6 +2490,7 @@ module ietf-layer0-types {
         on the receiver";
     }
     list cd-penalty {
+      key cd-index;
       config false;
       description
         "Optional penalty associated with a given accumulated
@@ -2498,10 +2498,19 @@ module ietf-layer0-types {
 
         This list of pair cd and penalty values can be used to
         sample the function penalty = f(CD).";
+      leaf cd-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the cd-penalty list.
+              
+          It may be equal to the cd-value attribute, when the
+          cd-value attribute is present.";
+      }
       leaf cd-value {
         type union {
-          type decimal64 {
-            fraction-digits 2;
+          type decimal-2 {
             range "0..max";
           }
           type empty;
@@ -2516,8 +2525,7 @@ module ietf-layer0-types {
       uses penalty-value;
     }
     leaf max-polarization-mode-dispersion {
-      type decimal64 {
-        fraction-digits 2;
+      type decimal-2 {
         range "0..max";
       }
       units "ps";
@@ -2531,6 +2539,7 @@ module ietf-layer0-types {
         compensate for polarization mode dispersion";
     }
     list pmd-penalty {
+      key pmd-index;
       config false;
       description
         "Optional penalty associated with a given accumulated
@@ -2538,10 +2547,19 @@ module ietf-layer0-types {
 
         This list of pair pmd and penalty can be used to
         sample the function penalty = f(PMD).";
+      leaf pmd-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the pmd-penalty list.
+              
+          It may be equal to the pmd-value attribute, when the
+          pmd-value attribute is present.";
+      }
       leaf pmd-value {
         type union {
-          type decimal64 {
-            fraction-digits 2;
+          type decimal-2 {
             range "0..max";
           }
           type empty;
@@ -2564,6 +2582,7 @@ module ietf-layer0-types {
         dependent loss (PDL) on the receiver";
     }
     list pdl-penalty {
+      key pdl-index;
       config false;
       description
         "Optional penalty associated with a given accumulated 
@@ -2571,6 +2590,16 @@ module ietf-layer0-types {
 
         This list of pair pdl and penalty values can be used to
         sample the function PDL = f(penalty).";
+      leaf pdl-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the pdl-penalty list.
+              
+          It may be equal to the pdl-value attribute, when the
+          pdl-value attribute is present.";
+      }
       leaf pdl-value {
         type power-loss-or-null;
         config false;
@@ -2608,12 +2637,24 @@ module ietf-layer0-types {
         and min-OSNR";
     }
     list rx-channel-power-penalty {
+      key rx-channel-power-index;
       config false;
       description
         "Optional penalty associated with a received power
           lower than rx-ref-channel-power.
           This list of pair power and penalty can be used to
           sample the function penalty = f(rx-channel-power).";
+      leaf rx-channel-power-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the
+          rx-channel-power-penalty list.
+              
+          It may be equal to the rx-channel-power-value attribute,
+          when the rx-channel-power-value attribute is present.";
+      }
       leaf rx-channel-power-value {
         type power-dbm-or-null;
         units "dBm";
@@ -2744,9 +2785,7 @@ module ietf-layer0-types {
         "OIF-400ZR-01.0: Implementation Agreement 400ZR";
     }
     leaf polarization-skew {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type decimal-2;
       units "ps";
       config false;
       description
@@ -3627,418 +3666,424 @@ Names" registry <xref target="RFC7950"/>:</t>
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+19aXcUSZLgd97jP/io3y6pakWSKQkBYuoQElDaAUEj1VRX
-z8ybF8qMlGKIjMiNQ0dRzG/Z37K/bO3wM8Ij8pAEdC963YWU6W5ubm5uZm5u
-bhYEwf17o2wcp2e7oionwZP79+7fK+MyiXbFnvht7+iVOAjLULzJxlEiJlku
-XofXUS4G4uR6FhXYOjw9zaOLXfFbmJ75WoyzURpOAd44DydlEEcwzGgUTmdB
-Phk9HTzdCk7jIkjCMirK+/ey0yJLIvh9V+B39+8V1ek0Loo4S0uAtysOX5y8
-vH/vMss/nOVZNdsV+/t7b96JX+EDmIV4hR/CnADcWZZf74qiHN+/F8/yXVHm
-VVFuDgZPB5uId1GG6fg/wyRLAeo1YjqLd8W/ldloQxRZXubRpIDfrqf8yyib
-TqO0LP6D5lyV51m+e/+eEAH+Rwie4nGUn8WZeB4lWVnG/E2WA22Psg9xyH/n
-GRI3GsdllvMn0TSME8CUOvdPufNPKXbpw7CNUQ5LwFo8rwp7hJ+r8DKK5wwR
-Y8/+KfT86Zzae+EfwBrBCsIskihfchJj6ouTgL4dc3hRlOcwxutIvM+q3+MR
-fxensO4v+vWPafS3OTBY5AwWEZA+jESNf8qoiXe8vRgmLF5VmQXxZVVWeQRU
-ECfR6DzNkuwsRj6wRgix21mV9ZFtfzrDDxk8bpu0zOPTqvQxws9hNo3DVPzt
-PErPWlZJDvE7Njnn9p2rEqYx7MF/iR2Av6TxRZQXcXktsglsvXQUFmVUW5M+
-bo2fEvVlPxz1qw+NAV6FpzmMEMEvSTw9jXKHg/fjYpQ5YM/OuN1PI/zKv8pp
-Ho8y2JQxMHfLfpDQuGlfNu3gnIPzvLqA/2bj627CjrFhY+Fq0J7HqfgtykBy
-/JZlqQXwxcn7Qwfc6fV1lf4UwZr386j/IW+Aeh+Pwnws/jVOwqQMbdKdnOw7
-oHJq2b/glj+NynLUZ8ZzAP6WVYDX6yiyYB2H06JSHCDBXWO7JIr65VXHTP81
-HpUonbNZ9HvnSlxQw36CDe11uH8vzfJpWALDEcMfnvwSnPznq/7O0yf9zV0G
-IVXHD/yXEHvTWRJP4mgsplVSxqPzME2BicdRWkTiMrwAdkvPynMQGxcxynjV
-j1rPkugKZXo4AyAg0eH7QlzG0LyIccJCgctmADpMVOc4BSafhCO1ly1pradN
-yIv3EYv1MQEXci7cED6LkDwXEe4FsTkYPuEvkD8jwGCSKTBWP0WUx4OnLkkO
-NVKkJEFwKbRBMYVpMQOVI9KoRM22NNowmo30mzAfnQPGm4N2jGUXhe/Tx4/7
-QxfjtRPEC6VLhNpvBoOdAtFb165j0XDGeTSLALsceEFNfBKD6SBQw4d5nMIo
-IQ5QXIOQmhZrS1OB5mDT4WV0mldhfo2kGLaTQvczxBgMarR4CZJThCNYvkKU
-GeJcjED6A2PAlKZxGiaF6L3qT6DZugjEu+wSvipm0QgWl/kdRTR+ANuBybLK
-BAcDe37/q0pwbsOnXXPjLnqz7uzUZrZ/HubhCGYRF7AqBaqRWZbAgvzOw07B
-9IM1BtRzWmVkBZhOCDKiEGBCYYc8GkWkh4Cvw9I0iWjlu8AtTwSYQcsaDzvW
-mHqBIQgf+mXYdoP9j9XqneXxmHn414M3DmODNsKPJnn0v6soHV1T0xWmhKPb
-k3oLEpiFTtcW1t3sWWyuMot9/Mja0qtPwxGeB8AWUngOtrrn4QjP42q2veUT
-RiQkgd8OX7x4IYaDV8/3jl8E70Hgt8tS2JZvT47W584GxgTRhSa+kAisMBPd
-z5rJVk0RrL2VqLKcA9lQxGcp7SQgPohBgAvyE8zLIh5HOS/R0uhvPW3bJDud
-6GO/+/eCIBDhaVGiYMC/of3JeVwIOMtVNMY4mgCmsP8BT7D0R8QBsDDIEfDb
-GM+MeF5jCUEnNZgU62NYLdR+dLikhigSEpwzWKhnYG5HfRwuKlDX5LBTxwqs
-hkhwNFQRghZBpZ+OoS1I51P4c4pMAH+eXiP8KomkbKLB1BmV4CjWAQ6bgGwG
-S9SsQu/kxTouxSQ+q3gpaEJwdixRXc3C0ziJS3VqKCpQu2EhfjU76RjsldE5
-4KFW/Uiz5a/Hb4+KdYI3QaUZ4K4jOAekYi0oB0rFvrFVbA+Fz7pm9L53pfSB
-Wrx/uU9n6r5a4Wk8HicR/vUnNE9yIBMtpIRDC/Tx4z9Bv8dPHw0+fRIxLrh/
-yURVMO3pG+rvkg27bUjC8e/vo2kGf7zLs1E0hoOY2A+TBE7aan3TrNS6kgWX
-nKmYhikMSdOb5Rmc2DPQvor4yFtHlh2176DxTrYXvaMXJ/tvj16uyynubG4P
-P31izuOpq6nJpZ0hQyEBiingCfuHJNFpFSdlEDdYHvC6gO1biGmEVmpcTJlF
-gELM1CKjAzD3mOTZlBDX4Ohz/4rGcqkW2n5yBxGY5ihmD/J4PHu169o2MG43
-llp6uyFUd5OyfkF7DldO84vcZASnsdEmYCACIxS4jJcREBn+TbM0OHlhvupF
-/bP+hpidXxfa5ld8UduoZH7BDrOdUmqza+0Q85mDEOxBY5ZsYNVUJcpfpGpp
-k1/SSM0Ptz8evQmIGoRJII09gEUSz13CUVIhd3gkBUFqlRYfP/6IzDrc2YL9
-+PGjY7/AJ7hY7qebnz5t1GQMyxcaZ1kZI8d/DOedT58IQgMHP9OGYzA+0uiS
-aMNEjnljAwNpdaAktRIBRnjxuCi+aJO+hCWdVDltoXFUwrkVfXURM2IeWYdJ
-kjjkueOldEbClfn48Ro2ejACBgACyqNZUU2nqC8ld3z8iJv4LCrQV2lPsaHG
-mmuNTAk2p56oLZveGEGGbtYCbOpI7MHhLS6Bdas80uxIiKKcerK1vSkx+NOf
-xAkdPtBzdU2LfJSVLC8lhu+jCQqZTK3b9vaO5hL64NETZBt1Iv0QXdN5pmBx
-LudCkNR8mJmwcWmNjQCAn/FIhFxTI0oBqjIFMcFSKKtSaz6sWmg+JxIDIA8w
-y9qbX45P1jb4X3H0ln5//+Ivvxy+f3GAvx//vPf6tf7lnmxx/PPbX14fmN9M
-z/23b968ODrgzvCpcD66t/Zm77c1nt3a23cnh2+P9l6vNZcThZ80MfBEP8sj
-tDLC4p6cPpPt+f67//t/httyjpvD4VParrSAw8fb8MfleZTyaFkKpzj+E8h6
-fQ9ESxTmCAX1DBgZ6LVFvQgi5Ty7TAUwfdS/JzngXQ4ccoWtyVF/hMero3Aa
-KQ44rE1gg9xBtBlogdJsLIU8KySLlbPT/0IBqmX+jIaCCVbof+F9gk509Hrx
-d4BjkY3iEElCjhpoI22BHIT3LEvHmj20hSY3PbHAH2o+/POHs1m9P38wj8Pp
-K8LuySBg6cvf0W1DgmLZ/tztDmbRX+Hn/r2Pu+JPZXgayHkWbLF/v/ZO/Y1U
-8sxETmDtE84Awb0gvzhuRjxlvkuisECpNEvCUURjaeLQ6GlFRwugnVaprsph
-E825V8EbGaQJWDclCrc5VrpNRtyrUlc7CmuDqUVwbJL1JVglMqVwoJMkKKWG
-cgGFYWtlZVWsNdZiTYFEV3oYp2y7TcCiyS4VcQlSHlUFmRIei2RXzhwWHocn
-yOqzH8SeOEXaM8ONgSaorZW0I3RJH4VFU9DubA4esayUxy0pr3aePjUaYHQ5
-ngaj86CYjZYZeT8Lc7+FL8dydfA+6WDp7YSxwhHtv27MFYrj1VAkx8acISWy
-LQMzT6SjydnS41rsdJSRd03sQzt0Y7zUvpZXcNSv0LMEvXtH+y9frQt1MG4l
-jbt6PEyRZGVwGY/LcxhRgzTonjw/2EX7Bc8+JONn+hwYAmtK4SN6IKQzIY3q
-dTVCVCd6BzScfhIXJXvUJFxnErwjmN/hs0Be3d46cOMKClgqoTi5/WHQgrgL
-8mRlZcD+wNJLWeMsZIhBAM7bk182pDWuVJrHeDc27uOBYp8fxHGMy26+I+cP
-SIxxFuGxpRRwegR+KiNpKmSzKFcHBukDIWULaiGNNupofXCZtz4IG1R2m4so
-HWd5oFzMrkFtNLaijd55GzaQmqkgj9O4XdWeoVngmoRJgGbCHTBfAUe+JDxF
-uVOGeRnAxKxRABSpHWoh6MYX+LVVDBp79SxK4awpr5RByc7YdGVbR6lKwtSM
-/ZB/j2yL9QmYrMQEBIeYS2kjMtAYCOJoFsMCSfhosFqESr90lvabZDjPZl+A
-ADBqY9K1+UpQ3bNmOI35gcLm72kGAXkiLRVB7KvpSq47G0VludhEsAaRiNW8
-EGyutGtMom0dIho8qgPwPli6cUY6h7tubw62uKvNB/LQJKxzVFQ3ktA1CdsF
-m0/x3Ge+1hSUQGYgR6YYV1F4mKMoo9mChOOpYYeihR7G1DkMDujuPCjBesVQ
-nSePH+8E1QwdynUNSjj7dyzzqzXzuVzLKlpzLQKRjLvKnsXuXRxs8a6H/hIs
-AvHsXZvh4AAXj861cUxuPj4PskuC5gvSL7wI44QYMpWGzUgaNuoSKdZ+P1jN
-QjjHykK6+rb6QwSmPALoDNpYYRw61YXjCwz1UCb99PvhhpzMNApT6TXHb0Dj
-GKh1aNeCj6/WB2hXsc/R0zgYIo08X/x5SG5mNVArozVk4jI8pkhm8ZhYgs3a
-JaOCtJg+aJGMjbkuLSFbaGHza6hwbSFOxw5fWN400GDRcyOJg6eZNlHjRQaO
-uqd6/YzjETdJm9CoqRECY/NREaFELqOEDDmfvVI7FNe/3pCAM3WvUPdLiwK2
-BpxDMn2jTidkcZrBWZGcMIHv4ghPBeYiyJDKbJYViSRqrLosYbC7lyTwxecm
-RmM3rUqTFqtjcaoYTPzEMd9/bhpZm3xV6iCIJnEW2EJRC6vgN5+HDhREwBEt
-gX3Ja8ReWCdJJmfGxzjT37kklj4CQDeRzpM1VDHFGl6wRGNlN7Bj3cSH4QEc
-FbiMwaITpEJVOWBrZ7E6fsq7ov21NK7/iEmxbEbgZvlZmMroncaZr4MOHIiR
-joEG1pmR43/k4tH1fGOQAi9h+DSrV4T9lUF0hfZ8XC6OhXXwDEuO14V551FC
-PmpoaMcOxkDgOOfLoiSexiVeD8JyFXwNaK2qQoSmY+t+W/NXyVjdjRZgv6uz
-gLxR+lHrO46GJz9dPAnI2A/wTsqsAQ0N+ABnBGWVAnyWDR0kqB+YLBCCQbD8
-ksYez19dS2IHYMF4Wk1pt0zDK/pddtTm2oZ9U6sMKWPMyeak9WsrWeOqlRZW
-OrGdHWYtMq0g+4+loNZL2WBIir6preke7tWyY2HV2W65tRyNg9kU/g9iKiE3
-I3y2oFRBj3DJwwK90XbGKcvTJbK59NDImckhGpcyoTgDJk4xnLGaVrwT9g+I
-Bu/eHPTNRYLaOWrk0XhDAO4bGrL0QqkjD3D5LIkMI1QpH1dU8+/FpLd/sIGj
-rCtykIeK1iJgVbGQQ8mK47NcsHTP6YReffqk5GSaLwS4BRiFiGpgs2J8M2CD
-gYE1vRGsnZ0dBvWnP1Fc32vSvdiBf3vPjybu36sfJeuXHLXTNx1ZAJ60dKJZ
-HhUkFz1nPPviKmQsjt8JxFsyGn0EClb05MGSL4WBed6+ORZv9l+t6/tfEpRm
-4OIc70BPo9rlmNVODQXNFM44VMHj5xEc6gLAN6KGoD/PUbvQv0V0pm/X9upz
-iluVowy04OCbtIzPqqwqrO4sbEY6qvZ3DkJDZdJ2FOe7exqX7iHYEVUHCVPM
-RkpthR6Eq9Scz1Gz0X2u26zQhHZNNs+qjiPYtmOioyKsvjAjjv0O75aVRKUI
-UravsNVGO/U2FXu1UxwdYwyM4ao4f3UN1atfu3EUHXRDuHUqW3Gt2kmDtlTF
-F/f1bfGj3hY0y/+GH3WtlITT03EIYmy4/Xgo0qn4szgSV030pnCArXIGmE7X
-FZAayQ4WJtlwKZIdeElWvwbsJJml4G9IsglS6+nWcDDoDwYD8ern3xchGjTr
-phpa78Dmt0M4kid68y1FF3SgKcJs0D3JWG0YC+KZfVN5/OurDblSYKINN/uP
-kCg+1Nc3VHx9Jy4ueLwIteDv9Dfb4QuMZECXImwQtuU8C8saobGwx7/Cyr6B
-hYT5+BZvzvIjml1r7hdRNabZYDBIJMTCDixm111oRVBZZ0b6ksIRAW793uwi
-TCoTZ4h980Ybm+J4tLLRMLrM6GPSwt1aVJ5XySOrpbiK1gfdVcioI4w7rWYi
-w1NIXb+2jtzkd+lgiAqw7dhIQ2OvtpXmuOTkJthQaG5YtnFYkXJ1goU8Nz7G
-1u3pCwmKh2ITYV3F43W4RmogmvLBC9DnDqpBklYKLYsO/yU/gg57aQ7Gq/8i
-BNmA+1Tf9PrpbbNEFHNAsO3Fxz+aPndLoSlmjVs1sZ5xC9Cu6wEPdKO0EK6a
-Oj8uWd/VYTV8xawPY+5JVF5y09ogoSNDLYke0oYI2Sb4BQv+aAU6h3ysqxHE
-eCQsuS3n74h1E55kjpq1bVOTmt8Jf4SJ0iE1saDO3SjjIthK5WUEW9xgVTxj
-oNDODl2ZhPhqE04P6hlejI6XSYcqwsCHMcXXy/2pRzbNbUfNwtRWCIZXt42g
-dEPcFMH6HlVc1yITGzdI88Siibuz/P4b+k+8ALC+k/7OkBkyOI3LaTjTorw1
-csAJolaKolsAe28qVpXAbRCWFsBtgG4gf23CAXktQ2IFQgGA1WnU6LwCeRow
-VqSMmE+WBQ59GHpPOsYMQ+qAVABs2VIbkYXfZqtvJ3N6eGZGaEp7H+wFbWI2
-5XY2Nh+RlVlzWtrySPvJtViROgBEROpHXYcUYvgwPSUo8yhinwzboifofmhk
-RuFUJfyohu1eAD+K4wB2w/17HLi12wxgvnfP8kX6LkPJ8v5zEIieVsTrP0pz
-HD/f7bFxgAfCdfX5H9yFDonpj4LDc2i8Xf7MATDydB15uo6aXc0W0QAkujJc
-9EcbgPysbcrRzJqtHQC88IRpo8ujsRPqShNRIXJ5NJk7f4I0WhaSnxxXmhw0
-Iw9ADzyXjKMJD1z7mduPqNrsWcVp+cS/DHi3fBOek19xSocAT1nVDO/deNIG
-zB8GGLddd79psrD108LNFkwSAjWQclJFdToK8xzkA7NK+l0HyEU2SONntR3T
-m0szC0yNZg5q1tbzIWV2YVvXaXfXqdv1ivBBjJvoXLn0lkN/J/5N/vYfjR5i
-EfHR0WXq6TL1ENBlEPs7o3bI3i0abbzNWufk9ll0Wp5ebTPzbGIrJkLvZb2V
-vRIMW6hQSF59JSNsFBCGxc0tJ6EWifZneqPsOeX8qIYb7jhtfQcOt62Zui/I
-eL4Y61aaC4sEURcJTQHgw3QxUesVsncqXudLV3e3z5euq1Oy8dNBWl8Isp/9
-53J/U0HWInQXMlSWNlEWslDEAhaKC8jEjbTH99Z2+lzDzQLlCsJFIS0l2rzx
-omYN5m6Hlo2wvLZcSU96NOQyunEprbiUPvRrwrk6cDntt6zeuwlb/H+n+Pzx
-vPck1y157Fj+wLHCUcOOxqPwILON8c91hzdl+Fptz+aZGyjnjOp80+hnvbND
-1xzGLH7nn5ruRWsnXRJG1tGYZhOU57/Xe8EqLt/Lpk5ZpfKB2Y9Or7N6L5hX
-eaUXeIbJygJAmsnCf45Ppwv0Ca/m9clXGKfZZ6FxyqwMGz08fYhRPGGNTabx
-NGqITWxWexNnsVf9K293a5SAuWoCAh6htHzlg9LOqC2cqnu2s2sr55m+rUw7
-v28767byrpjPvl4e6einGaWzXzsbL9tv4fFa2LmFn50IyppyBnjO1w3l3MkE
-3nV0ui4nuOyuS0ovp+vigqW7W6tssbstIca6uy062qLCzO5msnTSMhdtWtSJ
-adfaVPu8ufM/3XNgu9+C+Yb/gEj6jwaryS/8ni6B+hYzPjW69eqMK1pUOv+s
-qthrvZdS77W+K22ZP260a/640cZZRfnP7TmHoVcxBOb2XGLMpfdRt2lQG6DD
-QNAtxQ3MBA+QFmPB10P5WeZYEc1BlrMlmv2XtSg8EJa0K5oQlrUuPBCW0PmL
-9G7X/M3ey9gbi/RecuyFbQ+h+nVYIMKC3WGH2M1WEq0OgFWkqw1gJQHrAFhW
-3nV3niPy7M5LS9ruzsuNvJy8tTt7rBffT90csTIZUxK/4ruWjkoaBj+Ifv+h
-/p9r2DyU1suCg3vkf+v46mfR8c2LI+eN3z0Lj7rpU7d4NAjfIz4L0LKa6Qbn
-Vo2SfBQUUICFjYzzBX5cpQDF7uq+FrO6evRWwwz1eKSgZ1tr+8dyvBkhM44n
-k4AwC8ZREl7XIYyjUTwF2m3W+o3O8wwfMI0Ckwz9x2a/nW2r30g/GwP7mw3v
-P6zvNMGETTWrTStlbcTsbO1E4BqCPsSsB21NzPBLB7VbwYwjlcK0DJKs4LR+
-LGPwT3Tsp1WS2CiOkw4U4UsHxRZQi+OrA2wD64Gb9il3cSKqvrfHR++7WLFI
-c6sHSF0A4Yrtem9X/raI+lb6NFrqeWu4C9LJw55m2n+xXdeeH99eMoQ+Datx
-4N3EPpbNsyQJssmki8y+fmSZyBsYO8LH/mlaCHVcVV645uh+psD2qNz882vH
-lsY5z6PiPEvaTuS+fjDJU1AlQQac1kYhlwmzqgRydvdye5S1HS1ZCeQpP3RE
-CPwZKSB7L9vdig/RpWcwe1ZaccjHx1pNzlGLLceglrvS1kfa2sOyjFW77I3A
-cncBdYqEiTRevkZkl7WolzOhl7OZlzOSl7GK60ti04fekZulaTFzfHdtdSrU
-T4EeTVmf3GJdrBk2T4tWl65pqvztYAt/lhl34ZJH4RgDs2uYtNBnWeJ0YoMX
-2BXBN09MDCm8uTm7Qjj0bqpJo4RwMCHTrTsVDijzGtq44+NqXEosHwIWs4X6
-GSiAILqCz2ET5Ge8w1gpNADMKF+m46FG90FRglTHw9KZq2Nc1WKaRVliN21r
-hrQoSt0S/lFPETGqG5gycCO7daw3pY23Yr3fmBzLjUqZFOONvVR4tyc99Ud8
-OUmQL2S9pWF/+Aw/pLTd9CZorcrTXey6S7xZ7F5Nk9202MVuu80sy9Rb5udW
-sRHPOOWArf/4yeYa1tf01dRkMJROZ1TKtr++Er9Gp7tC/PN5Wc6K3YcPMaEp
-Vo35EOX0QqYPIzy8PHtIaTEeqrJw0O91XJS74p+x4lyZ7dLXP6kOP8h8CEIm
-0oYBPCUpzY+Cwo36z2u1Jz3gfHU6m/C4Vf95vSCnB2C9JGcTGLXoP3dLb3og
-eSpHNoG11Iz8gRfJSh0hF8rO360eJ6kSE04OcDfXtxxe1zIxFXc4txJn/7CS
-bJaZU1lHiJf0NKRZzYJfZNAzkl4jGbbs6y1IsW6enfRay+RIAE6/eqGdRiWQ
-vl6L/Wx2ncdn56XojdaxBtc2VZ0VJ1hAVmdTxSMxPr3S3g2VyxVTQ1CdJl1x
-YqQSyiSC4GICoiLKL6KxGfR9BMdslvYq5UdVUNKaIqvyEaeoOY1TrEpB9SQ2
-KJmL7A3iBv8CIxyXTpfN2cCXvzNMJ1XiW5ZZlRcVHJlhnUyZHaxtQ4n+VWoN
-WEwiLBeCkAm06MULv6V/j+U19GyfHx/AZuYe+DYZcIOVALSPZa7K7f5I0cFQ
-8YHKPvg6OoM1eIccVtBLtveYmkkmv6H2BzIbserRU7KG6vlGkZEzEnGK5lo3
-lCWGVtJUlXNxioAUmGGVMt2oYgDPsJiI7K/S9MdlESUTEu0T0NgiIdSxStEo
-Kuzh7CoWD7B6xYMN/hdrUeDvqooF/k7FK/QvEoZsxxUszG+mvy5cgX/Walk8
-kEnSYMy93x5wDoEHqqLFg8UrWkgo9boWYrgtekgPrGqxzr9iTYt1b0kLQ8Nr
-sVhhizXSTQ8fCq6k0N/1VE4AFVQB7e3iCZQiZ5pdRNSXZghLE0lYCgS9+5Xl
-Yag2mqnEIJlhVp0qdzI1kOBIpYOtgMzSu4ZpwHEpBTNlHF5TsgMNFMVFMNgO
-tgasyz3iGAUy0ZtfjI5ZaguT4kc3U+y4UDFuBiPzCtn4DIPBk2C41YXPIb4D
-BIrKbdKNEVbhWRajh9/Br9+JQ7ZRuWDadw8ZV10DwI6M7sJWDaKfJnbji48L
-d8UrzO4aJpSPh3IjFBJhzOkScPWlYB8jI4ALVP/e6+P99Q2ZS4HboGx6D4IW
-KLWhN71wixmK3nDzIZYKXN8VixRg1FC8hRjtdbWoRfHcHKl5OZ4qegkurmCT
-8pn6xkNLING+euW5phs26Lg6JYmCBswClLwlUnbQspua4xtR8+BOqWkgLM6Z
-br1QoOfgIdYVXZqevlKnreS04ohvRs+XGtB8guJT3FaCogxnYK9QbMSpJLGB
-wVQUDud+XQTW5K0nwOqSlnYKLaeSy61LTXevt1NONviCspPotzlI64xZp+sc
-5iQItQfuX1aKqhZfQppq6tZzjXVxZ2udoS/GnV62XH1bt+7qJlcS3YaDwdn5
-7zW+rFN0Dl8OZa6tr4o1v6xCIgo+ujlpH32jrI+ym49uTFnOzvGNsnV5sDm7
-OW0xzeA36t5rGKgeJYUFYyvM8zLLI0q3+qxdeRnjtEOFtRnHcuydmW/vNNDT
-C9WGX9vSYwbIrqX3E0aX7evS3db0Vy7T163mb2TRr2jP3wovLqH1LYJ38YJe
-kUXXe5kl+Xa2qq+H/8HugrvBn8/uG6tL0l6etWi1LtIvquG6af+Nwa+tlPse
-dhZrtBJOXVarQ5daO3h3/C+1BTU957nNsG/vQAZ/kS/63TlCOD6PJ6X4l+ia
-Lv8MvHar6S83QIP69v5SheM8pPrrqyJx8C64CR6qe+8A7zneWfFuwiBn2q9M
-qr03T1ZF8Ql0Fr0norienmawTSyi7U2BRctqHHE4BEFb76bVDRBR3S1cuqhm
-sDMwFkITBhnurMxY1LkH/78teq2Oi+5vo7MYycTyNNvavAHNoHMP/n9bNFsd
-F93fRueu2Gxn+wYkg849+P9tkWx1XHR/G53bI5nRUNF8L+NzV6dhUUpOvqxT
-ur98sa9a915m+SUWyXqR55jsNMtzjmVYF3blZFVAcxzlMYZytKnFM4z2rhs6
-0ULH9leyImUbQqL3KgDE1/vd5o0yMZ4+fiQuNvsDaWUM0MpQoCMCPTKgUfEb
-GEV1OoU1SyNYyaKMpkW/nXE4pdLKkz7G7h1TPl5yymBVXQzR9T14DJMebi0+
-6fP47BxfBlHUPVtYy9AhzVYnwlGGHNlB49ENCFyGcU5p1TuIvL8IlffSNLoS
-exg5owj+ePAUaA0EB1t28FTasm9PftkWSYYR8ZSj24CgkJNJOIo66HgDMr6d
-RWnHLN/SJHUe9qqQeYUNhOdZEW2I/fOwGp9XeUxxJj9nI7Syz86jqeg93/95
-HZdqDqX2kxDDuYY7/e3+dp1eW7gr0fYfIr02kUFV5uO3J0cWNhYJNeFULCf/
-8Iq8uN0ROtbmBmy4n6Xov0qppBFQUPSY52r1JcNU0KlJGLY1QOYyMMXecX71
-FGaExTxM73FW4WOc6AqwwOqLxwcB4THcfLJBwU0/h9Mpx4ePo77pZ6snUgCA
-WcLKQMZK0hFxJNf80UO1CJcY4YRprOPCAsL1IMXB8c/QC4RKSDVfRjXyfL6t
-+Mw3U4Z/cOus2xxJbZVHd8vEJurIvC1Y3ITQpfk4GBSUhEAl8RCBCQmMCg1y
-kKmCwgGeGMPJRT0NVqa+mx5RRVA+7qP6sohB+VDExRZpciTG8ImS1J+QkrU9
-aj+eOHr/t2Bz9uhVPSDDNJmza08o7XoK+ILJliIdfo8wewsAXveTgaoDnl5b
-64MUU5SpUwR3TVEIACewNJKH6S1AmkRb/c3+jk2ip4+eot5/giRivf9kvUOM
-1UkEu2T4xUmkwqaV4/6ES6rmpfglBShZjrVVYT8gsusNVvMw24LEfAzErHHc
-Dck5HFgM98X5CrBZgq0e3y5b1U+gXylbbRJbbX69bPX25DVYUsHx/o3o2Um2
-JitZ5yGeusCnwNdUDQjYCrhcEddL1G07fg8V8TqHHy9mkAuyZwwEOsWG/CgD
-iTrJqtwz/usQrSgY7rXXmm9j++GCCmfeOr18e7g//OwLpZbHNrL0QqHV8FYc
-KsuA9DStz/6Q1wMMJCKatVo8jeHiC2b1lUt3p9Q3cay+54Fddo31fqaAXxgH
-XKF511VPnu6KY6IzkvUFGtH8hINuKgxUvv6AlVL968+BWm+L4rwogwmcvzsn
-JfnJ22YOZ+3JqrGmHJqBwvY8Py+IxlZoHT8AAgv+1z3Rs+a5p0ddF9OoPM8w
-KCCD82Nh+rYNZp4h8EtErHwVXS1yabXyKrStg28lQJiMs+mdLcOJpKZLNTyx
-aVqZ1hbRGK1kocu9z0KnJAoLTEgSwgnwc1GLNy37LSza4CHadDqXpY6SMD+L
-qB5eEY/RFYupIEfkZEnlKxj4lidgnaewdnOIpyp+QIPncaoKSJnAYYfiCxz1
-jm6hWILPsxr8wJmkyB1KECrK7AgOfOFUjKKUT4GoWjbEaXQWpyk/yAa9rWqk
-M315z7vloGd5dgbLxDXJMlIySHz0STqNrZ0BMkTWvaM3f9CXioi6daQ79LZ8
-6P1FCDaOliBYgwhdFKtT96YEM37JsrqFiwewA1tuFNoVsOUV2TWGjAlVaFqB
-cre0qVrPeVfNbp6HFXv24PS9I16dPpy3+y3ExcUOmf07Kt6hfR4GQGNCaNge
-dVxieU5ci08Mw+UHgOvXOrOtlWe2JXrbYE8Ov9aZ1S8dF5/ZNtrIw/6Tr3bR
-9tOV5wZde6m4gpPmIwry+1omaLyiMA2V5Qb97h2CkVoJELQYbMU3wdSFznSW
-YNa4vH1zTFI+xlrJSURPwtvEGaNQyACqYIzWhQnek3SvITuH/PhkWQ0Ldg8o
-FHRS8yzUQEIN1Pv14c+/d7CBSiDG3e8Krd74+dRFQr7Cxce542hiv8Et+SNZ
-30mhxNfdmPXwWftK4vGc65BzlrcHRw/wfoMWktzkmEgAT+2eip16Jlrn9q3b
-rJOuEp8b4sHkwYZb2tyKh2svPV+Lg25WobfD8/jGpganB3/34QP8+wQLisZs
-XfNuexCmcILJm1N7wPuM04QVnI7gQpb81s9G+QE9DashPKih/MBT0L3+IKB5
-sWAf3/9xnk8pxh19IcY1Zuw8zrUOZ61Max19gHu3Hw9FOl2EbdPpepNpZXfJ
-nKMsvUDxg5nuFI9aOBFzagh+Jt33MGmTOTWQJpPWn1d2M+lnf+R3h29PFZvK
-WP5/aAGLLwr+DqQqodnk0dpriw3MraNkrH5zY8ySxkOdOTz9JcL8P7MolnXX
-HB6vlmbyNx1MbmL8bW7es2P/W9nWavO9eAPsevzrQtyKzdq4xf9i4RsnOPnI
-HX7gIjAd/HCo0mqRH9i9ClFgbexUjI4CcFgKSrmECcrkaDJ3kMrkQ2FGkyxJ
-sks36gskIkwr4ZhUq957IS9HHvW3GtczHWvt4q5vcLwEa8mbvhzpYBONs/yh
-DUtYsGjeFOoWYiHDC3TG4fqo/phEDKYXJpgC89omgJoDz6ieeL+dAupma7P/
-iO9/kf1/g5+2LEK1c+jhdBbGOZ5xgvASHWQn2SxLsrNrE3PryxeFIyybL0qE
-E4w1G+fwb0C5FCk3YSCvGIPYoFJKJAJO6QhQMJEYpo8qzimBFjIuDFlb4Vo+
-/ZvsCmeFZU49Xvx141+c2rFr6t8Tk9BK5maTW4QuCig5VU3Qae6wx2RXZkz5
-7GYgIdh9CgtInWN5X6C6UpwttmM3r/RR6ggtjTLB7thQ39jJ0rV2IlaHl3QC
-bONfmOQhUS4Yx2foRnlqfAP4T5Xih2tge63NUdQ1+Q+iATptCOZAMuOGm4/I
-kvMbCHaC52WR3vEi/WoVpF85SA/xCaGNNG8YR5+l+bLobnrRHT//adAfptMu
-nHuSbdflTRnuy6MsLiLxHneI0CYLmbsADg57qjPssyyp5FV+OibTZL6Gevr4
-McWK4hlocwhGAbn/MCdcZFVnIS+X7mwdesYqYefUSrzpWBC0G2E/RaBzcnPD
-qETBJD6F3WhC7DmpqAy09xsYaa4yKLvmZmq9blTCNc2fOR9E05l+Vvrp863D
-BmVGFB/S7DKl0wXsa0JFWr74repfpdSs799GeO/q3EDxtEAmSR1jKIAfov5+
-ZN2GtPgU8d0JNTxWZtYx1cEmbfUSx1x7Juo/qvunxoDbiw64LfarMptM+B0j
-Bj3zWO2gt1pAM7wtcaALlywO81EnzEew8mnwN4y7WwX4zqK02PGOQ0Y5WHLI
-Ss07vq6BHy868GPxHAyI4BB2OLqy4UDWMquODcPiBJ3ZY4tH/RtYl/S4oVz1
-4bFnwZFbi6JsLuE4SUD820qjtLBk0T1Wki9z0ZQCA00p/h4MAxILwvhDPDLE
-7QDWiOiQJXzhcBbGqW8hAktq0J24WBv0+9NQRyjVtds8XUwD4a3/83noLLwI
-pstKq+BiJUnOLzUUrQ2RVa8asfnaBaE8pKJEi5KdGn8OsjOCYVmCYJDnwnlr
-YNdAWnANsMvKa9CC4moLstQqkMr0L8OzlehsStnMJzMNviSdqc8NCV3HcTU6
-21AWpPb4dLoYrTttZDMRwn46Z8QlCQw9bkhexmoOUV1iKigSwFxyKsI98pGz
-S4M+Wlk1TdAsWESFPlpahT5aieDz8WzXoQpI+4osrkSL8bKLMPQfZzF+YDG+
-b8YevDs+WG86fK5nZC3yVHbFVv+peBEMtzfsIwoeSX99+Obn3xfwZj59PNCP
-Np7iU7wQayOMRlFBDiQ4xHHa+Fyw4z5MdBh071V/Aq3XRSDe+efgeILaSL34
-Zi7GN9zGfiK3bWttfft4CTq2cpIMz3ilymzcN/EZuj4O3qAm6OfHKmZ5GYC1
-3hVmg3NAv4fVBZHkPyMuMkEXLEzya/aSmNoQ8mqT2lvhkPzt6DyLQeQ3cra3
-Bavw/QQVUKC6IP9TXp/QmPh8opk7mx5ZUOtaHmmBwdb1eBX+IVqvySDKAGMu
-kVWweENPV13VOG/YPfnn39fcZOD/vra+5o7Qeoaiaf5rmMRWDQSTph4XHudq
-vQSxWNBiUFWmZ5en57RuHXmpe+Ia0q2XwDVUPTFmNPRqt/U1JDovsWw8NME+
-OWwy8jHI6I4ZZHTbDLK/FIOM7opBFEvUkG8Gs/w9cYhV/sdaLroL0xS1MtfX
-5GyLC+Tzxq442tCrFaJZl0JgsNQK6+TgFZByLS0olKXU9xXraM1joxh8l+Qf
-V37aEFE56i8u6mnPyTA3N9fqcpv76xb9VhW/+sDdiX8b4NrlwGvDKSo4rB5c
-RjEQ6m6Eg3Tq5HrEn4rNR/wv8ArfoFA0DzKUZ8JftXjwKhBiiNHnY7svo1Dm
-sV1rYYQGuBuxXToFrov7EXDd5sC6R5E/EymPNszNM735x4mzSlO31qrl3xP7
-dWgnj1KKZl+FPjLcfHeRlGYMKja2tbMFM3nz7vWxeHv87mVw8sJ+QYil56oZ
-vVnIJlYMlYbRWjbQKRgoeii91v2PlD169zzrVLsqk5tpvJD2dcni0cIrnL1W
-O23J8fjLgi4EScBRrje1jz8uJgi4O+JA3ZUYcLcq4SJb1iRS68kPf+YeoDpx
-I/xucJDCn0UPUzXB+akxe7pH900+SOKiRB+LekhyI2JgpW/9hmTzZrQqiFgY
-VHNjahGzUhInM1FPf8k8Ddq2CntCe8k4yCYER3p1ZV9WP21rfdPD7Lfz4Gc+
-D4Lw/io07zyNRN46KobapZhq3j2YQ0IB7pZ6UoRUdKmDVxpJVorNvWTtto/9
-xvG/r9XKyNXt4rZIhj1TktgYxcjEjmFcA24xruYSvy615seBjjaV5Fbtrh+A
-P9129+L58B1pAviEoDUUjlaqfXs7tNHtDcxlWk0F1xk/BdMnAsKZiPmiD9YT
-DwD049OesyVfWXcH3h2hd8XjnadPdsXLPJxG9K4UQ1reg/yMc6mIcHeQkRfg
-G/qxM8w+sFqeJa6B127YOX3nG3kOSWkxUUNaqzAJR2WWN9aS3zi4yyiv7YfO
-tX3bmg0XWaM9FV6HsdwqeNdb82ADs8iQjqpVEqdEH2qpTdeCzWaO+cXwYhlh
-hB/a7yyIis3uMWbDSkYVyw/30UVLF3IziO8b2tVP7+9aNtWCHLfCucHl7U4e
-8/GV030uj4VXd8hj9DT4QV/88L0Aceul7wMXKuVGDqZRUYRndeX9JryqLyUN
-cIoSloI78ZUBXYfRC2+wJmpr3GS/fuvuuNt90JzKUvug2X3uPmh2ad0HXp5o
-2wc11A4n6h41Gm/45tmyZA4QtXy+BaMh8CKzOYwDw6VNF8S/7438yWuPoWNv
-2Qvb47dHi9/YmtYaTTdvzd25Cr5dyXaPTKvZPNgCW/5DuMa/3a2acfelC8xy
-XeKTiQqVDogk+OXvYrm/ppOskZw3dq6ijPz84lCO9M1b+lm8pUydO/eWfnOH
-fnOH/qO5Q78iqe/xL3aJ/kNL0Ien+HT9dXiNz/AaIYuaazyCv8sVx8mqrWCX
-Rb2EOuhFjf7JQmKWx5nrENTH+yfPuuG+U13hoGOSWBvy0iLECZXwkgCcQ13v
-8Hj/YF5lH1z47c0BnLPwhNV+vLLYwhqCjlDBuzwrs1GWNBigR2e39Rpdvgbu
-c05rKwdSeayNu4mW+hYn9S1O6ms5DH6Lk/oWJ/WPaKZ8gWRxWh21xyLPcyFa
-V5SLOhI1fvW+PiOqlseubnfLr+dYMjczuJsHRqcQXiEHPXWTN21xbQ3lR97g
-jPZ0gwIfm/6mSkPbiUxl6w7HF1FexoXcTQbE9Puh2oDTKEwLlXEqdyobeE56
-6UatZI/5ipzllEbc0y0YItnUFwaE1eTPQ6SwHry/kA32OTOVcSf17w3i/TSM
-24z3szakSWJDa9KxH1+a/VRbSAVXL0NbsKf7AsHagdPuHThddgcumHXv62Kb
-BYXnzUM0NcSadT/Xw+en/lzPXotXr84lLis2z6d+9xhwVVkVVlJLS/PWPWYN
-cY8/H6JrFWeSuuZDF+h56NfNqm5Yi5pUOB8QD2ZKithFbWWZTjWLxedUa7GN
-GzGbVliUM8/CnWi3W6oEbkwikGA2OLmLEjk3I1tqBKTBKqWf6lNt8RgS1O6V
-aV//OTGlC/LvHMJYy+qK1a7J1kH4J9/hj+yUeF+pqlrGoWaUVaBTCH6O+MBv
-kXZ3FWm3FFPavRcJrfMypg3kW2jdt9C6b6F130LrvoXWfQutu+XQOu+jyBWv
-bJpHO+uQzf7mNq/23MvDRokA3w2iY0zItjuzTdeeaD8LdYSuOJ7k9vACh9v1
-ijgXHDtUdcoxPNpLPN7g7C9WOf6796umisPSC6VLP8xdJmrZWKRvS+FdCmd3
-LnHdTeVOw5JrO6uLC6agpaXUXLSCsSYgI3FAYj04euBqmZeoRq/CKcikDekI
-C/lWSNYKaF0kC4h96oBB1NJsyBdHzpfzcexmjVFWJWPULHgkIAawgBymnHkc
-HREbJnMZgVUenOJcQYhotrKYsQUFzmkFjApLw5ndjcIuorJUSd2dVQWVs+kS
-trZq+EdSZDJLVlgsTM841T7gBVj9pk/Db3YCb1FTVJpmFAFzza+KR2TTPeOC
-suOnY/bGnkbGscHLIhdDdbeVGlZwsId+UKhKAKo1+pX0ChlpEF3hnVVccjm+
-4hwrzGERjeoMnTnR2M1Prar1iQj+E+XaIAs4IWqO5Q5IDMCSqSR87ghlBLsv
-LOVlCgK0LJUs33Ahqr5MSUWpbsAGHFX0zqj6xbhGCZPfnEAXlrvCRwNVrluB
-qM2U8cFhdmHXcE0EKWecbjZvjFTcDl4saR4AMZtd1kP5bTZCUzYdh2C9XgO4
-al7BwEO21yNCEZeM8GkyCm1ZXWnFttLw2416+QnYytRLZlG0F6IetKKqiNQd
-2k6xmGe1L2F5phlKG9nGHburC6wdr2iLX9wDye++ndOQmk5iMEtB0rn3/t2+
-XZCqtFvdreinr+umpGl2U2Il8s0joMDaCA8fdtPGT213/3rp3Nrk9ins8KlL
-W5geEcHBZika2XNqSJclglb2HY8/iiKu16JqIIEGd8nfOOsKHtM5fDd3vZqp
-v3vdQ15jgPoE21nFIahmEmyDMQmwTE0+kcrVbkNycJ62dSTqnWldZ5S62vVW
-3vn/WesiG0ldZhSsYsz65oBjblEz837FIfnzcoNyr2qFRuEVdC5osntoR1SY
-5SHclInbn3eGW+gmzgzrHVGq18IazO3WEHt0zYYfBm4UfYswdG7ehn6vN08l
-0ZeiCuNuPJU3lVHxhN3LGlIfa7ds0pJGL+rmo0cdEXYOhocHzUOdz6Bt8W2S
-dG4zvSVf8uZi4j50eLz211pTJv5ZrNVl3lKhiHs8uKrNqovrMO9q+1Lu5Xp3
-tbcbzzzs9y6KoeqF2hraR8WOMNDmt7ARQ1xA/YAP/ufy60MPf3oWGH/INeqA
-8lCX6OsO8W9yiO9HVQ5nv7K3/h/tPW1TsrEs+NP5ikfnfqbaZKgQKHKS1G+t
-4mDh6+0qWksZrD1rrGSDPt3vi9SNt8SNcm0jnyyA14Lq36ftG2j62MxjA/7j
-c5pn0rfKb54zwLIsd0cctxpmN2E7b1QGWZceDVooo9G1Pj2NuMlcA7JmZ3pL
-m7ZXQ2qULmVjCS2WsyqEIcsoYruTBL58wGOce4elvlOCc4tdz5SccVTFlO5E
-yAFk7sWeBwfHo1+D6/L33sW6rGQrjxCFY4iiIYQWBfZPzRlALjZPIo9GWBp1
-rKM+uBlHYfjooe0C38nea7+0vIjxUa/T6dZxWPeeALiIFtj8uV2hU1rjNgfb
-gAv7So8Lb9ao0lbtUxKm/vUqtOGmXIDOrh6LrhjGSQfyWJvJ1hemNmwhenuH
-6y1blsnj8/DPqVqrJutvtcqc55e2bT0Rz+WcWQQdyuuAA2I7eGZPHv6tyCTl
-v5cwZFCtPj7KgHTrrlxVStQ9KHhX9PpRH45X+wcb4t0b/M/B6/V+jbW8ePqr
-YLSXI8Gftspq/OOtO2UxgIZuF9Wwvm3UTGpZ6KWcmKgt3x4fvddkC4siG8Wh
-45pVkWoqxsD0N1VXhTwxgmQjid9Vag0Fr4GxXKGYFl7zurq8vGYEteNuUHME
-Ma0VqaNfNXn9VYBtvwdd0EhNWTiRpZaaMAMqILqOryFqEk9jmcHNdQ704HBK
-C0fRDMTbZv2viN/p84PXG+IvKiaDoPHzx3XLaX+YSv/tpOYLq4vv8ryu6BQI
-QJmQc5+2JGAo4DkJaBKcxkDNcqmXwqa3x+G8uIh7DjTDoR8mVAk145rJLF4U
-yXlOIeyZgiqT+m7ILJatmyLyRczj/rC/6RPr/slzmNSz2v5+BY0fAsQ5u7zj
-FUKOtdrUkD39ohIfuA3WW2duoNRIYE8EY32wRFlAvB6MgYevRW1azRqOcmaz
-YqU5qVCkA1karYzpdRiML3h8mlEsL1vY0wF/GQhJmHpfjuNkRud5hvd8I5iW
-rg7qnY8r7LtEfYugrwvyWfHQlC1eiSJYJGpWUiwB/FpNZTSXnpOw5tTbP7DD
-SbPUkdZ18qC4Go0DpRQ+roDk25kUHW2aJVRhAgZ10719DqQZnCtyEr5KwqLo
-BNRJgDnGA8r7VPug7Vi/wtwmTqqUt7Lq+r2Y9Nw3/pwvY1y3FtrshW6LYZ7N
-0GE1+N7UupaD68XzMl2779NvRLRHOqLk2deLduAu2vyacfizSt04Z5ZkrzrW
-XMuun2UYFCENaPJRfIHdfxdb356YsK+FEKC1JmAvrLfJAH9QiNZ4OzuyrvkQ
-65rvn4dIiyiH7RePCnZvGBwshkLhbKGAjtooLZDHCrY2JhoTvoCweVS2ZfHe
-mKQF1yfIZtMvKcm6sJULsYhIg0k4Mm1VYYYD1qUZEujvVZzdlSx7Zy/bG1y2
-g9qyNYSaDWOB8qR3KtTG0QzdS2nplERuFBdWlR9v8UQ5R0K1Sit7WRB3Ov4g
-7j08sy9isMzGyWff56Jlo3vnsNA+Hyc3tV1gLNrqEkRzuwOd/Nu9gzFub3ct
-o8I0GW0IiN/KO0U/2Ee9j0Piblkyh5XpeaOD6RsNhoekC1r1UtC+Wo9T7USw
-6IAsIf2L3tNNnAbk2al5kFPjJ2xWhl4Kf+WCwJwMBbtNEdtBfyjSqV0N9xRY
-hN5OWK9MYq3uxwwkLMV7FGJYJdacuemuxPTq5VcBfKmfEFDzdZShCXWk1yFv
-Do8Cdo2EWPN8lEeY9t4+EFLUQUbn8oCeEAHfZEUZvHyxL9IoGhcyXCW6wmwk
-0dhHXx8mXjlr175e8iivXr8zcNr8YWFRh12h6DPV7lb0ZRkoKEkUI/hEZn7l
-TuCu5adechrN3dR6/XyUtYOzfVKTa90vYB/Nt5DqNGnIzwbRuoSpVSvdko2+
-nXe79st7RWkqDD3PG+vWpMefO7RVgB//0ng62O06muv0dgJeUDD9RQ4AYgV3
-dXkO8ug8S7xb2eiE07AaBx5X3UKnwKGHIIz+8/FKAva5xqZLNVhspzzNlmqw
-N46BJx/OIHooRKw2xfX0NEvIYYq8YVQdf2S1xFRA1BiXPEcnaEYBlFaTWZUw
-R6iv+zaAw1I/4Kmmp/xAcoznSNiUErSt7s7x6ACmFLsn6dFFWazD7kDPdOYE
-gwsZKDaNC7LXp9E4dt77WQjH+FCFVjBMEmcPyLnDHpJDIjsJ5UX2uhTzLEmC
-bDJZhX22vU6EoWebzd0BFg+R0aywknuidxqVIYtkaV5SHqQBknFoewn1hWAh
-zrNLaYADISQ9ivMQT2lXo8iN0YNmuJGIY/ricPL9QJZ2j64AASDyNJSPndo6
-QZ8hM71cbBqjqC3yo8H/UO5s3RU3POf2jSkKQtg/fmGkUrP43yOalBpn57+v
-psidBzzqHWrhvHBX75TG0slt+15UTgOKb5M5V+zUWUiCywxWaJqdRWmUVYV4
-e3Jsv0Tqce6s8/BCipJwam4ARjUXDmDJQ/HDIpth9Zh4sz0651vimFbgmuIe
-Zkk4Al5Io6uSbtJwITIMrHUXmqIzlBEzriKVOw3025SMyCSc2dOeSnXuqEpc
-4JwGO0tgB2EOLvtoZd1qnWPyJYc2kh8renBFgVKcYr7mtIrSM0rZVM/fpFYN
-pVWYWmknrCVq0k0/W8PVCsf/FSKFCR3vXYvRSpNotOwRRXVZQXis7emEaqA5
-fZghcJSAK2vKJ15R5/eXzscXsDTotOGrDYAvja8jGRRO0rvx/AUcWtCo5/2K
-houtcEGM4KpgZrosB1O65PwH3reiINfw2BVkcODrOAIueSChk5rKeIkKRB5N
-9QlPszir39LCv1CZHUGYV9KPxok3ne1Tf7HZsY/U8YifXkYi2OoPxs/5zKhf
-gFqSR+KEkYFa2kyqHCO4ZCrABRFYN0deEIC106o4Liyjy/x2QoKPVoXpGFtH
-OQo8sNI4OAQ1MOBsDUfrn8Tw6Vb/sTj5+XeVA3eBF8xvD18G24PB394Hg2F/
-sCsO8RiEUQZs3u2d5RH9KaiRNzqpKsGMuAu+ojgDE/MTfnAWi0930sZD3XGW
-N3xv2ALwQ6XgMKBZbJvzWhdIN7XcFxItueREIv2sBDi3dKLK6QTr5OxQEJ39
-gXNsRcKi8zKcYoDAIJ2ccteMUta80fIorG0br5+EeGBVBnLZxeuIZR6xkLAP
-0izRQjbKGi2VfPoriZrfWpy+xV2T1aFp8SG6vNld5S1dSSL5/xr8JhAhzGIz
-Sqox0zKUpbil88D14Ld5zv1XZGWWRDmZWhwSdXey7pMTw+zGldFOxUb6+wWe
-g3ZFo+1z3KMVVEUOK8wQ0P4q0ffmufHIyLANvy74OmKx7MdSZDcsEJtlK3A3
-SqszIt45DLy3nhsq3yE+DlAeS+3n0mR38g87UbJ2JLN8X5Cl/qncVhiZy5ML
-8JzvKSdLx6Cs0FvMSQXnBnJLicp9pOnbm/wnyHewkcBUpd/Cq/VaRC2dqtl8
-MikpW8/VpXWu7jhCz0IscUvPOqyHiuYw5tb3Ke2aQGXLXFpj3D4f8tJKuCHy
-tu61Xl1Ac1XAZBGnxgr428hZc4AtYE2Akcb8JgUm3cHM4ZuPXrFJgiUdhrbx
-+kk0Ob6Nf/3CWD8hX03y0qOOFsnK3c2LSA9Oz1w7yL0pQM/0Te+IWIoqrgdb
-cVYp40ZFQsaqmE2LcVZDKry6LaQkNy+IlKWkmpcqt08qqh24DKWaON06pVbB
-qczK8DYxsva6upvPr6yEgpe1hAkq37P3/MJO/bBWNh4z6VElI3Vkd42VdiWn
-97J/q9vCjkRUp0bj98G47bU44zwDqRUOrQHqgHrycqLCZxNSvjPWb4X0cztL
-OHjQMz0Y02fdzfMoHCPprMb1Nw8LDDKfHHoad0iSu34McItx/z6WtjJdlY1k
-XE0T0qKDgfEFjMYWcd8mLhq31B1hCfyaV/vftLNv1nbXbACsEhXnWxTEw+7/
-5pfjE3H09kRf+kuA9fUyEMw6dckhFHzWijoZL4ztgOXysonwmN5zt/aCEgs7
-BcQ3d71R61pvYYZZNrilxkVubMjtc9F8bXrXM6WhFphnPTT+BvNsMrNhpKV5
-GUuiVMQYVvMO9n1nOJVLR11H+UD0qMw6/G3SBq6Lk4pNihovmtpOQVigiCYm
-XlxtePt3KhCxZqUs3EuSTD7tfROV55kbPdLIoqsPVfMP1857QTsTZ6IjmWDT
-wm+nWZWOeaer3uacJQ/k/MQrJFfwukdauqMd//z2l9cHjqykC07EAV12TgUI
-LUj4Rkr2PTVlz6pC5bHkFJhTFVIQp3DgC41sZSOAttRyp+ql37MyCc0gRELU
-8az8TesaIb0SglZhWYxVHnNMY16bspPAvDV9Oc2DGcAM7U2FrXnG7u6r/Pxp
-ZXrW8ViNnvXdAsIEL94DkyR1qfO6kShioG7wDSAr29ipftmoWltX/bV6tkWa
-B9EVAIFzVX7WOIA6V17qJpgvgn0yhTMcD+ZQeA8mNR7H6p0tj8v4w+e8OUt5
-9UqH4jrVbTFOemF0Ho0+qF0ZFWU8pdsyrXe8lWbxmqn3Cv67vtiycTqlefng
-vKvm5H6rrQodRMpzBcCM4q6UnlVwdqv3kAquRSwkjEqf5eDoFRcGsShLviBy
-ljQY43XpmK+qiSP4sVUST/wSz0wB5UpR3tUsGPqSkwmBnc7IEzHLQKGjg8Gq
-/6grUYVJJtkLQ52s/s2Fg//A//4bfu7f+7gr/gRzCa5hZ1NIiQDDIom+X1NM
-ekJJJX7bO3rF0YHR2v17RVblo4gCUGD3fgBr5/s1lKxrwvomBTS+X4ujchIk
-ZAZxcbmfNgeb28FgKxhs93HQNdpufxLHEdiM6Lbdl3FOfMEobSMko4WDKW3A
-d2yg7MfZqCJTSZkWoShALExDDhkPSzYmOH6L6juCbaSzNOLLjAJl50UcipQz
-M6PaACVFQGeyHHVBUWAEKSzE0YuT/bdHL8XHj//0/uX+zub28NMnNPPevzi2
-v3gy2B58+tTnWUgeUF2JNARPBoYWSAedNQXO4NRiQ0d8aF0GZnwQq0s+2Y2n
-qLsCyGMGd3weAQP1jo9/XjfYbtaR0ng7WP18cvLueEEE3MFPXh8TEEmG7e0d
-GNFaUZkCG5ecjmfyqpLWAj8s8yyhl2iA+tHe/huF+5MtpDSBgYW5iMfqaoEr
-ZWYYygDid1TKdeU3lCFIVSz/kWviy8hdPW3QnpyjKsQskdahsahOVR5YIKMp
-v9kGSLGLSSjBLz4xQwYQS1Jd9TatLyTVPaumYqGZRvYaqtQwxPNTMtp1hHOc
-XmSkGHH0HE4c+LsaV0Yzhd7hIo4jDjmmEswu+JjocA1G7tRexez0v6JRWeid
-aO9TzgzFmW5gC8oUNYiMUq/Sp3qUSTgajIQgXzXgGQ631mWO9w9oLjARC+Z5
-k0ZHPxwD1uSL0lCVq8UMTBiZqRWwk9uIxyv6yqELJJVOhkzHXlJMsAZsD3oZ
-U3QMQarKmGsl4MjMgSS2Uba8f7dvMcWGir8AhgXLKcR9REKL4BBMimAl2qXZ
-WCUqlVNEYiAfUl1wpBD/gcPqvrx85Owj9oEhoskECS0j8JS0s1g1njDB4lRG
-3aHvjhlqGmJwQFYVyTVQCk6L0jgrIk0kCQSTj2NGXB5Fi2f9ztkpxsC0l9KZ
-6Kui01yG4kWHc2+WR5jBVcko7hOSx0HKbbX3WRxI6tYJqRK6WMG1BWb8L0E/
-UxKsKkHLEVcPg/+zqaFXlF7EeUbH68LeDoVSZDV6ALMlCb4Yq0pFFJrYsD90
-N7clMh8/fQSag+4Wrk2eD01LYJ5LANpnDXq4d7Tn0Z4vpX1h8rz98v5QYbB2
-+OLkpfjrm9fifXQWg9C8XoOhf4Sht3aePPn0aYOhnocYOTzm7D3Ervo9Vhwl
-Y6bxREWsWSjuIgZsacCkYOBd2B55uotmwS659Yrdq2mymxa7aAzsNswFlquM
-Gy4gJbQelbtM68MXx6+oBcwAPjp6uPdM4gensgKxpbmixKFJok1CVfP6Cqv7
-905ckmIiIziFUBc1ZVuiybPJGn1G7xmBg44Q7hoMyzR0Vs8lAbYETP3zPFLo
-rUSld7AE8RV0TVzayaXa5YrIf4UfM3n85AUcxYBHjrIS2rxL8OkgHlgwrp1a
-m6xY2Fo+XGHfkjqrWRQkZgyCQJyGow/4O1qY8iVLcBoX0tzbl29baJcj3KeD
-p1u0HNY5kJTTpCorSrQsa2moO4lxHk54NBiBsYrG36+RUa6Myr0ROghh13G+
-XGuXhhXoSZmHAaeGWxr3BmfZwUfP+HGcYwXdESY+RNfDB5Im7zMYiiXPr3FS
-yiJQej8DIUoSxxdxdEnwT2CK7yKsg4MNqcgKqERGCAVhlauT4ZRsHexjmbNg
-62czTVohnVu6wSXsTbBWgE20b+oDcMyYrxH+H4+tr7WmiQEA
+H4sIAAAAAAAAA+19a3PbSJLgd0f4P9Rq4s5Uj0CTkizb8vZDlmy3bm3ZY6m3
+p2d3YwMiQQlrEOABoB7t9v6W+y33yy4f9QQKIEhJtmfOipm2RFZlZWVlZWZl
+ZWUGQXD/3igbx+nZrpiXk+DJ/Xv375VxmUS7Yj+bTrNU/LZ39EochGUoTq5n
+USEmWS5eh9dRLgbiKCovs/xDgb3C09M8utgVrwdOT+p0/944G6XhFKCO83BS
+BnEEg41G4XQW5JPR08HTreA0LoIkLKOivH8vOy2yJILfdwV+d/9eMT+dxkUR
+Z2kJ8HbF4YuTl/fv4dhneTafAbL7e2/eiV/hA5iLeIUfwswA3FmWX++Kohzf
+vxfP8l1R5vOi3BwMng42EeuiDNPxf4ZJlgLUa8R0Fu+Kfyuz0YYosrzMo0kB
+v11P+ZcRzCxKy+I/aMbz8jzLd+/fEyLA/wjBUzyO8rM4E8+jJCvLmL/JcqDw
+UfYhDvnvPEMSR+O4zHL+JJqGcQKYUuf+KXf+KcUufRi2NsphCViL5/PCHuHn
+eXgZxQuGiLFn/xR6/nRO7b3wD2CNYJFhFkmULzmJMfXFSUDfljm8KMpzGON1
+JN5n89/jEX8Xp7DuL/rVj2n0t3mYnkXOYBEB6cNI1PinjJp4x9uLYcLi1Tyz
+IL6cl/M8AiqIk2h0nmZJdhYjH1gjhNjtbJ71kW1/OsMPGTxunrTM49N56WOE
+n8NsGoep+Nt5lJ41rJIc4ndscs7tW1clTOMoEf8SOwB/SeOLKC/i8lpkE9id
+6SgsyqiyJn3cGj8l6st+OOrPP9QGeBWe5jBCBL8k8fQ0yh0O3o+LUeaAPTvj
+dj+N8Cv/Kqd5PMpgU8bA3A37QULjpn3ZtIVzDs7z+QX8NxtftxN2jA1rC1eB
+9jwGaRVlIDl+y7LUAvji5P2hA+70+nqe/hTBmvfzqP8hr4F6H4/CfCz+NU7C
+pAxt0p2c7DugcmrZv+CWP43KctRnxnMA/pbNAa/XUWTBOg6nxVxxgAR3je2S
+KOqXVy0z/dd4VKIAz2bR760rcUEN+wk2tNfh/r00y6dhCQxHDH948ktw8p+v
++jtPn/Q3dxmEVCA/8F9C7E1nSTyJo7GYzpMyHp2HaQpMPI7SIhKX4QWwW3pW
+noPYuIhRxqt+1HqWRFco08MZAAGJDt8X4jKG5kWMExYKXDYD0GGiOscpMPkk
+HKm9bElrPW1CXryPWKyPCbiQc+GG8FmE5LmIcC+IzcHwCX+B/BkBBpNMgbH6
+KaI8Hjx1SXKokSI9CoJLoQ2KKUyLGagckbJWXRptGM1G+k2Yj84B481BM8ay
+i8L36ePH/aGL8doJ4oXSJULtN4PBToHojWvXsmg44zyaRYBdDrygJj6JwXAQ
+qOHDPE5hlBAHKK5BSE2LtaWpQHOw6fAyOs3nYX6NpBg2k0L3M8QYDCq0eAmS
+U4QjWL5ClBniXIxA+gNjwJSmcRomhei96k+g2boIxLvsEr4qZtEIFpf5HUU0
+fgDbgcmyygQHA3t+/2ue4NyGT9vmxl30Zt3Zqcxs/zzMwxHMIi5gVQpUI7Ms
+gQX5nYedZmNY9BhQz2mVkRVgOiHIiEKACYUd8mgUkR4Cvg5L0ySilW8DtzwR
+YAYNazxsWWPqBYYgfOiXYds19j9Wq3eWx2Pm4V8P3jiMDdoIP5rk0f+eR+no
+mpquMCUc3Z7UW5DALHTatrDuZs9ic5VZ7ONH1pZefRqO8DwAtpDCc7DVPg9H
+eB7PZ9tbPmFEQhL47fDFixdiOHj1fO/4RfAeBH6zLIVt+fbkaH3hbGBMEF1o
+4guJwAoz0f2smWxVFMHaW4kqyzmQDUV8ltJOAuKDGAS4ID/BvCzicZTzEi2N
+/tbTpk2y04o+9rt/LwgCEZ4WJQoG/PvkPC4EHOTmNMA4mgCasPkBSTDzR7T8
+sCojPvyN8cSIhzU4NcEMUph3jL/jDOnMBtMrcCuSEqSjInVByZDg1MFQPQOr
+O+qLk/OoQI2Tw34dL4APpzJ7ABGCakFLIB1DVxDZp/DnFDkD/jy9xtHmSSQF
+Fg2tzrZk2k/isznTnvCGw2KJ+mkWnsaJnE8xByUbFuJXs2+OwToZncMAao2P
+NBP+evz2qFhHYPfvTVBHBrjJgLFQm1ogDpQ2fWNr0x7KmXXN031cFFhEd130
+2Vm8f7lPx+e+WsxpPB4nEf71J7REcpg8LZuEQ4vw8eM/Qb/HTx8NPn0SMS6v
+f1nEvGCK0jfU3yUYdtuQJOPf30fTDP54l2ejaAxnLrEfJgmzBPVPs1KrRZZR
+cqZiGqYwJE1vlmdwOM9A0SrKI/8cWSbTvoPGO9le9I5enOy/PXq5Lqe4s7k9
+/PSpj+ST/KemRlAK2ErAJkiAYgp4wlYhoXM6j5MyiG0GJN4AvC6ADwsxjdAg
+jYsp251AIeZckdFZl3tM8mxKiGtw9Ll/RWO5VF02m9omBKY+itlnPB7PXm0t
+Mxtrh6LAySMpoPQmQqhycNmLVQmabrhyml9AYk8m8gj/wpJsvZMX62ICtiAw
+QoHLeBkBkeHfNEuDkxfmq17UP+tviNn5daHNe8UXlS1KlhZsL9tFpVSCVgQx
+Hy8IwR40ZjkGBsy8RFGLVC1t8ksaqfnhxsdTNgFRgzAJpF0HsEiquUs4SubI
+HR4xQZAaRcXHjz8isw53tmA/fvzomCrwCS6W++nmp08sZavyhcZZVsbI8R/D
+0ebTJ4JQw8HPtOEY7Iw0uiTaMJFj3tjAQFrkK/mrRIARXjwuii/apC9hSSfz
+nLbQOCrhiIqyN2JGzCPr3EgSh5x0vJTOSLgyHz9ew0YPRsAAQEB5Civm0ymq
+RskdHz/iJj6LCnRL2lOsqar6WiNTgnmpJ2rLpjdGkKFLtQDzORJ7cE6LS2Dd
+eR5pdiREUU492drelBj86U/ihM4Z6KS6pkU+ykqWlxLD99EEhUym1m17e0dz
+CX3w6AmyjTp8foiu6ehSsDiXcyFIaj7MTNi4tMZGAMDPePpBrqkQpQAlmYKY
+YCmUzVNrPqxa+mxQMAZAHmCWtTe/HJ+sbfC/4ugt/f7+xV9+OXz/4gB/P/55
+7/Vr/cs92eL457e/vD4wv5me+2/fvHlxdMCd4VPhfHRv7c3eb2s8u7W3704O
+3x7tvV6rLycKP2k44OF9lkdoO4TFPTl9Jtvz/Xf/9/8Mt+UcN4fDp7RdaQGH
+j7fhj8vzKOXRshQObPwnkPX6HoiWKMwRCuoZMC/QQYt6EUTKeXaZCmD6qH9P
+csC7HDjkCluTU/4IT1JH4TRSHHBYmcAGeX5oM9ACpdlYCnlWSBYrZ6f/hQJU
+y/wZDQUTnKOrhfcJ+svRwcXfAY5FNopDJAn5ZKCNtAVyEN6zLB1r9tB2l9z0
+xAJ/qPnwzx/OZvX+/ME8DgetCLsng4ClL39HFwsJimX7c7c7mEV/hZ/79z7u
+ij+V4Wkg51mwcf792jv1N1LJMxM5gbVPOAME94Jc4LgZ8UD5LonCAqXSLAlH
+EY2liUOjp3M6RQDttEp1VQ6baEq78L3LG6YJWDclCjev0DU2uU1G3KtSVzsK
+a4OpRXBskvUlWCUypXCgQyMopZpyAYVha2VlVazV1mJNgUSveRinbLtNwKLJ
+LhVxCVIezQsyJTwWya6cOSw8Dk+Q1Wc/iD1xirRnhuNjwbWWdoQu6aOwqAva
+nc3BI5aV8mQl5dXO06dGA4wux9NgdB4Us9EyI+9nYe638OVYrg7eJx0sHZsw
+Vjii/deOuUJxvBqK5MNYMKREtmFg5ol0NDlbelyLnY4ycqSJfWiHHouX2q3y
+Ck71c3QiQe/e0f7LV+tCnYEbSeOuHg9TJFkZXMbj8hxG1CANuifPD3bRfsGz
+D8n4mT4BhsCaUviIHgjpTEijel2NEFWJ3gINp5/ERcnOMwnXmQTvCOZ3+CyQ
+d7W3Dtx4fQKWSihObn8YtCDugjxZOTdgf2DppaxxFjLEIADn7ckvG9IaVyrN
+Y7wbG/fxQLHPD+I4xmU335GfByTGOIvw2FIKOD0CP5WRNBWyWZSrA4P0c5Cy
+BbWQRhtVtD64zFsdhA0qu81FlI6zPFDeZNegNhpb0UbvvA0bSMVUkMdp3K5q
+z9AscE3CJEAz4Q6Yr4AjXxKeotwpw7wMYGLWKACK1A61EHS5C/zaKAaNvXoW
+pXDWlLfHoGRnbLqyraNUJWFqxn7Iv0e2xfoETFZiAoJDzKW0ERloDARxNIth
+gSR8NFgtQqULOkv7dTKcZ7MvQAAYtTbpynwlqPZZM5za/EBh8/c0g4CcjpaK
+IPbVdCWHnI2islxsIliDSMQqXgg2V5o1JtG2ChENHtUBeB8s3TgjncNdtzcH
+W9zV5gN5aBLWOSqqGknocITtgs2neO4zX2sKSiAzkCNTDKEoPMxRlNGsI+F4
+atihaKCHMXUOgwO6Jg9KsF4xKufJ48c7wXyGvuOqBiWc/TuW+dWa+UKuZRWt
+uRaBSMZdZc9i9zYOtnjXQ38JFoF49q7NcHCAi0fn2jgmNx+fB9klQfMF6Rde
+hHFCDJlKw2YkDRt1XxRrvx+sZiGcY2UhXX1b/SECUx4BdAZtrDAOnerC8QVG
+dSiTfvr9cENOZhqFqfSF4zegcQzUKrRrwcdX6wO0q9jn6GkcDJFGni/+PCQ3
+sxqokdFqMnEZHlMks3hMLMFmzZJRQeqmDxokY22uS0vIBlrY/BoqXBuI07LD
+O8ubGhosem4kcfA00yRqvMjAUfdUr59xPOImaRIaFTVCYGw+KiKUyGWUkCHn
+s1cqh+Lq1xsScKbuFap+aVHA1oBzSKYvz+mELE4zOCuSEyaoDMEQ4VRgLoIM
+qcxmWZFIosKqyxIGu3tJAl98bmLUdtOqNGmwOrpTxWDiJ475/nPTyNrkq1IH
+QdSJ02ELRQ2sgt98HjpQvAAHrwT29a4Re2GVJJmcGR/jTH/nelj6CADdRDpP
+1lDFFGt4wRKNld3AjnUTCoYHcFTgMtyKTpAKVeWArZzFqvgp74r219K4/iMm
+ha0ZgZvlZ2EqA3VqZ74WOnDMRToGGlhnRg71kYtHl+61QQq8hOHTrF4R9lcG
+0RXa83HZHQvr4BmWHJoL886jhHzU0NAOE4yBwHHOl0VJPI1LvB6E5Sr4GtBa
+VYUITcfW/bbmnydjdTdagP2uzgLyRulHre848J38dPEkIGM/wDspswY0NOAD
+nBGU8xTgs2xoIUH1wGSBEAyC5Zc09nj+6loSOwALxtP5lHbLNLyi32VHba5t
+2De1ypAyxpxsTlq/spIVrlppYaUT29lh1iLTCrL/WApqvZQ1hqRAm8qa7uFe
+LVsWVp3tllvL0TiYTeH/IKYScjPCZx2lCnqESx4W6I22M05Zni6RzaWHRs5M
+DlG7lAnFGTBxipGL8+mcd8L+AdHg3ZuDvrlIUDtHjTwabwjAfUNDll4odeQB
+Lp8lkWGEecrHFdX8ezHp7R9s4CjrihzkoaK1CFhVdHIoWSF7lguW7jmdKKtP
+n5ScTPNOgBuAUTSoBjYrxjcDNhgYWNMbwdrZ2WFQf/oThfC9Jt2LHfi39/w+
+4v696lGyeslROX3TkQXgSUsnmuVRQXLRc8azL65CxuL4nUC8JaPRR6BgRU8e
+LPlSGJjn7Ztj8Wb/1bq+/yVBaQYuzvEO9DSqXI5Z7dRQ0EzhjEMVPH4ewaEu
+AHwjagj68xy1C/1bRGf6dm2vOqe4UTnKQAsOvknL+GyezQurOwubkQ6g/Z1D
+y1CZNB3F+e6exqV7CHZEVUHCFLORUluhB+F5as7nqNnoPtdtVmhCuyabZ1XH
+EWzbMdFREVZfmBHHfod3y0qiUrAo21fYaqOZepuKvZopjo4xBsZwVUi/uobq
+Va/dKIQOuyHcKpWtEFbtpEFbas4X99Vt8aPeFjTL/4Yfda2UhNPTcQhibLj9
+eCjSqfizOBJXdfSmcICd5wwwna4rIBWSHXQm2XApkh14SVa9BmwlmaXgb0iy
+CVLr6dZwMOgPBgPx6uffuxANmrVTDa13YPPbIRzJE735lqILOtAUYTbonmSs
+NowF8cy+qTz+9dWGXCkw0Yab/UdIFB/q6xsqlL4VFxc8XoRa8Hf6m83wBUYy
+oEsRNgjbcp6FZY1QW9jjX2Fl38BCwnx8i7dg+RHNtjX3i6gK02wwGCQSYmEH
+D7PrLrQiqKwzI31J4YgAt3pvdhEmcxNniH3zWhub4ni0stEwuszoY9LC7VpU
+nlfJI6uluArMB91VyKgjjDudz0SGp5Cqfm0cuc7v0sEQFWDbsZGGxl5lKy1w
+yclNsKHQ3LBs43BOytUJFvLc+Bhbt6cvJCgeik2EdRWP1+IaqYCoywcvQJ87
+qAJJWim0LDr8l/wIOuylPhiv/osQZAPuU33T66e3zRJRzAHBthcf/6j73C2F
+ppg1btTEesYNQNuuBzzQjdJCuGrq/I5kfVeH1fAVsz6MuSdReclNa4OEjgy1
+JHpIGyJkk+AXLPijFegc8rGuQhDjkbDktpy/I9ZNeJI5ala2TUVqfif8ESZK
+h1TEgjp3o4yLYCuVlxFscYNV8YyBQjs7dGUS4gNNOD2oF3cxOl4mLaoIAx/G
+FF8v96ce2TS3HTWdqa0QDK9uG0HphrgpgtU9qriuQSbWbpAWiUUTd2f5/Tf0
+n3gBYH0n/Z0hM2RwGpfTcKZFeWPkgBNErRRFuwD23lSsKoGbICwtgJsA3UD+
+2oQD8lqGxAqEAgCr06jWeQXy1GCsSBmxmCwdDn0Yek86xgxD6oBUAGzZUhuR
+hd9mq24nc3p4ZkaoS3sf7I42MZtyOxubj8jKrDgtbXmk/eRarEgdACIi9aOu
+QwoxfJieEpR5FLFPRuY8QfeD/QiFI3hfmUc1bPcC+FEcB7Ab7t/jwK3degDz
+vXuWL9J3GUqW95+DQPS0Il7/UZrj+Pluj40DPBCuq8//4C50SEx/FByeQ+Pt
+8mcOgJGn68jTdVTvaraIBiDRleGiP9oA5GdNU45m1mztAODOE6aNLo/GTqgr
+TUSFyOXRZOH8CdJoWUh+clxpctCMPAA98FwyjiY8cOVnYT+iar3nPE7LJ/5l
+wLvlm/Cc/IqzNwR4yprP8N6NJ23A/GGAcdt195s6C1s/DdxswSQhUAEpJ1XM
+T0dhnoN8YFZJv2sB2WWD1H5W2zG9hTSzwFRo5qBmbT0fUmYXNnWdtnedul2v
+CB/EuI7OlUtvOfR34t/kb/9R6yG6iI+WLlNPl6mHgC6D2N8ZtUP2blFr423W
+OCe3T9dpeXo1zcyzia2YCL2X9Vb2SjBsoUIhefWVjLBRQBgWNzechBok2p/p
+jbLnlPOjGm6447T1HTjctmbqviDjxWKsXWl2FgmiKhLqAsCHaTdR6xWydype
+F0tXd7cvlq6rU7L200JaXwiyn/0Xcn9dQVYidDsZKkubKJ0sFNHBQnEBmbiR
+5vjeyk5faLhZoFxB2BXSUqLNGy9q1mDhdmjYCMtry5X0pEdDLqMbl9KKS+lD
+vyZcqAOX037L6r2bsMX/d4rPH897T3LdkseO5Q8cKxw17Gg8Cg8y2xj/XHd4
+U4avVfZsnrmBcs6ozje1ftY7O3TNYczid/6p6V60dtIlYWQdjWk2QXn+e7UX
+rOLyvWzqlPNUPjD70el1Vu0F8yqv9ALPMC9ZAEgzWfjP8em0Q5/walGffIVx
+6n06jVNmZVjr4elDjOIJa6wzjadRTWxis8qbOIu9ql95u1ujBMxVExDwCKXh
+Kx+UZkZt4FTds5ldGznP9G1k2sV9m1m3kXfFYvb18khLP80orf2a2XjZfp3H
+a2DnBn52IigryhngOV/XlHMrE3jX0em6nOCyuy4pvZyu3QVLe7dG2WJ3W0KM
+tXfrOlpXYWZ3Mwk5aZmLJi3qxLRrbap93tz5n+45sN1vwXzDf0Ak/UeN1eQX
+fk+XQH2LGZ9q3XpVxhUNKp1/VlXsld5LqfdK35W2zB832jV/3GjjrKL8F/Zc
+wNCrGAILey4x5tL7qN00qAzQYiDoluIGZoIHSIOx4Ouh/CwLrIj6IMvZEvX+
+y1oUHghL2hV1CMtaFx4IS+j8Lr2bNX+99zL2RpfeS47d2fYQql+LBSIs2C12
+iN1sJdHqAFhFutoAVhKwDoBl5V175wUiz+68tKRt77zcyMvJW7uzx3rx/VTN
+EStpMSXxK75r6KikYfCD6Pcf6v+5hs1Dab10HNwj/xvHVz9dxzcvjpw3fvcs
+PKqmT9Xi0SB8j/gsQMtqphucWzVK8lFQQAEWNjLOF/jxPAUodlf3tZjV1aO3
+amaoxyMFPZta2z+W480ImXE8mQSEWTCOkvC6CmEcjeIp0G6z0m90nmf4gGkU
+mLznPy7oN9LPxsD+hj/idBxdsQH+h9WGPv7RD8hupwksbCpbbRpXwp6Incid
+FqQyId9ErAdwMBP8yzcV/fmP7VPBds5cbmUqHAoVpmWQZAXnDWQhhn/izUE6
+TxJ7TuPEnhP85Z2T+nzRnKCdM6eGsbtPUIf8BtaTO+3l5h//3kBl/Pb46H3b
+5ijS3OoBegBAuIqk2tvVCA3KxxC09pWPuv5GdS5s7qDJp9HrSG7PPjLU+4vt
+k/f8+PaIWa/TcD4OvNJJ9tvZtmmYJUmQTSZtq+XrRyaXvFqyQ5fsn7rpU8VV
+Jbyrj+7nLWyPWts/v2ZsaZzzPCrOs6TJ1eDrB5M8BR0ZZMCwTRRyeTmbl0DO
+9l5uj7IiSSQrgaLgF5wIgT8jzWrLELtb8SG69Axm84rWiPJVtdb/C/R9w/mu
+4RK48fW5dh0tY64ve9Wx3CVHlSJhIq2yrxHZZY8Ky50NljsMLGf9L2PuV5fE
+pg89kDdL02C/+S4Rq1SoHm89Gro6uW5drBnWj8FWl7ZpqsT0YOR/lhm34ZJH
+4RgjziuYNNBnWeK0YoM383OCb97OGFJ4k462xabo3VSRRgnhYGLBG3cqnLwW
+NbRxx1fjuJRYAgWOAhbqZ6AAgugKPodNkJ/xDmOlUAMwo0Sgjusd/SJFCVId
+T4Fnro5xVYtpFmWJ3bSpGdKiKHVL+Ee9scRwdWDKwA1Z10HslA/fCmJ/Y5JH
+O2HsOngde6m4dU/e7Y/4JJQgX8iaUcP+8Bl+SPnI6bHT2jxPd7HrLvFmsXs1
+TXbTYhe77dbTR1NvmXhcBX0841wKtv7jt6hrWCPUVxeUwVCeoFEp2/76Svwa
+ne4K8c/nZTkrdh8+xEytWPnmQ5TT058+jPDw8uwh5ft4qErbQb/XcVHuin/G
+qnlltktf/6Q6/CATPQiZIRwG8JTVND8KCjfqP6/Uz/SA89UarcPjVv3n1aKi
+HoDVsqJ1YNSi/9wtH+qB5Kl+WQfWUPfyB14kKyeGXCg7Mbl6daVqZzjJzd0k
+5nJ4XaTFFAjipFGc1sTKHlpmphAQdX1Jb17qZTr4qQm9j+nVsnzLvt5KG+vm
+PU2vsf6PBOD0W68mYK+WOOnrtdjPZtd5fHZeit5oHeuIbVPlXHGCRXB1mlg8
+u+ObMu22UUlqMecF1ZrSpTRGKlNOIgguZlYqovwiGptB30fjuGBpr3KZzAvK
+xlNk83zEuXdO4xTLbVChjA3KUiN7g7jBv8AIx6XT9YA28EnzDPNklfhIZzbP
+izkc1WGdTP0gLNpDFQxUzhBYTCIsV7iQmcHoKQ8nCXiPdUP0bJ8fH8Bm5h74
+6Bpwg5UAtI9lEs7t/kjRwVDxgUqr+Do6gzV4hxxW0BO995hzSmb1ofYHMs2y
+6tFTsoZqEkeRkTMScQpTWzeUJYZW0lTVqXGqmxSYOpZS+KgqB8+wSorsr+oP
+xGURJRMS7RPQ2CIh1LH80igq7OHs8hwPsCzHgw3+F4ts4O+qPAf+TlU59C8S
+hmzHpTnMb6a/rsiBf1aKdDyQ2d9gzL3fHnByhAeqVMeD7qU6JJRqwQ4x3BY9
+pAeW61jnX7FYx7q3Voeh4bXoVrFjjXTTw4eCS0T0dz0lIUAFzYH2dlUIyv0z
+zS4i6kszhKWJJCwFgh40y7o3VN/NlJiQzDCbnyo/OTWQ4Eilg62AzNK7hmnA
+cSkFM2UcXlMWBw0UxUUw2A62BqzLPeIYBTLRm5/CjllqC5O7SDdT7LirkgtS
+8ZI3lLShZmIwGJkwycZnGAyeBMOtNnwO8YEjUFRuk3aMsLzQshg9/A5+/U4c
+6ppz+OdDxlUXN7BDvtuwVYPoN5ft+OKryV3xCtPWhgklGqKkD6ooOyarCbis
+VLCPIR/ABap/7/Xx/vqGTBLBbVA2vQdBC5Ta0JteuAUZRW+4+RDLHa7vii5F
+JDUUbzFJe10talGgOoegXo6nil6Cq0bYpHymvvHQEki0r56vrumGNTquTkmi
+oAHTgZK3RMoWWrZTc3wjah7cKTUNhO6c6dY8BXoOHmJt1KXp6SvX2khOK0D6
+ZvR8qQEtJii+MW4kKMpwBvYKxUacShIbGExF4XDu10VgTd5qZq82aWnnBnNK
+1Ny61HT3ejPlZIMvKDuJfpuDtMqYVbouYE6CUHm5/2WlqGrxJaSppm41iVob
+dzYWUPpi3Olly9W3deOurnMl0W04GJyd/17hyypFF/DlUCYR+6pY88sqJKLg
+o5uT9tE3yvoou/noxpTltCPfKFuVB5uzm9MW8yd+o+69moHqUVJYCXeOCWxm
+eUR5ZJ81Ky9jnLaosCbjWI69M/PtnRp6eqGa8Gtaekxt2bb0fsLoeoRtutua
+/sr1B9vV/I0s+hXt+VvhxSW0vkXwNl7QK9J1vZdZkm9nq+p6+F8id9wN/kR9
+31hdkvbyrEGrtZG+q4Zrp/03Br+2agl42Fms0Uo4BWetDm1q7eDd8b9UFtT0
+XOQ2w769Axn8Rb7od+cI4fg8npTiX6Jruvwz8Jqtpr/cAA3q2/vLPBznIRWW
+XxWJg3fBTfBQ3XsHeM/xzop3EwY5035lUu29ebIqik+gs+g9EcX19DSDbWIR
+bW8KLFrOxxGHQxC09XZa3QAR1d3CpY1qBjsDoxOaMMhwZ2XGos49+P9t0Wt1
+XHR/G51uJBPL02xr8wY0g849+P9t0Wx1XHR/G527YrOd7RuQDDr34P+3RbLV
+cdH9bXRuj2RGQ0WLvYzPXZ2G1TY5q7TOVf/yxb5q3XuZ5ZdY/etFnmMW1yzP
+OZZhXdgloVVl0HGUxxjK0aQWzzDau2roRJ2O7a9kqc0mhETvVQCIr/fbzRtl
+Yjx9/EhcbPYH0soYoJWhQEcEemRAo+I3MIr56RTWLI1gJYsymhb9ZsbhXFEr
+T/oYu7dM+XjJKYNVdTFE1/fgMUx6uNV90ufx2Tk+eaKoe7awlqFDmq1OhKMM
+ObKFxqMbELgM45zyxbcQeb8LlffSNLoSexg5owj+ePAUaA0EB1t28FTasm9P
+ftkWSYYR8ZR83ICgkJNJOIpa6HgDMr6dRWnLLN/SJHWC+XkhEyYbCM+zItoQ
+++fhfHw+z2OKM/k5G6GVfXYeTUXv+f7P67hUCyi1n4QYzjXc6W/3t6v02sJd
+ibb/EOm1iQyqUjq/PTmysLFIqAmnYjn5h1fkxe2O0LI2N2DD/SxF/1VKtZqA
+gqLHPFcpnBmmgk5NwrCtAbKQgSn2jhPHpzAjrFJieo+zOT7Gia4ACywreXwQ
+EB7DzScbFNz0czidcnz4OOqbfrZ6IgUAmCWsDGSsJB0RR3LNHz1Ui3CJEU6Y
+nzsuLCBc6FIcHP8MvUCohFTMZlQhz+fbis98M2X4B7fOuvWR1FZ5dLdMbKKO
+zNuC7iaErjnIwaCgJAQqiYcITEhgVEGRg0wVFA7wxBhOrlZqsDKF6/SIKoLy
+cR/Vl0UMSvQiLrZIkyMxhk+UpP6ElKzsUfvxxNH7vwWbs0evqgEZpsmCXXtC
++eRTwBdMthTp8HuEaWkA8LqfDFT28PTaWh+kmKJMlSK4a4pCADiBNZ88TG8B
+0iTa6m/2d2wSPX30FPX+EyQR6/0n6y1irEoi2CXDL04iFTatHPcnXCs2L8Uv
+KUDJciwaC/sBkV2vsZqH2ToS8zEQs8JxNyTncGAx3BfnK8BmCbZ6fLtsVT2B
+fqVstUlstfn1stXbk9dgSQXH+zeiZyvZ6qxknYd46gKfAl9TmSNgK+ByRVwv
+Ubft+D1UxOscftzNIBdkzxgIdIoN+VEGEnWSzXPP+K9DtKJguNdea76J7Ycd
+Fc6idXr59nB/+NkXSi2PbWTphUKr4a04VJYB6Wlan/0hrwcYSEQ0a7V4GsPu
+C2b1lUt3p9Q3cay+54Ftdo31fqaAXxgHXKFF11VPnu6KY6IzkvUFGtH8hINu
+KgxUvv6AlVL9q8+BGm+L4rwogwmcv1snJfnJ22YBZ+3JcrimzpuBwvY8Py+I
+xlZoHT8AAgv+1z3Rs+a5p0ddF9OoPM8wKCCD82Nh+jYNZp4h8EtEQRkZulxa
+rbwKTevgWwkQJuNsemfLcCKp6VINT2yaVqa1RTRGK+l0ufdZ6JREYYGJUEI4
+AX4uavGmZb+FRRs8RJtO57KGUxLmZxEV+iviMbpiMcfliJwsqXwFA9/yBKzz
+FBalDvFUxQ9o8DxO5Q4pxTnsUHyBo97RdYol+DyrwQ+cSYrcoQShatOO4MAX
+TsUoSvkUiKplQ5xGZ3Ga8oNs0Nuq+DvTl/e8W+d6lmdnsExcbC0jJYPER5+k
+09jaGSBDZEE/evMHfak6qlsgu0Vvy4feX4Rg42gJgtWI0EaxKnVvSjDjlyzn
+t3DxAHZgw41CswK2vCK7xpAxoQp1K1DuliZV6znvqtkt8rBizx6cvnfEq9OH
+i3a/hbi42CGzf0fFOzTPwwCoTQgN26OWSyzPiav7xDBcfgC4fq0z21p5Zlui
+tw325PBrnVn10rH7zLbRRh72n3y1i7afrjw36NpLxRWcNB9RkN/XMkHjFYVp
+qCw36HdvEYzUSoCgxWArvgmmLnSmswSzxuXtm2OS8jEWgU4iehLeJM4YhUIG
+UAVjtC5M8J6kewXZBeTHJ8tqWLB7QKGgk5pnoQYSaqDerw9//r2FDVQCMe5+
+V2j1xs+nLhLyFS4+zh1HE/sNbskfycJVCiW+7sZ0js+aVxKP51xgnbO8PTh6
+gPcbtJDkJsdEAnhq95Qi1TPROrdv3WadtNUu3RAPJg823JrtVjycmIjvxfDp
+1nAw6A/kc5g/iyPYPZU4aNGbgtWOSYfQDMHCp3Z4Ht/YVOD04O8+fIB/n2Cl
+1Jita95tD8IUTjB5fWoPeJ9xmrCC0xFcyFrm+tkoP6CnYTWEBxWUH3gq1Vcf
+BNQvFuzj+z/O8ynFuKMvxLjGjF3EudbhrJFpraMPcO/246FIp13YNp2u15lW
+dpfMOcrSCxQ/mOlO8aiFEzGnhuBn0n0Pk9aZUwOpM2n1eWU7k372R353+PZU
+samM5f+HFrD4ouDvQKoSmnUerby22MDcOkrG6jc3xiypPdRZwNNfIsz/M4ti
+WVDO4fH50kz+poXJTYy/zc17dux/I9tabb4Xb4Bdj3/txK3YrIlb/C8WvnGC
+k2jd4QeubtPCD4cqrRb5gd2rEAXWxk7F6CgAh6WglEuYoEyOJnMHqUw+FGY0
+yZIku3SjvkAiwrQSjkm1CtkX8nLkUX+rdj3TstYu7voGx0uwhoTwy5EONtE4
+yx/asIQFi+ZNoW4hVmi8QGccro/qj0nEYHphgikwr20CqDnwjKoVBZopoG62
+NvuP+P4X2f83+GnKIlQ5hx5OZ2Gc4xknCC/RQXaSzbIkO7s2Mbe+fFE4wrL5
+okQ4wVizcQ7/BpRLkXITBvKKMYgNKqVEIuCUjgAFE4lh+qjinBJoIePCkJUV
+rhQKuMmucFZY5tTjxV83/sWpHbum/j0xCa1kbja5ReiigJJTVQSd5g57THZl
+xpTPbgYSgt2nsIDUOZb3BaorxdliO3bzSh+ljtDSKBPslg31jZ0sXWsnYnV4
+Saf1Nv6FSR4S5YJxfIZulKfGN4D/zFP8cA1sr7UFiroi/0E0QKcNwRxIZtxw
+8xFZcn4DwU7wvCzSO16kX62C9CsH6SE+IbSR5g3j6LM096EbbD5zkBk//2nQ
+H6bTNox6kinX5T0Y7rqjLC4i8R75X2iDhIxZAAdHOdUZdlGWzOVFfTomw2Ox
+/nn6+DFFguIJZ3MIKp+ce5jxLbKKypAPS3e2jjRjlY5zaqXVdOwD2muwWyLQ
+KLm5P1QbfRKfwl4zAfScMlSG0fvNhzRX+ZFdYzK13i4q0Znmz5wPoulMPxr9
+9PnWYYPyHooPaXaZ0tkBdi2hIu1a/Fb1n6fUrO/fJHir6twv8bRA4kgNYiiA
+H6J2fmTddTR4DPFVCTU8VkbUMZXvJl30EsdceyaqP6r7p9qA210H3Bb78zKb
+TPiVIoY081jNoLcaQDO8LXGg66d0h/moFeYjWPk0+BtG1a0CfKcrLXa845DJ
+DXYaslL9Bq9t4MddB34snoN5EBzCDkdHNRy3GmbVsmFYnKCremzxqH8Da/m4
+rJDfXLxx9yw4cmtRDM0lHBYJiH9baZQ6S5aqkF9OvixEUwoMNJT4e1D7JBaE
+8XZ4ZIjbAWwN0SJL+DrhLIxTv/oyM6Ybb7E26PenoY4/clXt+PkiTUsD4Z3+
+80XodF4E02WlVXCxkiTndxiK1obIqleF2HypglAeUqmjrmSnxp+D7IxgWJYg
+GOSpb9Ea2IWSOq4Bdll5DRpQXG1BlloFUpndjLdudDaFahaTmQZfks7U54aE
+ruK4Gp1tKB2pPT6ddqN1q41sJkLYTxeMuCSBoccNyctYLSCqS0wFRQJYSE5F
+uEc+crZp0Ecrq6YJmgVdVOijpVXoo5UIvhjPZh2qgDSvSHclWoyXXYSh/7CK
+0QHd+L4eWfDu+GC97s65npG1yFPZFVv9p+JFMNzesI8oeCT99eGbn3/v4Kt8
++nign2Q8xYd2IVY+GI2igtxDcIjjpPC5YLd8mOgg596r/gRar4tAvPPPwfHz
+NJG6+2Yuxjfcxn4iN21rbX37eAk6NnKSDL54pYpo3DfRF7r6Dd6PJujFxxpl
+eRmAtd4WRINzQK+G1QWR5D8jLiFB1ydM8mv2gZjKD/LiktpbwY787eg8i0Hk
+1zKyN4Wi8O0DlUegqh//U16O0Jj4OKKeGZueUFDrSpZogaHU1WgU/iFar8kQ
+yQAjKpFVsDRDTxeL1Thv2D3559/X3FTf/762vuaO0HiGomn+a5jEVoUDk4Qe
+Fx7nar3zsFjQYlBVhGeXp+e0bhx5qVvgCtKNV7wVVD0RZDT0anfxFSRar6hs
+PDTBPjlsMvIxyOiOGWR02wyyvxSDjO6KQRRLVJCvh6r8PXGIVdzHWi666dIU
+tfLSV+Rsgwvk80amONrQqxWiWZtCYLDUCqvg4AWPci11FMpS6vtKcTRmqVEM
+vkvyj+s6bYioHPW7i3raczKIzc2kutzm/rpFv1Wjrzpwe1rfGrhmOfDacIoK
+/aqGjlGEg7r54BCcKrke8adi8xH/C7zC9yMUq4MM5ZnwVy0evAqEGGL0+dju
+yyiURWzXWPagBu5GbJdOgevifgRctzmw7lHkz0TKow1zr0wv+nHirNLUnbRq
++ffEfi3ayaOUotlXoY8MN99dnKQZg0qJbe1swUzevHt9LN4ev3sZnLyw3wdi
+Ybn5jF4kZBMrQkrDaCwK6JQDFD2UXuv+J8gevXuetapdlafNNO6kfV2yeLTw
+Cmev1U5bcjz+sqALQRJwlMlN7eOP3QQBd0ccqLsSA+5WJVxky4pEajz54c/C
+A1QrboTfDQ5S+NP1MFURnJ9qs6d7dN/kgyQuSvSxqGciNyIG1vHWL0Q2b0ar
+goiFITM3phYxK6VoMhP19JfMU6Nto7AntJeMcqxDcKRXW25l9dO01jc9zH47
+D37m8yAI769C8y7SSOSto1KnbYqp4t2DOSQUvm6pJ0VIRZcqeKWRZB3Y3EvW
+dvvYbxz/+1qlSFzVLm6KZNgzBYeNUYxM7BjGFeAW42ou8etSa34cxmhTSW7V
+9uoA+NNud3fPdu9IE8AnBK2hcLQS6dvboYlub2Au0/lUcBXxUzB9IiCciYcv
++mA98QBAPz7tOVvylXV34N0Relc83nn6ZFe8zMNpRK9GMaTlPcjPOJeKCHcH
+GXkBvpAfO8PsA6vlWeIaeM2GndN3sZHnkJQWEzWktQqTcFRmeW0t+QWDu4zy
+2n7oXNs3rdmwyxrtqfA6jNRWobneigYbmCOGdFSlTjil8VBLbboWbDZzRC8G
+D8sII/zQfkVBVKx3jzHXVTKas/xwn1Q0dCE3g/i+pl399P6uYVN15LgVzg0u
+b7fymI+vnO4LeSy8ukMeo4e/D/rih+8FiFsvfR+4UCnzcTCNiiI8qyrvN+FV
+dSlpgFOUsBTciW8I6DqM3m+DNVFZ4zr79Rt3x93ug/pUltoH9e4L90G9S+M+
+8PJE0z6ooHY4Ufeo0XjDN8+GJXOAqOXzLRgNgReZ9WEcGC5t2iD+fW/kT157
+DB17y17YHr896n5ja1prNN2sNHfnKvh2Jds+Mq1m/WALbPkP4Rr/drdqxt2X
+LjDLdYlPJuaodEAkwS9/F8v9NZ1kjeS8sXMVZeTnF4dypG/e0s/iLWXq3Lm3
+9Js79Js79B/NHfoVSX2Pf7FN9B9agj48xYfpr8NrfIZXC1nUXOMR/G2uOE5F
+bQW7dPUS6qAXNfonC4lZHmeuQ1Af7588a4f7TnWFg45JUW3IS4sQJ1SgSwJw
+DnW9w+P9g0V1e3DhtzcHcM7CE1bz8cpiC2sIOkIF7/KszEZZUmOAHp3d1it0
++Rq4zzmtrRxI5bE27iZa6luc1Lc4qa/lMPgtTupbnNQ/opnyBVLBaXXUHIu8
+yIVoXVF2dSRq/Kp9fUZUJUtd1e6WXy+wZG5mcNcPjE6Zu0IOeuqmZtriyhnK
+j7zB+erpBgU+Nv1NDYamE5nKxR2OL6K8jAu5mwyI6fdDtQGnUZgWKp9U7tQt
+8Jz00o1KQR7zFTnLKUm4p1swRLKpLwwIq8mfh0hhPXi/kw32OfOQcSf17w3i
+/TSM24z3szakSVFDa9KyH1+a/VRZSAVXL0NTsKf7AsHagdP2HThddgd2zKn3
+dbFNR+F58xBNDbFi3S/08Pmpv9Cz1+DVq3KJy4r186nfPQZcVc4LK2WlpXmr
+HrOauMefD9G1ijNJXfOhDfQi9KtmVTusriYVzgfEg5mSInZRWVmmU8Vi8TnV
+GmzjWsymFRblzLNwJ9ruliqBG5MIJJgNTu6iRM7NyJYKAWmwudJP1ak2eAwJ
+avvKNK//gpjSjvy7gDDWsrpitW2yVRD+ybf4I1sl3leqqpZxqBllFegEgZ8j
+PvBbpN1dRdotxZR27y6hdV7GtIF8C637Flr3LbTuW2jdt9C6b6F1txxa530U
+ueKVTf1oZx2y2d/c5NVeeHlYKwDgu0F0jAnZdme26doTzWehltAVx5PcHF7g
+cLteEeeCY4dqSjmGR3MBxxuc/cUqx3/3ftXUaFh6oXRhh4XLRC1ri/RtKbxL
+4ezOJa67qZhpWHLlZnVxwRS0tJSai1Yw1gRkJA5IrAdHD1wt8xLV6FU4BZm0
+IR1hId8KyUoAjYtkAbFPHTCIWpoN+eLI+XIxju2sMcrmyRg1Cx4JiAEsIIcp
+5xVHR8SGyVxGYJUHpzhXECKarSxVbEGBc1oBo8LScN52o7CLqCxVynZnVUHl
+bLqErawa/pEUmcySFRad6Rmn2gfcgdVv+jT8ZifwBjVFhWdGETDX4pp3RDbd
+My4o9306Zm/saWQcG7wscjFUd1upYX0Ge+gHhcrzr1qjX0mvkJEG0RXeWcUl
+F9srzrF+HJbImJ+hMycau/mpVS0+EcF/olwbZAEnRM2xmAGJAVgylYTPHaGM
+YPeFpbxMQYCWpZLlGy5E1ZcpqSjVDtiAo3rdGdW2GFcoYfKbE+jCclf4aKCK
+cSsQlZkyPjjMLuwarngg5YzTzeaNkYrbwYslzQMgZrPLaii/zUZoyqbjEKzX
+awA3X1QO8JDt9YhQxCUjfOqMQltW11GxrTT8dqNaXAK2MvWSWRTthagGraga
+IVWHtlMK5lnlS1ieaYbSRrZxx27rAmvHK9rgF/dA8rtvFzSkppMYzFKQdO69
+f7tvF6Qq7VZ3K/rp67opaZrtlFiJfIsIKLDywcOH7bTxU9vdv146Nza5fQo7
+fOrSFqZHRHCwWYpG9pxq0mWJoJV9x+OPooirsagKR6DBXfLXzrqCx3QO3/Vd
+r2bq7171kFcYoDrBZlZxCKqZBNtgTAIsU51PpHK125AcXKRtHYl6Z1rXGaWq
+dr11df5/1rrIRlKXGQWrGLO6OeCYW1TMvF9xSP683KDcq1qhUXgFnQvq7B7a
+ERVmeQg3ZeL2F53hOt3EmWG9I0r1WliDud1qYo+u2fDDwI2ibxCGzs3b0O/1
+5qkk+lJUYdyOp/KmMiqesHtZIepj5ZZNWtLoRd189Kglws7B8PCgfqjzGbQN
+vk2Szk2mt+RL3lxM3IcOj1f+WqvLxD+LtarMWyoUcY8HV5VXdXEd5l1tX8q9
+XO2u9nbtmYf93kUxVLUMW037qNgRBlr/FjZiiAuoH/DB/1x+fejhT88C4w+5
+Rh1QHuoSfd0h/k0O8f1onsPZr+yt/0dzT9uUrC0L/rS+4tG5n6nyGCoEipwk
+9VupJ1j4eruK1lIGa89qK1mjT/v7InXjLXGjXNvIJx3w6qj+fdq+hqaPzTw2
+4D8+p3kmfav85jkDLMtyd8Rxq2F2E7bzRmWQdenRoIUyGl3r09OImyw0ICt2
+prdwaXM1pFphUjaW0GI5m4cwZBlFbHeSwJcPeIxz77DUd0pwbrGrlZIzjmqU
+0p0IOYDMvdjz4OB49GtwXf7eu1iXdWrlEaJwDFE0hNCiwP6pOQPIxeZJ5NEI
+C5+OddQHN+MoDB89tF3gO9l77ZeGFzE+6rU63VoO694TABfRAps/t+tvSmvc
+5mAbcGFf6XFZzQpVmmp5SsJUv16FNtyUC9DZtWHRFcM46UAeazPZ+sJUfi1E
+b+9wvWHLMnl8Hv4FNWnVZP2tVpnz4sK1jSfihZwzi6BDeR1wQGwLz+zJw78V
+maT89xKGDKrVx0cZkG7dlatKiboHBe+KXj/qw/Fq/2BDvHuD/zl4vd6vsJYX
+T38VjOaqUvjjrSxlLbHub5fNsL6tVUVqWMql3JSoD98eH73XhAmLIhvFoeN8
+VbFoKorA9DdVU4U8E4LsIpneVkwNRauBsVwpmAZu8jqzvNxkRLHjUFBzBEGs
+VaWjQTV5/VV8bc8GXcFIXVg4saOWIjADKiC6Dq8hahJPY5mjzT3+9+D4SQtH
+8QrEvWb9r4ij6fOD1xviLyrqgqDxA8d1yy1/mEoP7aTi7aoK6PK8qsoUCECZ
+kHMfryRgCuBJCGgSnMZAzXKpt8Cmt8el3F2IPQea4dAPE6p1mnHNYxYgiuQ8
+pxD2TEG1R313YBbLVo0N+eblcX/Y3/QJbv/kORDqWWV/v4LGDwHigl3e8s4g
+x2psasiefjOJT9gG640zN1AqJLAngtE8WIQsIF4PxsDD16IyrXqVRjmzWbHS
+nFSw0YEsflbG9P4Lxhc8Ps0oltcp7MuAvwyEJEy9b8NxMqPzPMObvBFMS9f/
+bJiPzaENwrwqrGfFQ1N8eKVZY6mnWUkRAfDrfCpjsjTewsK7t39gB4VmqSOR
+qyRAkTQaB0rw68mhHww+j8EKuVoF87czKTOaVEqoIgDMfEz35omRSnBuv0nq
+KtGKMhPwJsnl2AUo6FPtXrbD+ApzUTiZp7yHVdfvxaTnPt/nVBiSMLep9JvC
+A3EzW0YXzDFLsexwmesQB2v9kA52kAL92H/j0QZ2C0YkqPg1CYKVrZbsRnXb
+3evtqCw6e4h9OV0VvSqGU5Pp1E7HFkr6ng+7JpTrsPTuzGY3r9+aal+1fc3E
+By4TLy6Phz+rlMhzZkmmuWO4Noi/WYbxH/KsQO6YOxKDdyEDbeSFfcuFAC26
+g3G03iQM/TEuWr3v7Mgy7UMs075/HmJZwSiHrRaPCvbWGBwspkFNZKGAfuco
+LZCPCjatJhoTvk+x+VC2ZV1Wm6QF1yfRZ9MGkY5ffCGZ3jYHuTxdhDvMwJHu
+q4p1HLAq1zV1vhLBbi/jqpIdYXQS7Z6GXWS76fb1Cfe7kuzvbFZ+g6x8UGHl
+moi3YXSoS3unIn4czdCvmJZOLexaVWlV8vMWHQ0LZHmjXLeXBXGnUzHi3kNn
+TRcbdzZOGiQifPFZJaI1GWeO3pl1kojj5Kb2LoxFQlGCqAtGRaSvRTBaq7my
+YAQY3QRjvWEnwai7VWnWssVuT04tYzZp1rMhIH4ryxyd8wLtSRwS5c6SaeBM
+zxt5ft5oMDwkxTiox7Z2dEqcai+dRQfcRtJF73UfxGlArtPKJUxqXO314upL
+4a98fJjWpOCbB8R20B+KdGoXlD4FFqHnR9ZDrVibmGMGEpbiPaoDLLRsnFp0
+3Wh69fKrAL7Ur3Co+ToyfUId6YHVm8OjgH2P8EecjvIIK0fYHhcK3MnI8RXQ
+Kzzgm6wog5cv9kUaReNCRnxFV5jQJxr76OvDxKux7PLxS/rKVAIJBk4CMyws
+6vBtAl476BsLdBYbKCh9FSP4lE9+5U7Ar4lqre5SLWmuoKHcfa+X2Ed8R9R6
+lBH17mKgLzbRqwSpqSU/xb4OHeWM1LT+q+quGsCqIrNhaJtyUa8uWq0Bhl/F
+wZ70aDifPLxd+/y9Ym6qeL/oEortbxvIHdriICX+UnsT3e4xX3jX50Tyobr4
+ixwAhD3K2vIcFvU8S7wC1mjq03A+Djw3FBKxnW17lSfoA6HDRHwWO7GPVbfP
+8/FKau+5xqZNYVtspy7YLIVtby0DT74IRPRQtFttiuvpaZbQPRHyhjFA+COr
+JeY4o8a45Dne/WQUGW41mc0T5gj1dd8GcFjql4nz6SmLkDF6lEAOStC2EXKO
+sgoOBXwrQ6/JymIddgdeyGXOKxchI2CncUHn0Wk0jp2HzBbCMb7AoxUMk8TZ
+A3LusIfkkMhOQl2eeW9S8ixJgmwyWYV9tq2dbeTy0LPNFu4Ai4dI6Cms5J7o
+nUZlyFpQHpQowdsAyTi0L060eC/EeXYpD5hACEmP4jxEL8TVKHKDj6EZbiTi
+mL44nHw/oLhpjL0CBIDI01C+4mzqBH2GzPRysWmMorLIjwb/Q52GdFfc8Jy0
+PKbwLmH/+IWRyjnlf2htcgWdnf++mnnlvExUD+wLJ3WHeoA5lnd7thdWJWuh
+SwqZTMrOCYgkuMxghabZWZRG2bwQb0+O7SeWPU4KeB5eSFESTs3F56jizAUs
+eSh+MWkzrB4TQ3ZG5xz+EtMKXFNA1ywJR8ALaXRVUgABLkSGLwbchaawM2Va
+jueRSgoJ+m1Kpn0SzuxpT6UF5ahKXOCcBjtLYAdhckHbSWBd5p9jVjmHNpIf
+5/SSlCJAuXZGxX0dpWeUi66amE6tGkqrMLXy6VhLVKebPrrjaoXj/wqRwoSO
+94rZaKVJNFr24Ki6rCA81vZ0pkjQnD7MEDhKwJU15ROvqPPfnCzGF7A06DTh
+qw2AL42vIxkUTtJ79/wFHCXxqMX7FQ0XW+GCGMFVwZSbWQ6nl5ITu3gfwYNc
+w8NwkMExvOVgvuQxkc7PKpUvKhDpMNDnbs3irH5LC/9CpawFYT6XfmLOKOxs
+n+pT9JZ9pA6t/KY8EsFWfzB+zid5/bTdkjwSJwx51tJmMs8xNFXmOO2IwLpx
+RIAArPgQxHFhGV3mNzov8aowHWPrgE3xVlZ+GoegBsagP0yn4icxfLrVfyxO
+fv5dJffukJrh7eHLYHsw+Nv7YDDsD3bFIZ48MbiKzbu9szyiPwU18oZdzksw
+I+6Cryi8ygQzhh+cxeIDtbTxUHec5TUvMrYA/FApOAxoFtvmvMYF0k0tp5JE
+Sy45kUi/lwPOLZ3nMuQ0KO1kRAqisz9wjo1IWHRehlMMEBiklVPumlHKym2L
+PApr28brvSIeWJWBXHbxXikwj1hI2AdplmghG2W1lko+/ZVEzW8N1xfFXZPV
+oWnxIbq844AzJOxfg98EDoWJt0bJfMxUCsUkvoJfpVvAvXtqut3xX3iXWRLl
+ZERxjOfdSbFPzrMLN1CW9iA20t93eMHeFl67z6HaVpQoef8wqUnzQ2pfmoba
+u0jDEPwg6usILrXfd5JF0CHY1FbNbthp6yMex8x/b72QVo5YfM+k3L/ag6XJ
+7qRMdwL77ccX8kkUujR9U7mtuFiXJzvwnO/1Ocu9oJyjd57zoLax5oklK7mP
+NGp7k/8EyQ3WDxih9Ft4tV55BEDnZTaMTBbdxhNzaZ2YWw7HsxCrctNLNOtt
+tTlmuSXJHMdy2TCXxqDdz4e81P83RN7WqtZDMWiuai51cVesgL+NnDUH2ALW
+BBhpTMlUYJ4wLHaw+egVGxtYhWZom6WfRJ3jm/jXL4x11ovVJC+9Q2uQrNzd
+POL24PTMtXDcOwD0Od/0To6lqOJ6sAJnc2W2qNDuWNXfajC7KkiFV7eFlOTm
+jkhZSqp+XXL7pKJyp8tQqo7TrVNqFZzKrAxvEyNrr6tYiPzKyoF6WcnxolLU
+e08m7K6X7/jQD0EKEpN/UvE1dRh3jZVmJaf3sn+r28KORFSrRuOUBrjttTjj
+1Cip9b5DA9RXg+S/RIXPJqRMjaCfN+oXwpZw8KBnejCmz9qb51E4RtJZjauP
+uDoMspgcehp3SJK7ft10iw+ZfCxtJecra/kD6yakRQcD4wsYjQ3ivklc1O6f
+W8JAOAGB9qxpN96s6RbZAFglntO3KIiH3f/NL8cn4ujtiY6gkACr62UgmHVq
+k0Mo+KwVdZL0GNsBK3xmE+ExvRdu7Y4SCzsFxDd3vVGrWq8zwywbTFThIjfQ
+5va5aLE2veuZ0lAd5ll94nKDedaZ2TDS0ryMVZzmxBhW8xb2fWc4lavdXUf5
+QPSwDinOyWQ6XRcnczYpKrxoytEFYYEimpi4u9rw9m9VIGLNyrK6lySZzEbw
+JirPMzcupJb4Wx+qFh+unQfQdvLgRIeFwaaF306zeTrmna56m3OWPJDzm9WQ
+nLzrHmnpjnb889tfXh84spKuLhEHdNk5RWu0IOG7Jtn31FRqnBcq9S5n7Z2q
+YIE4hQNfaGQrGwG0pZY7VS/9QJ9JaAYhEoaeeLMKIb0SglZhWYxV6QWsvFCZ
+slNzobHiAs2DGcAM7c3er3nG7u4rVv9pZXpW8ViNntXdAsIEr9QDk9d5qfO6
+kShioO7mDSArQeKpfqqtWluX+JUS3EWaB9EVAIFzVX5WO4A6l1nqjpeveH0y
+hZOyDxZQeA8mNR7HKnEAj8v4w+e8OUt5qUqH4irVbTFOemF0Ho0+qF0ZFWU8
+pXswrXe8xbHxAqn3Cv673m3ZOAPcohSW3lVz0lVWVoUOIuW5AmBGcVdKzyo4
+u9UbRgXXIhYSRmX8c3D0iguDWJQlXxA5SxqM8SJ0zJfQxBH8oDKJJ36JZ6aA
+cqUo72oWDH3JyYTATmfkiZhloNDRwWCVrNXF88Ikk+yFQUxW//rCwX/gf/8N
+P/fvfdwVf4K5BNewsylYRIBhkUTfrykmPaE8OL/tHb3iuL9o7f69Ipvno4hC
+S2D3fgBr5/s1lKxrwvomBTS+X4ujchIkZAZxPcyfNgeb28FgKxhs93HQNdpu
+fxLHEdiM6LbdlxFMfHUobSMko4WDqcbCd2yg7MfZaE6mkjItQlGAWJiGHKIf
+lmxMcGQWlaQF20gnlsWXMAXKzos4FCknk0e1AUqKgMKuLLMRhnRifBdBCgtx
+9OJk/+3RS/Hx4z+9f7m/s7k9/PQJzbz3L47tL54MtgefPvV5FpIHVFciDcGT
+IZ8F0kEneoIzOLXY0LEcWpeBGR/E6pJPduMp6q4A8pjBHZ9HwEC94+Of1w22
+m1WkNN4OVj+fnLw77oiAO/jJ62MCIsmwvb0DI1orKrP245LT8UxeVdJa4Idl
+niX0hhJQP9rbf6Nwf7KFlCYwsDAX8VhdLXBx3wyDFED8jkq5rvxOOgSpihWL
+ck18GZOrpw3ak9PqhRjrbh0ai/mpSl0NZDQVg5sAKXYxGXL4VTem/MEIejn9
+F9XWF5LqnlVTUc5MI3sNVTYr4vkpGe06djlOLzJSjDh6DicO/F2NK+OUQu9w
+EUcIhxwtCWYXfEx0uAYjd2qvYnb6X9GoLPROtPcpJ7Pj5FywBWVWLURGqVfp
+Uz3KJBwNRkKQT0TwDIdb6zLH+wc0F5iIBfO8yfylHzcCa/JFaagqbGPSOIy5
+1ArYScfG4xV95dAFkkonQ6ajKinaVwO2B72MKe6FIM3LmMu74MjMgSS2Uba8
+f7dvMcWGiqwAhgXLKcR9REKL4BBMik0l2qXZWOVWllNEYiAfbgh5yuU/cFjd
+l5ePnH3EPjBENJkgoWVsnZJ2FqvGEyZYnMp4OvTdMUNNQwwOyOZFcg2UgtOi
+NM6KSBNJAsF6CZjEm0fR4lnnMnDqxzDtpXQm+qq4M5eheNHh3JvlESadVjKK
++4TkcZByW+19FgeSulVCqgxVVthsgUVKStDPlLdvnqDliKuHYf3Z1NArSi/i
+PKPjdWFvh0Ipsgo9gNmSBF/ozUtFFJrYsD90N7clMh8/fQSag+4Wrk3iIk1L
+YJ5LANpnDXq4d7Tn0Z4vpX1hUlP+8v5QYbB2+OLkpfjrm9fifXQWg9C8XoOh
+f4Sht3aePPn0aYOhnocYEzzmdGTErvr9WxwlY6bxRMWiWSjuIgZsacCkYOBd
+2B55uotmwS659Yrdq2mymxa7aAzs1swFlquMGy4g5eAflbtM68MXx6+oBcwA
+Pjp6uPdM4gensgKxpbmixKFJok1ChT77Cqv7905ckmJmNjiFUBc1ZVuiybPJ
+Gn1G70eBg44Q7hoMyzR0Vs8lAbYETP3zPFLorUSld7AE8RV0TVzayaXa5SLu
+f4UfM3n85AUcxYBHjrIS2rxL8KkmHlgwYp1amzR/2Fo+SWHfkjqrWRQkZgyC
+QJyGow/4O1qY8o1KcBoX0tzbl69WaJcj3KeDp1u0HNY5kJTTZF7OKTe8LP+j
+7iTGeTjh0WAExioaf79GRrkyKvdG6CCEXccpvq1dGs5BT8pcKzg13NK4Nzht
+GD7Mx4/jHIt+jzBXK7oePpA0eZ/BUCx5fo2TUtat0/sZCFGSOL6Io0uCfwJT
+fBdh6S5sSHWhQCUyQigI57k6GU7J1sE+ljkLtn4206QV0rmlG1yG9DIP2ET7
+pj4Ax4z5GuH/AYbx3U0BjwEA
 
 -->
 

--- a/draft-ietf-ccamp-rfc9093-bis.xml
+++ b/draft-ietf-ccamp-rfc9093-bis.xml
@@ -58,12 +58,13 @@
 
 
 <t>This document defines a collection of common data types, identities, and groupings
-in the YANG data modeling language. These derived common data types, identities,
+in the YANG data modeling language. 
+These common types and groupings, derived from the built-in YANG data types, identities,
 and groupings are intended to be imported by modules that model Layer 0
 configuration and state capabilities, such as Wavelength Switched Optical Networks (WSONs) and
 flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.</t>
 
-<t>This document obsoletes RFC 9093.</t>
+<t>This document obsoletes RFC 9093 by replacing the YANG module it contained with a new revision that includes additional YANG data types, identities and groupings.</t>
 
 
 
@@ -101,6 +102,12 @@ flexi-grid Dense Wavelength Division Multiplexing (DWDM) networks.</t>
    statements of the YANG module in <xref target="yang-code"/> or the summary in
    <xref target="changes-bis"/>.</t>
 
+<t>This document obsoletes <xref target="RFC9093"/> by replacing it in its entirety. It
+provides a new revision of the YANG module contained in that RFC,
+and retains the data types previously defined, but also adds new type
+definitions to the YANG module.
+For further details, see <xref target="changes-bis"/>.</t>
+
 <t>The YANG data model in this document conforms to the Network
    Management Datastore Architecture defined in <xref target="RFC8342"/>.</t>
 
@@ -121,9 +128,9 @@ appear in all capitals, as shown here.</t>
 
 <t>In this document, names of data nodes and other data model objects
    are prefixed using the standard prefix associated with the
-   corresponding YANG imported modules.</t>
+   corresponding YANG imported module.</t>
 
-<texttable title="Prefixes and corresponding YANG modules" anchor="tab-prefixes">
+<texttable title="Prefixes and corresponding YANG module" anchor="tab-prefixes">
       <ttcol align='left'>Prefix</ttcol>
       <ttcol align='left'>YANG module</ttcol>
       <ttcol align='left'>Reference</ttcol>
@@ -133,7 +140,7 @@ appear in all capitals, as shown here.</t>
 </texttable>
 
 <t>RFC Editor Note:
-Please replace XXXX with the RFC number assigned to this document.</t>
+Please replace XXXX with the RFC number assigned to this document and remove this note.</t>
 
 </section>
 </section>
@@ -325,55 +332,52 @@ Please replace XXXX with the RFC number assigned to this document.</t>
 <t>transceiver-capabilities:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping to define the transceiver capabilities (also called
-   "modes") needed to determine optical signal compatibility.</t>
+  <t>A YANG grouping to define the transceiver capabilities (also called
+"modes") needed to determine optical signal compatibility.</t>
 </li></ul>
 
 <t>standard-mode:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping for the standard modes defined in <xref target="ITU-T_G.698.2"/>.</t>
+  <t>A YANG grouping for the standard modes defined in <xref target="ITU-T_G.698.2"/>.</t>
 </li></ul>
 
 <t>organizational-mode:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping to define transponder operational mode supported by
-   organizations or vendors.</t>
+  <t>A YANG grouping to define transponder operational mode supported by
+organizations or vendors, as defined in <xref target="I-D.ietf-ccamp-optical-impairment-topology-yang"/>.</t>
 </li></ul>
 
 <t>common-explicit-mode:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping to define the list of attributes related to optical
-   impairments limits in case of transceiver explicit mode.  This
-   grouping should be the same used in
-   <xref target="I-D.ietf-ccamp-dwdm-if-param-yang"/>.</t>
+  <t>A YANG grouping to define the list of attributes related to optical
+impairments limits in case of transceiver explicit mode, as defined in <xref target="I-D.ietf-ccamp-optical-impairment-topology-yang"/>.</t>
 </li></ul>
 
 <t>transmitter-tuning-range:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping that defines the transmitter tuning range, which
-   includes the minimum and maximum tuning frequency, as well as the
-   frequency tuning steps.</t>
+  <t>A YANG grouping that defines the transmitter tuning range, which
+includes the minimum and maximum tuning frequency, as well as the
+frequency tuning steps.</t>
 </li></ul>
 
 <t>common-organizational-explicit-mode:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping to define the common capabilities attributes limit
-   range in case of operational mode and explicit mode.  Also this
-   grouping should be used in <xref target="I-D.ietf-ccamp-dwdm-if-param-yang"/>.</t>
+  <t>A YANG grouping to define the common capabilities attributes limit
+range in case of operational mode and explicit mode.</t>
 </li></ul>
 
 <t>cd-pmd-penalty:</t>
 
 <ul empty="true"><li>
-  <t>a YANG grouping to define the triplet used as entries in the list
-   optional penalty associated with a given accumulated CD and PMD.
-   This list of triplet cd, pmd, penalty can be used to sample the
-   function penalty = f(CD, PMD).</t>
+  <t>A YANG grouping to define the triplet used as entries in the list
+optional penalty associated with a given accumulated CD and PMD.
+This list of triplet cd, pmd, penalty can be used to sample the
+function penalty = f(CD, PMD).</t>
 </li></ul>
 
 <t>modulation-format:</t>
@@ -402,7 +406,7 @@ Please replace XXXX with the RFC number assigned to this document.</t>
 
 <section anchor="wdm-label-and-label-range"><name>WDM Label and Label Range</name>
 
-<t>As described in <xref target="RFC6205"/> and <xref target="RFC7699"/>, the WDM label represents the frequency slot assigned to a WDM LSP on a given WDM Link (which models an OMS MCG).</t>
+<t>As described in <xref target="RFC6205"/> and <xref target="RFC7699"/>, the WDM label represents the frequency slot assigned to a WDM Label Switched Path (LSP) on a given WDM Link, which models an Optical Multiplex Section (OMS) Media Channel Group (MCG) as described in <xref target="I-D.ietf-ccamp-optical-impairment-topology-yang"/>.</t>
 
 <t>The same WDM label shall be assigned to the same WDM LSP on all the WDM Links on a regen-free LSP path or path segment.</t>
 
@@ -3330,6 +3334,45 @@ Names" registry <xref target="RFC7950"/>:</t>
   <seriesInfo name='DOI' value='10.17487/RFC8363'/>
 </reference>
 
+
+<reference anchor='I-D.ietf-ccamp-optical-impairment-topology-yang' target='https://datatracker.ietf.org/doc/html/draft-ietf-ccamp-optical-impairment-topology-yang-15'>
+   <front>
+      <title>A YANG Data Model for Optical Impairment-aware Topology</title>
+      <author fullname='Dieter Beller' initials='D.' surname='Beller'>
+         <organization>Nokia</organization>
+      </author>
+      <author fullname='Esther Le Rouzic' initials='E.' surname='Le Rouzic'>
+         <organization>Orange</organization>
+      </author>
+      <author fullname='Sergio Belotti' initials='S.' surname='Belotti'>
+         <organization>Nokia</organization>
+      </author>
+      <author fullname='Gabriele Galimberti' initials='G.' surname='Galimberti'>
+         <organization>Individual</organization>
+      </author>
+      <author fullname='Italo Busi' initials='I.' surname='Busi'>
+         <organization>Huawei Technologies</organization>
+      </author>
+      <date day='4' month='March' year='2024'/>
+      <abstract>
+	 <t>   In order to provision an optical connection through optical networks,
+   a combination of path continuity, resource availability, and
+   impairment constraints must be met to determine viable and optimal
+   paths through the network.  The determination of appropriate paths is
+   known as Impairment-Aware Routing and Wavelength Assignment (IA-RWA)
+   for WSON, while it is known as Impairment-Aware Routing and Spectrum
+   Assignment (IA-RSA) for SSON.
+
+   This document provides a YANG data model for the impairment-aware TE
+   topology in optical networks.
+
+	 </t>
+      </abstract>
+   </front>
+   <seriesInfo name='Internet-Draft' value='draft-ietf-ccamp-optical-impairment-topology-yang-15'/>
+   
+</reference>
+
 <reference anchor='RFC8040' target='https://www.rfc-editor.org/info/rfc8040'>
   <front>
     <title>RESTCONF Protocol</title>
@@ -3523,53 +3566,6 @@ Names" registry <xref target="RFC7950"/>:</t>
   <seriesInfo name='DOI' value='10.17487/RFC7581'/>
 </reference>
 
-
-<reference anchor='I-D.ietf-ccamp-dwdm-if-param-yang' target='https://datatracker.ietf.org/doc/html/draft-ietf-ccamp-dwdm-if-param-yang-10'>
-   <front>
-      <title>A YANG model to manage the optical interface parameters for an external transponder in a WDM network</title>
-      <author fullname='Gabriele Galimberti' initials='G.' surname='Galimberti'>
-         <organization>C</organization>
-      </author>
-      <author fullname='Dharini Hiremagalur' initials='D.' surname='Hiremagalur'>
-         <organization>Juniper</organization>
-      </author>
-      <author fullname='Gert Grammel' initials='G.' surname='Grammel'>
-         <organization>Juniper</organization>
-      </author>
-      <author fullname='Roberto Manzotti' initials='R.' surname='Manzotti'>
-         <organization>Cisco</organization>
-      </author>
-      <author fullname='Dirk Breuer' initials='D.' surname='Breuer'>
-         <organization>DEUTSCHE TELEKOM AG</organization>
-      </author>
-      <date day='23' month='October' year='2023'/>
-      <abstract>
-	 <t>   This memo defines a Yang model related to the Optical Transceiver
-   parameters characterising coherent 100G and above interfaces.  100G
-   and above Transceivers support coherent modulation, multiple
-   modulation formats, multiple FEC codes including some not yet
-   specified (or in phase of specification by) ITU-T G.698.2 or any
-   other ITU-T recommendation.  Use cases are described in RFC7698.  Is
-   to be noted that the Transceivers can be located on the Transponders
-   (optical layer) or on the Router (in general packet layer) in form of
-   Pluggable modules.
-
-   The Yang model defined in this memo can be used for Optical
-   Parameters monitoring and/or configuration of the endpoints of a
-   multi-vendor IaDI optical link.  The use of this model does not
-   guarantee interworking of transceivers over a DWDM.  Optical path
-   feasibility and interoperability has to be determined by tools and
-   algorithms outside the scope of this document.  The purpose of this
-   model is to program interface parameters to consistently configure
-   the mode of operation of transceivers.
-
-	 </t>
-      </abstract>
-   </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-ccamp-dwdm-if-param-yang-10'/>
-   
-</reference>
-
 <reference anchor='RFC3688' target='https://www.rfc-editor.org/info/rfc3688'>
   <front>
     <title>The IETF XML Registry</title>
@@ -3666,424 +3662,427 @@ Names" registry <xref target="RFC7950"/>:</t>
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+19a3PbSJLgd0f4P9Rq4s5Uj0CTkizb8vZDlmy3bm3ZY6m3
-p2d3YwMiQQlrEOABoB7t9v6W+y33yy4f9QQKIEhJtmfOipm2RFZlZWVlZWZl
-ZWUGQXD/3igbx+nZrpiXk+DJ/Xv375VxmUS7Yj+bTrNU/LZ39EochGUoTq5n
-USEmWS5eh9dRLgbiKCovs/xDgb3C09M8utgVrwdOT+p0/944G6XhFKCO83BS
-BnEEg41G4XQW5JPR08HTreA0LoIkLKOivH8vOy2yJILfdwV+d/9eMT+dxkUR
-Z2kJ8HbF4YuTl/fv4dhneTafAbL7e2/eiV/hA5iLeIUfwswA3FmWX++Kohzf
-vxfP8l1R5vOi3BwMng42EeuiDNPxf4ZJlgLUa8R0Fu+Kfyuz0YYosrzMo0kB
-v11P+ZcRzCxKy+I/aMbz8jzLd+/fEyLA/wjBUzyO8rM4E8+jJCvLmL/JcqDw
-UfYhDvnvPEMSR+O4zHL+JJqGcQKYUuf+KXf+KcUufRi2NsphCViL5/PCHuHn
-eXgZxQuGiLFn/xR6/nRO7b3wD2CNYJFhFkmULzmJMfXFSUDfljm8KMpzGON1
-JN5n89/jEX8Xp7DuL/rVj2n0t3mYnkXOYBEB6cNI1PinjJp4x9uLYcLi1Tyz
-IL6cl/M8AiqIk2h0nmZJdhYjH1gjhNjtbJ71kW1/OsMPGTxunrTM49N56WOE
-n8NsGoep+Nt5lJ41rJIc4ndscs7tW1clTOMoEf8SOwB/SeOLKC/i8lpkE9id
-6SgsyqiyJn3cGj8l6st+OOrPP9QGeBWe5jBCBL8k8fQ0yh0O3o+LUeaAPTvj
-dj+N8Cv/Kqd5PMpgU8bA3A37QULjpn3ZtIVzDs7z+QX8NxtftxN2jA1rC1eB
-9jwGaRVlIDl+y7LUAvji5P2hA+70+nqe/hTBmvfzqP8hr4F6H4/CfCz+NU7C
-pAxt0p2c7DugcmrZv+CWP43KctRnxnMA/pbNAa/XUWTBOg6nxVxxgAR3je2S
-KOqXVy0z/dd4VKIAz2bR760rcUEN+wk2tNfh/r00y6dhCQxHDH948ktw8p+v
-+jtPn/Q3dxmEVCA/8F9C7E1nSTyJo7GYzpMyHp2HaQpMPI7SIhKX4QWwW3pW
-noPYuIhRxqt+1HqWRFco08MZAAGJDt8X4jKG5kWMExYKXDYD0GGiOscpMPkk
-HKm9bElrPW1CXryPWKyPCbiQc+GG8FmE5LmIcC+IzcHwCX+B/BkBBpNMgbH6
-KaI8Hjx1SXKokSI9CoJLoQ2KKUyLGagckbJWXRptGM1G+k2Yj84B481BM8ay
-i8L36ePH/aGL8doJ4oXSJULtN4PBToHojWvXsmg44zyaRYBdDrygJj6JwXAQ
-qOHDPE5hlBAHKK5BSE2LtaWpQHOw6fAyOs3nYX6NpBg2k0L3M8QYDCq0eAmS
-U4QjWL5ClBniXIxA+gNjwJSmcRomhei96k+g2boIxLvsEr4qZtEIFpf5HUU0
-fgDbgcmyygQHA3t+/2ue4NyGT9vmxl30Zt3Zqcxs/zzMwxHMIi5gVQpUI7Ms
-gQX5nYedZmNY9BhQz2mVkRVgOiHIiEKACYUd8mgUkR4Cvg5L0ySilW8DtzwR
-YAYNazxsWWPqBYYgfOiXYds19j9Wq3eWx2Pm4V8P3jiMDdoIP5rk0f+eR+no
-mpquMCUc3Z7UW5DALHTatrDuZs9ic5VZ7ONH1pZefRqO8DwAtpDCc7DVPg9H
-eB7PZ9tbPmFEQhL47fDFixdiOHj1fO/4RfAeBH6zLIVt+fbkaH3hbGBMEF1o
-4guJwAoz0f2smWxVFMHaW4kqyzmQDUV8ltJOAuKDGAS4ID/BvCzicZTzEi2N
-/tbTpk2y04o+9rt/LwgCEZ4WJQoG/PvkPC4EHOTmNMA4mgCasPkBSTDzR7T8
-sCojPvyN8cSIhzU4NcEMUph3jL/jDOnMBtMrcCuSEqSjInVByZDg1MFQPQOr
-O+qLk/OoQI2Tw34dL4APpzJ7ABGCakFLIB1DVxDZp/DnFDkD/jy9xtHmSSQF
-Fg2tzrZk2k/isznTnvCGw2KJ+mkWnsaJnE8xByUbFuJXs2+OwToZncMAao2P
-NBP+evz2qFhHYPfvTVBHBrjJgLFQm1ogDpQ2fWNr0x7KmXXN031cFFhEd130
-2Vm8f7lPx+e+WsxpPB4nEf71J7REcpg8LZuEQ4vw8eM/Qb/HTx8NPn0SMS6v
-f1nEvGCK0jfU3yUYdtuQJOPf30fTDP54l2ejaAxnLrEfJgmzBPVPs1KrRZZR
-cqZiGqYwJE1vlmdwOM9A0SrKI/8cWSbTvoPGO9le9I5enOy/PXq5Lqe4s7k9
-/PSpj+ST/KemRlAK2ErAJkiAYgp4wlYhoXM6j5MyiG0GJN4AvC6ADwsxjdAg
-jYsp251AIeZckdFZl3tM8mxKiGtw9Ll/RWO5VF02m9omBKY+itlnPB7PXm0t
-Mxtrh6LAySMpoPQmQqhycNmLVQmabrhyml9AYk8m8gj/wpJsvZMX62ICtiAw
-QoHLeBkBkeHfNEuDkxfmq17UP+tviNn5daHNe8UXlS1KlhZsL9tFpVSCVgQx
-Hy8IwR40ZjkGBsy8RFGLVC1t8ksaqfnhxsdTNgFRgzAJpF0HsEiquUs4SubI
-HR4xQZAaRcXHjz8isw53tmA/fvzomCrwCS6W++nmp08sZavyhcZZVsbI8R/D
-0ebTJ4JQw8HPtOEY7Iw0uiTaMJFj3tjAQFrkK/mrRIARXjwuii/apC9hSSfz
-nLbQOCrhiIqyN2JGzCPr3EgSh5x0vJTOSLgyHz9ew0YPRsAAQEB5Civm0ymq
-RskdHz/iJj6LCnRL2lOsqar6WiNTgnmpJ2rLpjdGkKFLtQDzORJ7cE6LS2Dd
-eR5pdiREUU492drelBj86U/ihM4Z6KS6pkU+ykqWlxLD99EEhUym1m17e0dz
-CX3w6AmyjTp8foiu6ehSsDiXcyFIaj7MTNi4tMZGAMDPePpBrqkQpQAlmYKY
-YCmUzVNrPqxa+mxQMAZAHmCWtTe/HJ+sbfC/4ugt/f7+xV9+OXz/4gB/P/55
-7/Vr/cs92eL457e/vD4wv5me+2/fvHlxdMCd4VPhfHRv7c3eb2s8u7W3704O
-3x7tvV6rLycKP2k44OF9lkdoO4TFPTl9Jtvz/Xf/9/8Mt+UcN4fDp7RdaQGH
-j7fhj8vzKOXRshQObPwnkPX6HoiWKMwRCuoZMC/QQYt6EUTKeXaZCmD6qH9P
-csC7HDjkCluTU/4IT1JH4TRSHHBYmcAGeX5oM9ACpdlYCnlWSBYrZ6f/hQJU
-y/wZDQUTnKOrhfcJ+svRwcXfAY5FNopDJAn5ZKCNtAVyEN6zLB1r9tB2l9z0
-xAJ/qPnwzx/OZvX+/ME8DgetCLsng4ClL39HFwsJimX7c7c7mEV/hZ/79z7u
-ij+V4Wkg51mwcf792jv1N1LJMxM5gbVPOAME94Jc4LgZ8UD5LonCAqXSLAlH
-EY2liUOjp3M6RQDttEp1VQ6baEq78L3LG6YJWDclCjev0DU2uU1G3KtSVzsK
-a4OpRXBskvUlWCUypXCgQyMopZpyAYVha2VlVazV1mJNgUSveRinbLtNwKLJ
-LhVxCVIezQsyJTwWya6cOSw8Dk+Q1Wc/iD1xirRnhuNjwbWWdoQu6aOwqAva
-nc3BI5aV8mQl5dXO06dGA4wux9NgdB4Us9EyI+9nYe638OVYrg7eJx0sHZsw
-Vjii/deOuUJxvBqK5MNYMKREtmFg5ol0NDlbelyLnY4ycqSJfWiHHouX2q3y
-Ck71c3QiQe/e0f7LV+tCnYEbSeOuHg9TJFkZXMbj8hxG1CANuifPD3bRfsGz
-D8n4mT4BhsCaUviIHgjpTEijel2NEFWJ3gINp5/ERcnOMwnXmQTvCOZ3+CyQ
-d7W3Dtx4fQKWSihObn8YtCDugjxZOTdgf2DppaxxFjLEIADn7ckvG9IaVyrN
-Y7wbG/fxQLHPD+I4xmU335GfByTGOIvw2FIKOD0CP5WRNBWyWZSrA4P0c5Cy
-BbWQRhtVtD64zFsdhA0qu81FlI6zPFDeZNegNhpb0UbvvA0bSMVUkMdp3K5q
-z9AscE3CJEAz4Q6Yr4AjXxKeotwpw7wMYGLWKACK1A61EHS5C/zaKAaNvXoW
-pXDWlLfHoGRnbLqyraNUJWFqxn7Iv0e2xfoETFZiAoJDzKW0ERloDARxNIth
-gSR8NFgtQqULOkv7dTKcZ7MvQAAYtTbpynwlqPZZM5za/EBh8/c0g4CcjpaK
-IPbVdCWHnI2islxsIliDSMQqXgg2V5o1JtG2ChENHtUBeB8s3TgjncNdtzcH
-W9zV5gN5aBLWOSqqGknocITtgs2neO4zX2sKSiAzkCNTDKEoPMxRlNGsI+F4
-atihaKCHMXUOgwO6Jg9KsF4xKufJ48c7wXyGvuOqBiWc/TuW+dWa+UKuZRWt
-uRaBSMZdZc9i9zYOtnjXQ38JFoF49q7NcHCAi0fn2jgmNx+fB9klQfMF6Rde
-hHFCDJlKw2YkDRt1XxRrvx+sZiGcY2UhXX1b/SECUx4BdAZtrDAOnerC8QVG
-dSiTfvr9cENOZhqFqfSF4zegcQzUKrRrwcdX6wO0q9jn6GkcDJFGni/+PCQ3
-sxqokdFqMnEZHlMks3hMLMFmzZJRQeqmDxokY22uS0vIBlrY/BoqXBuI07LD
-O8ubGhosem4kcfA00yRqvMjAUfdUr59xPOImaRIaFTVCYGw+KiKUyGWUkCHn
-s1cqh+Lq1xsScKbuFap+aVHA1oBzSKYvz+mELE4zOCuSEyaoDMEQ4VRgLoIM
-qcxmWZFIosKqyxIGu3tJAl98bmLUdtOqNGmwOrpTxWDiJ475/nPTyNrkq1IH
-QdSJ02ELRQ2sgt98HjpQvAAHrwT29a4Re2GVJJmcGR/jTH/nelj6CADdRDpP
-1lDFFGt4wRKNld3AjnUTCoYHcFTgMtyKTpAKVeWArZzFqvgp74r219K4/iMm
-ha0ZgZvlZ2EqA3VqZ74WOnDMRToGGlhnRg71kYtHl+61QQq8hOHTrF4R9lcG
-0RXa83HZHQvr4BmWHJoL886jhHzU0NAOE4yBwHHOl0VJPI1LvB6E5Sr4GtBa
-VYUITcfW/bbmnydjdTdagP2uzgLyRulHre848J38dPEkIGM/wDspswY0NOAD
-nBGU8xTgs2xoIUH1wGSBEAyC5Zc09nj+6loSOwALxtP5lHbLNLyi32VHba5t
-2De1ypAyxpxsTlq/spIVrlppYaUT29lh1iLTCrL/WApqvZQ1hqRAm8qa7uFe
-LVsWVp3tllvL0TiYTeH/IKYScjPCZx2lCnqESx4W6I22M05Zni6RzaWHRs5M
-DlG7lAnFGTBxipGL8+mcd8L+AdHg3ZuDvrlIUDtHjTwabwjAfUNDll4odeQB
-Lp8lkWGEecrHFdX8ezHp7R9s4CjrihzkoaK1CFhVdHIoWSF7lguW7jmdKKtP
-n5ScTPNOgBuAUTSoBjYrxjcDNhgYWNMbwdrZ2WFQf/oThfC9Jt2LHfi39/w+
-4v696lGyeslROX3TkQXgSUsnmuVRQXLRc8azL65CxuL4nUC8JaPRR6BgRU8e
-LPlSGJjn7Ztj8Wb/1bq+/yVBaQYuzvEO9DSqXI5Z7dRQ0EzhjEMVPH4ewaEu
-AHwjagj68xy1C/1bRGf6dm2vOqe4UTnKQAsOvknL+GyezQurOwubkQ6g/Z1D
-y1CZNB3F+e6exqV7CHZEVUHCFLORUluhB+F5as7nqNnoPtdtVmhCuyabZ1XH
-EWzbMdFREVZfmBHHfod3y0qiUrAo21fYaqOZepuKvZopjo4xBsZwVUi/uobq
-Va/dKIQOuyHcKpWtEFbtpEFbas4X99Vt8aPeFjTL/4Yfda2UhNPTcQhibLj9
-eCjSqfizOBJXdfSmcICd5wwwna4rIBWSHXQm2XApkh14SVa9BmwlmaXgb0iy
-CVLr6dZwMOgPBgPx6uffuxANmrVTDa13YPPbIRzJE735lqILOtAUYTbonmSs
-NowF8cy+qTz+9dWGXCkw0Yab/UdIFB/q6xsqlL4VFxc8XoRa8Hf6m83wBUYy
-oEsRNgjbcp6FZY1QW9jjX2Fl38BCwnx8i7dg+RHNtjX3i6gK02wwGCQSYmEH
-D7PrLrQiqKwzI31J4YgAt3pvdhEmcxNniH3zWhub4ni0stEwuszoY9LC7VpU
-nlfJI6uluArMB91VyKgjjDudz0SGp5Cqfm0cuc7v0sEQFWDbsZGGxl5lKy1w
-yclNsKHQ3LBs43BOytUJFvLc+Bhbt6cvJCgeik2EdRWP1+IaqYCoywcvQJ87
-qAJJWim0LDr8l/wIOuylPhiv/osQZAPuU33T66e3zRJRzAHBthcf/6j73C2F
-ppg1btTEesYNQNuuBzzQjdJCuGrq/I5kfVeH1fAVsz6MuSdReclNa4OEjgy1
-JHpIGyJkk+AXLPijFegc8rGuQhDjkbDktpy/I9ZNeJI5ala2TUVqfif8ESZK
-h1TEgjp3o4yLYCuVlxFscYNV8YyBQjs7dGUS4gNNOD2oF3cxOl4mLaoIAx/G
-FF8v96ce2TS3HTWdqa0QDK9uG0HphrgpgtU9qriuQSbWbpAWiUUTd2f5/Tf0
-n3gBYH0n/Z0hM2RwGpfTcKZFeWPkgBNErRRFuwD23lSsKoGbICwtgJsA3UD+
-2oQD8lqGxAqEAgCr06jWeQXy1GCsSBmxmCwdDn0Yek86xgxD6oBUAGzZUhuR
-hd9mq24nc3p4ZkaoS3sf7I42MZtyOxubj8jKrDgtbXmk/eRarEgdACIi9aOu
-QwoxfJieEpR5FLFPRuY8QfeD/QiFI3hfmUc1bPcC+FEcB7Ab7t/jwK3degDz
-vXuWL9J3GUqW95+DQPS0Il7/UZrj+Pluj40DPBCuq8//4C50SEx/FByeQ+Pt
-8mcOgJGn68jTdVTvaraIBiDRleGiP9oA5GdNU45m1mztAODOE6aNLo/GTqgr
-TUSFyOXRZOH8CdJoWUh+clxpctCMPAA98FwyjiY8cOVnYT+iar3nPE7LJ/5l
-wLvlm/Cc/IqzNwR4yprP8N6NJ23A/GGAcdt195s6C1s/DdxswSQhUAEpJ1XM
-T0dhnoN8YFZJv2sB2WWD1H5W2zG9hTSzwFRo5qBmbT0fUmYXNnWdtnedul2v
-CB/EuI7OlUtvOfR34t/kb/9R6yG6iI+WLlNPl6mHgC6D2N8ZtUP2blFr423W
-OCe3T9dpeXo1zcyzia2YCL2X9Vb2SjBsoUIhefWVjLBRQBgWNzechBok2p/p
-jbLnlPOjGm6447T1HTjctmbqviDjxWKsXWl2FgmiKhLqAsCHaTdR6xWydype
-F0tXd7cvlq6rU7L200JaXwiyn/0Xcn9dQVYidDsZKkubKJ0sFNHBQnEBmbiR
-5vjeyk5faLhZoFxB2BXSUqLNGy9q1mDhdmjYCMtry5X0pEdDLqMbl9KKS+lD
-vyZcqAOX037L6r2bsMX/d4rPH897T3LdkseO5Q8cKxw17Gg8Cg8y2xj/XHd4
-U4avVfZsnrmBcs6ozje1ftY7O3TNYczid/6p6V60dtIlYWQdjWk2QXn+e7UX
-rOLyvWzqlPNUPjD70el1Vu0F8yqv9ALPMC9ZAEgzWfjP8em0Q5/walGffIVx
-6n06jVNmZVjr4elDjOIJa6wzjadRTWxis8qbOIu9ql95u1ujBMxVExDwCKXh
-Kx+UZkZt4FTds5ldGznP9G1k2sV9m1m3kXfFYvb18khLP80orf2a2XjZfp3H
-a2DnBn52IigryhngOV/XlHMrE3jX0em6nOCyuy4pvZyu3QVLe7dG2WJ3W0KM
-tXfrOlpXYWZ3Mwk5aZmLJi3qxLRrbap93tz5n+45sN1vwXzDf0Ak/UeN1eQX
-fk+XQH2LGZ9q3XpVxhUNKp1/VlXsld5LqfdK35W2zB832jV/3GjjrKL8F/Zc
-wNCrGAILey4x5tL7qN00qAzQYiDoluIGZoIHSIOx4Ouh/CwLrIj6IMvZEvX+
-y1oUHghL2hV1CMtaFx4IS+j8Lr2bNX+99zL2RpfeS47d2fYQql+LBSIs2C12
-iN1sJdHqAFhFutoAVhKwDoBl5V175wUiz+68tKRt77zcyMvJW7uzx3rx/VTN
-EStpMSXxK75r6KikYfCD6Pcf6v+5hs1Dab10HNwj/xvHVz9dxzcvjpw3fvcs
-PKqmT9Xi0SB8j/gsQMtqphucWzVK8lFQQAEWNjLOF/jxPAUodlf3tZjV1aO3
-amaoxyMFPZta2z+W480ImXE8mQSEWTCOkvC6CmEcjeIp0G6z0m90nmf4gGkU
-mLznPy7oN9LPxsD+hj/idBxdsQH+h9WGPv7RD8hupwksbCpbbRpXwp6Incid
-FqQyId9ErAdwMBP8yzcV/fmP7VPBds5cbmUqHAoVpmWQZAXnDWQhhn/izUE6
-TxJ7TuPEnhP85Z2T+nzRnKCdM6eGsbtPUIf8BtaTO+3l5h//3kBl/Pb46H3b
-5ijS3OoBegBAuIqk2tvVCA3KxxC09pWPuv5GdS5s7qDJp9HrSG7PPjLU+4vt
-k/f8+PaIWa/TcD4OvNJJ9tvZtmmYJUmQTSZtq+XrRyaXvFqyQ5fsn7rpU8VV
-Jbyrj+7nLWyPWts/v2ZsaZzzPCrOs6TJ1eDrB5M8BR0ZZMCwTRRyeTmbl0DO
-9l5uj7IiSSQrgaLgF5wIgT8jzWrLELtb8SG69Axm84rWiPJVtdb/C/R9w/mu
-4RK48fW5dh0tY64ve9Wx3CVHlSJhIq2yrxHZZY8Ky50NljsMLGf9L2PuV5fE
-pg89kDdL02C/+S4Rq1SoHm89Gro6uW5drBnWj8FWl7ZpqsT0YOR/lhm34ZJH
-4RgjziuYNNBnWeK0YoM383OCb97OGFJ4k462xabo3VSRRgnhYGLBG3cqnLwW
-NbRxx1fjuJRYAgWOAhbqZ6AAgugKPodNkJ/xDmOlUAMwo0Sgjusd/SJFCVId
-T4Fnro5xVYtpFmWJ3bSpGdKiKHVL+Ee9scRwdWDKwA1Z10HslA/fCmJ/Y5JH
-O2HsOngde6m4dU/e7Y/4JJQgX8iaUcP+8Bl+SPnI6bHT2jxPd7HrLvFmsXs1
-TXbTYhe77dbTR1NvmXhcBX0841wKtv7jt6hrWCPUVxeUwVCeoFEp2/76Svwa
-ne4K8c/nZTkrdh8+xEytWPnmQ5TT058+jPDw8uwh5ft4qErbQb/XcVHuin/G
-qnlltktf/6Q6/CATPQiZIRwG8JTVND8KCjfqP6/Uz/SA89UarcPjVv3n1aKi
-HoDVsqJ1YNSi/9wtH+qB5Kl+WQfWUPfyB14kKyeGXCg7Mbl6daVqZzjJzd0k
-5nJ4XaTFFAjipFGc1sTKHlpmphAQdX1Jb17qZTr4qQm9j+nVsnzLvt5KG+vm
-PU2vsf6PBOD0W68mYK+WOOnrtdjPZtd5fHZeit5oHeuIbVPlXHGCRXB1mlg8
-u+ObMu22UUlqMecF1ZrSpTRGKlNOIgguZlYqovwiGptB30fjuGBpr3KZzAvK
-xlNk83zEuXdO4xTLbVChjA3KUiN7g7jBv8AIx6XT9YA28EnzDPNklfhIZzbP
-izkc1WGdTP0gLNpDFQxUzhBYTCIsV7iQmcHoKQ8nCXiPdUP0bJ8fH8Bm5h74
-6Bpwg5UAtI9lEs7t/kjRwVDxgUqr+Do6gzV4hxxW0BO995hzSmb1ofYHMs2y
-6tFTsoZqEkeRkTMScQpTWzeUJYZW0lTVqXGqmxSYOpZS+KgqB8+wSorsr+oP
-xGURJRMS7RPQ2CIh1LH80igq7OHs8hwPsCzHgw3+F4ts4O+qPAf+TlU59C8S
-hmzHpTnMb6a/rsiBf1aKdDyQ2d9gzL3fHnByhAeqVMeD7qU6JJRqwQ4x3BY9
-pAeW61jnX7FYx7q3Voeh4bXoVrFjjXTTw4eCS0T0dz0lIUAFzYH2dlUIyv0z
-zS4i6kszhKWJJCwFgh40y7o3VN/NlJiQzDCbnyo/OTWQ4Eilg62AzNK7hmnA
-cSkFM2UcXlMWBw0UxUUw2A62BqzLPeIYBTLRm5/CjllqC5O7SDdT7LirkgtS
-8ZI3lLShZmIwGJkwycZnGAyeBMOtNnwO8YEjUFRuk3aMsLzQshg9/A5+/U4c
-6ppz+OdDxlUXN7BDvtuwVYPoN5ft+OKryV3xCtPWhgklGqKkD6ooOyarCbis
-VLCPIR/ABap/7/Xx/vqGTBLBbVA2vQdBC5Ta0JteuAUZRW+4+RDLHa7vii5F
-JDUUbzFJe10talGgOoegXo6nil6Cq0bYpHymvvHQEki0r56vrumGNTquTkmi
-oAHTgZK3RMoWWrZTc3wjah7cKTUNhO6c6dY8BXoOHmJt1KXp6SvX2khOK0D6
-ZvR8qQEtJii+MW4kKMpwBvYKxUacShIbGExF4XDu10VgTd5qZq82aWnnBnNK
-1Ny61HT3ejPlZIMvKDuJfpuDtMqYVbouYE6CUHm5/2WlqGrxJaSppm41iVob
-dzYWUPpi3Olly9W3deOurnMl0W04GJyd/17hyypFF/DlUCYR+6pY88sqJKLg
-o5uT9tE3yvoou/noxpTltCPfKFuVB5uzm9MW8yd+o+69moHqUVJYCXeOCWxm
-eUR5ZJ81Ky9jnLaosCbjWI69M/PtnRp6eqGa8Gtaekxt2bb0fsLoeoRtutua
-/sr1B9vV/I0s+hXt+VvhxSW0vkXwNl7QK9J1vZdZkm9nq+p6+F8id9wN/kR9
-31hdkvbyrEGrtZG+q4Zrp/03Br+2agl42Fms0Uo4BWetDm1q7eDd8b9UFtT0
-XOQ2w769Axn8Rb7od+cI4fg8npTiX6Jruvwz8Jqtpr/cAA3q2/vLPBznIRWW
-XxWJg3fBTfBQ3XsHeM/xzop3EwY5035lUu29ebIqik+gs+g9EcX19DSDbWIR
-bW8KLFrOxxGHQxC09XZa3QAR1d3CpY1qBjsDoxOaMMhwZ2XGos49+P9t0Wt1
-XHR/G51uJBPL02xr8wY0g849+P9t0Wx1XHR/G527YrOd7RuQDDr34P+3RbLV
-cdH9bXRuj2RGQ0WLvYzPXZ2G1TY5q7TOVf/yxb5q3XuZ5ZdY/etFnmMW1yzP
-OZZhXdgloVVl0HGUxxjK0aQWzzDau2roRJ2O7a9kqc0mhETvVQCIr/fbzRtl
-Yjx9/EhcbPYH0soYoJWhQEcEemRAo+I3MIr56RTWLI1gJYsymhb9ZsbhXFEr
-T/oYu7dM+XjJKYNVdTFE1/fgMUx6uNV90ufx2Tk+eaKoe7awlqFDmq1OhKMM
-ObKFxqMbELgM45zyxbcQeb8LlffSNLoSexg5owj+ePAUaA0EB1t28FTasm9P
-ftkWSYYR8ZR83ICgkJNJOIpa6HgDMr6dRWnLLN/SJHWC+XkhEyYbCM+zItoQ
-++fhfHw+z2OKM/k5G6GVfXYeTUXv+f7P67hUCyi1n4QYzjXc6W/3t6v02sJd
-ibb/EOm1iQyqUjq/PTmysLFIqAmnYjn5h1fkxe2O0LI2N2DD/SxF/1VKtZqA
-gqLHPFcpnBmmgk5NwrCtAbKQgSn2jhPHpzAjrFJieo+zOT7Gia4ACywreXwQ
-EB7DzScbFNz0czidcnz4OOqbfrZ6IgUAmCWsDGSsJB0RR3LNHz1Ui3CJEU6Y
-nzsuLCBc6FIcHP8MvUCohFTMZlQhz+fbis98M2X4B7fOuvWR1FZ5dLdMbKKO
-zNuC7iaErjnIwaCgJAQqiYcITEhgVEGRg0wVFA7wxBhOrlZqsDKF6/SIKoLy
-cR/Vl0UMSvQiLrZIkyMxhk+UpP6ElKzsUfvxxNH7vwWbs0evqgEZpsmCXXtC
-+eRTwBdMthTp8HuEaWkA8LqfDFT28PTaWh+kmKJMlSK4a4pCADiBNZ88TG8B
-0iTa6m/2d2wSPX30FPX+EyQR6/0n6y1irEoi2CXDL04iFTatHPcnXCs2L8Uv
-KUDJciwaC/sBkV2vsZqH2ToS8zEQs8JxNyTncGAx3BfnK8BmCbZ6fLtsVT2B
-fqVstUlstfn1stXbk9dgSQXH+zeiZyvZ6qxknYd46gKfAl9TmSNgK+ByRVwv
-Ubft+D1UxOscftzNIBdkzxgIdIoN+VEGEnWSzXPP+K9DtKJguNdea76J7Ycd
-Fc6idXr59nB/+NkXSi2PbWTphUKr4a04VJYB6Wlan/0hrwcYSEQ0a7V4GsPu
-C2b1lUt3p9Q3cay+54Ftdo31fqaAXxgHXKFF11VPnu6KY6IzkvUFGtH8hINu
-KgxUvv6AlVL9q8+BGm+L4rwogwmcv1snJfnJ22YBZ+3JcrimzpuBwvY8Py+I
-xlZoHT8AAgv+1z3Rs+a5p0ddF9OoPM8wKCCD82Nh+jYNZp4h8EtEQRkZulxa
-rbwKTevgWwkQJuNsemfLcCKp6VINT2yaVqa1RTRGK+l0ufdZ6JREYYGJUEI4
-AX4uavGmZb+FRRs8RJtO57KGUxLmZxEV+iviMbpiMcfliJwsqXwFA9/yBKzz
-FBalDvFUxQ9o8DxO5Q4pxTnsUHyBo97RdYol+DyrwQ+cSYrcoQShatOO4MAX
-TsUoSvkUiKplQ5xGZ3Ga8oNs0Nuq+DvTl/e8W+d6lmdnsExcbC0jJYPER5+k
-09jaGSBDZEE/evMHfak6qlsgu0Vvy4feX4Rg42gJgtWI0EaxKnVvSjDjlyzn
-t3DxAHZgw41CswK2vCK7xpAxoQp1K1DuliZV6znvqtkt8rBizx6cvnfEq9OH
-i3a/hbi42CGzf0fFOzTPwwCoTQgN26OWSyzPiav7xDBcfgC4fq0z21p5Zlui
-tw325PBrnVn10rH7zLbRRh72n3y1i7afrjw36NpLxRWcNB9RkN/XMkHjFYVp
-qCw36HdvEYzUSoCgxWArvgmmLnSmswSzxuXtm2OS8jEWgU4iehLeJM4YhUIG
-UAVjtC5M8J6kewXZBeTHJ8tqWLB7QKGgk5pnoQYSaqDerw9//r2FDVQCMe5+
-V2j1xs+nLhLyFS4+zh1HE/sNbskfycJVCiW+7sZ0js+aVxKP51xgnbO8PTh6
-gPcbtJDkJsdEAnhq95Qi1TPROrdv3WadtNUu3RAPJg823JrtVjycmIjvxfDp
-1nAw6A/kc5g/iyPYPZU4aNGbgtWOSYfQDMHCp3Z4Ht/YVOD04O8+fIB/n2Cl
-1Jita95tD8IUTjB5fWoPeJ9xmrCC0xFcyFrm+tkoP6CnYTWEBxWUH3gq1Vcf
-BNQvFuzj+z/O8ynFuKMvxLjGjF3EudbhrJFpraMPcO/246FIp13YNp2u15lW
-dpfMOcrSCxQ/mOlO8aiFEzGnhuBn0n0Pk9aZUwOpM2n1eWU7k372R353+PZU
-samM5f+HFrD4ouDvQKoSmnUerby22MDcOkrG6jc3xiypPdRZwNNfIsz/M4ti
-WVDO4fH50kz+poXJTYy/zc17dux/I9tabb4Xb4Bdj3/txK3YrIlb/C8WvnGC
-k2jd4QeubtPCD4cqrRb5gd2rEAXWxk7F6CgAh6WglEuYoEyOJnMHqUw+FGY0
-yZIku3SjvkAiwrQSjkm1CtkX8nLkUX+rdj3TstYu7voGx0uwhoTwy5EONtE4
-yx/asIQFi+ZNoW4hVmi8QGccro/qj0nEYHphgikwr20CqDnwjKoVBZopoG62
-NvuP+P4X2f83+GnKIlQ5hx5OZ2Gc4xknCC/RQXaSzbIkO7s2Mbe+fFE4wrL5
-okQ4wVizcQ7/BpRLkXITBvKKMYgNKqVEIuCUjgAFE4lh+qjinBJoIePCkJUV
-rhQKuMmucFZY5tTjxV83/sWpHbum/j0xCa1kbja5ReiigJJTVQSd5g57THZl
-xpTPbgYSgt2nsIDUOZb3BaorxdliO3bzSh+ljtDSKBPslg31jZ0sXWsnYnV4
-Saf1Nv6FSR4S5YJxfIZulKfGN4D/zFP8cA1sr7UFiroi/0E0QKcNwRxIZtxw
-8xFZcn4DwU7wvCzSO16kX62C9CsH6SE+IbSR5g3j6LM096EbbD5zkBk//2nQ
-H6bTNox6kinX5T0Y7rqjLC4i8R75X2iDhIxZAAdHOdUZdlGWzOVFfTomw2Ox
-/nn6+DFFguIJZ3MIKp+ce5jxLbKKypAPS3e2jjRjlY5zaqXVdOwD2muwWyLQ
-KLm5P1QbfRKfwl4zAfScMlSG0fvNhzRX+ZFdYzK13i4q0Znmz5wPoulMPxr9
-9PnWYYPyHooPaXaZ0tkBdi2hIu1a/Fb1n6fUrO/fJHir6twv8bRA4kgNYiiA
-H6J2fmTddTR4DPFVCTU8VkbUMZXvJl30EsdceyaqP6r7p9qA210H3Bb78zKb
-TPiVIoY081jNoLcaQDO8LXGg66d0h/moFeYjWPk0+BtG1a0CfKcrLXa845DJ
-DXYaslL9Bq9t4MddB34snoN5EBzCDkdHNRy3GmbVsmFYnKCremzxqH8Da/m4
-rJDfXLxx9yw4cmtRDM0lHBYJiH9baZQ6S5aqkF9OvixEUwoMNJT4e1D7JBaE
-8XZ4ZIjbAWwN0SJL+DrhLIxTv/oyM6Ybb7E26PenoY4/clXt+PkiTUsD4Z3+
-80XodF4E02WlVXCxkiTndxiK1obIqleF2HypglAeUqmjrmSnxp+D7IxgWJYg
-GOSpb9Ea2IWSOq4Bdll5DRpQXG1BlloFUpndjLdudDaFahaTmQZfks7U54aE
-ruK4Gp1tKB2pPT6ddqN1q41sJkLYTxeMuCSBoccNyctYLSCqS0wFRQJYSE5F
-uEc+crZp0Ecrq6YJmgVdVOijpVXoo5UIvhjPZh2qgDSvSHclWoyXXYSh/7CK
-0QHd+L4eWfDu+GC97s65npG1yFPZFVv9p+JFMNzesI8oeCT99eGbn3/v4Kt8
-+nign2Q8xYd2IVY+GI2igtxDcIjjpPC5YLd8mOgg596r/gRar4tAvPPPwfHz
-NJG6+2Yuxjfcxn4iN21rbX37eAk6NnKSDL54pYpo3DfRF7r6Dd6PJujFxxpl
-eRmAtd4WRINzQK+G1QWR5D8jLiFB1ydM8mv2gZjKD/LiktpbwY787eg8i0Hk
-1zKyN4Wi8O0DlUegqh//U16O0Jj4OKKeGZueUFDrSpZogaHU1WgU/iFar8kQ
-yQAjKpFVsDRDTxeL1Thv2D3559/X3FTf/762vuaO0HiGomn+a5jEVoUDk4Qe
-Fx7nar3zsFjQYlBVhGeXp+e0bhx5qVvgCtKNV7wVVD0RZDT0anfxFSRar6hs
-PDTBPjlsMvIxyOiOGWR02wyyvxSDjO6KQRRLVJCvh6r8PXGIVdzHWi666dIU
-tfLSV+Rsgwvk80amONrQqxWiWZtCYLDUCqvg4AWPci11FMpS6vtKcTRmqVEM
-vkvyj+s6bYioHPW7i3raczKIzc2kutzm/rpFv1Wjrzpwe1rfGrhmOfDacIoK
-/aqGjlGEg7r54BCcKrke8adi8xH/C7zC9yMUq4MM5ZnwVy0evAqEGGL0+dju
-yyiURWzXWPagBu5GbJdOgevifgRctzmw7lHkz0TKow1zr0wv+nHirNLUnbRq
-+ffEfi3ayaOUotlXoY8MN99dnKQZg0qJbe1swUzevHt9LN4ev3sZnLyw3wdi
-Ybn5jF4kZBMrQkrDaCwK6JQDFD2UXuv+J8gevXuetapdlafNNO6kfV2yeLTw
-Cmev1U5bcjz+sqALQRJwlMlN7eOP3QQBd0ccqLsSA+5WJVxky4pEajz54c/C
-A1QrboTfDQ5S+NP1MFURnJ9qs6d7dN/kgyQuSvSxqGciNyIG1vHWL0Q2b0ar
-goiFITM3phYxK6VoMhP19JfMU6Nto7AntJeMcqxDcKRXW25l9dO01jc9zH47
-D37m8yAI769C8y7SSOSto1KnbYqp4t2DOSQUvm6pJ0VIRZcqeKWRZB3Y3EvW
-dvvYbxz/+1qlSFzVLm6KZNgzBYeNUYxM7BjGFeAW42ou8etSa34cxmhTSW7V
-9uoA+NNud3fPdu9IE8AnBK2hcLQS6dvboYlub2Au0/lUcBXxUzB9IiCciYcv
-+mA98QBAPz7tOVvylXV34N0Relc83nn6ZFe8zMNpRK9GMaTlPcjPOJeKCHcH
-GXkBvpAfO8PsA6vlWeIaeM2GndN3sZHnkJQWEzWktQqTcFRmeW0t+QWDu4zy
-2n7oXNs3rdmwyxrtqfA6jNRWobneigYbmCOGdFSlTjil8VBLbboWbDZzRC8G
-D8sII/zQfkVBVKx3jzHXVTKas/xwn1Q0dCE3g/i+pl399P6uYVN15LgVzg0u
-b7fymI+vnO4LeSy8ukMeo4e/D/rih+8FiFsvfR+4UCnzcTCNiiI8qyrvN+FV
-dSlpgFOUsBTciW8I6DqM3m+DNVFZ4zr79Rt3x93ug/pUltoH9e4L90G9S+M+
-8PJE0z6ooHY4Ufeo0XjDN8+GJXOAqOXzLRgNgReZ9WEcGC5t2iD+fW/kT157
-DB17y17YHr896n5ja1prNN2sNHfnKvh2Jds+Mq1m/WALbPkP4Rr/drdqxt2X
-LjDLdYlPJuaodEAkwS9/F8v9NZ1kjeS8sXMVZeTnF4dypG/e0s/iLWXq3Lm3
-9Js79Js79B/NHfoVSX2Pf7FN9B9agj48xYfpr8NrfIZXC1nUXOMR/G2uOE5F
-bQW7dPUS6qAXNfonC4lZHmeuQ1Af7588a4f7TnWFg45JUW3IS4sQJ1SgSwJw
-DnW9w+P9g0V1e3DhtzcHcM7CE1bz8cpiC2sIOkIF7/KszEZZUmOAHp3d1it0
-+Rq4zzmtrRxI5bE27iZa6luc1Lc4qa/lMPgtTupbnNQ/opnyBVLBaXXUHIu8
-yIVoXVF2dSRq/Kp9fUZUJUtd1e6WXy+wZG5mcNcPjE6Zu0IOeuqmZtriyhnK
-j7zB+erpBgU+Nv1NDYamE5nKxR2OL6K8jAu5mwyI6fdDtQGnUZgWKp9U7tQt
-8Jz00o1KQR7zFTnLKUm4p1swRLKpLwwIq8mfh0hhPXi/kw32OfOQcSf17w3i
-/TSM24z3szakSVFDa9KyH1+a/VRZSAVXL0NTsKf7AsHagdP2HThddgd2zKn3
-dbFNR+F58xBNDbFi3S/08Pmpv9Cz1+DVq3KJy4r186nfPQZcVc4LK2WlpXmr
-HrOauMefD9G1ijNJXfOhDfQi9KtmVTusriYVzgfEg5mSInZRWVmmU8Vi8TnV
-GmzjWsymFRblzLNwJ9ruliqBG5MIJJgNTu6iRM7NyJYKAWmwudJP1ak2eAwJ
-avvKNK//gpjSjvy7gDDWsrpitW2yVRD+ybf4I1sl3leqqpZxqBllFegEgZ8j
-PvBbpN1dRdotxZR27y6hdV7GtIF8C637Flr3LbTuW2jdt9C6b6F1txxa530U
-ueKVTf1oZx2y2d/c5NVeeHlYKwDgu0F0jAnZdme26doTzWehltAVx5PcHF7g
-cLteEeeCY4dqSjmGR3MBxxuc/cUqx3/3ftXUaFh6oXRhh4XLRC1ri/RtKbxL
-4ezOJa67qZhpWHLlZnVxwRS0tJSai1Yw1gRkJA5IrAdHD1wt8xLV6FU4BZm0
-IR1hId8KyUoAjYtkAbFPHTCIWpoN+eLI+XIxju2sMcrmyRg1Cx4JiAEsIIcp
-5xVHR8SGyVxGYJUHpzhXECKarSxVbEGBc1oBo8LScN52o7CLqCxVynZnVUHl
-bLqErawa/pEUmcySFRad6Rmn2gfcgdVv+jT8ZifwBjVFhWdGETDX4pp3RDbd
-My4o9306Zm/saWQcG7wscjFUd1upYX0Ge+gHhcrzr1qjX0mvkJEG0RXeWcUl
-F9srzrF+HJbImJ+hMycau/mpVS0+EcF/olwbZAEnRM2xmAGJAVgylYTPHaGM
-YPeFpbxMQYCWpZLlGy5E1ZcpqSjVDtiAo3rdGdW2GFcoYfKbE+jCclf4aKCK
-cSsQlZkyPjjMLuwarngg5YzTzeaNkYrbwYslzQMgZrPLaii/zUZoyqbjEKzX
-awA3X1QO8JDt9YhQxCUjfOqMQltW11GxrTT8dqNaXAK2MvWSWRTthagGraga
-IVWHtlMK5lnlS1ieaYbSRrZxx27rAmvHK9rgF/dA8rtvFzSkppMYzFKQdO69
-f7tvF6Qq7VZ3K/rp67opaZrtlFiJfIsIKLDywcOH7bTxU9vdv146Nza5fQo7
-fOrSFqZHRHCwWYpG9pxq0mWJoJV9x+OPooirsagKR6DBXfLXzrqCx3QO3/Vd
-r2bq7171kFcYoDrBZlZxCKqZBNtgTAIsU51PpHK125AcXKRtHYl6Z1rXGaWq
-dr11df5/1rrIRlKXGQWrGLO6OeCYW1TMvF9xSP683KDcq1qhUXgFnQvq7B7a
-ERVmeQg3ZeL2F53hOt3EmWG9I0r1WliDud1qYo+u2fDDwI2ibxCGzs3b0O/1
-5qkk+lJUYdyOp/KmMiqesHtZIepj5ZZNWtLoRd189Kglws7B8PCgfqjzGbQN
-vk2Szk2mt+RL3lxM3IcOj1f+WqvLxD+LtarMWyoUcY8HV5VXdXEd5l1tX8q9
-XO2u9nbtmYf93kUxVLUMW037qNgRBlr/FjZiiAuoH/DB/1x+fejhT88C4w+5
-Rh1QHuoSfd0h/k0O8f1onsPZr+yt/0dzT9uUrC0L/rS+4tG5n6nyGCoEipwk
-9VupJ1j4eruK1lIGa89qK1mjT/v7InXjLXGjXNvIJx3w6qj+fdq+hqaPzTw2
-4D8+p3kmfav85jkDLMtyd8Rxq2F2E7bzRmWQdenRoIUyGl3r09OImyw0ICt2
-prdwaXM1pFphUjaW0GI5m4cwZBlFbHeSwJcPeIxz77DUd0pwbrGrlZIzjmqU
-0p0IOYDMvdjz4OB49GtwXf7eu1iXdWrlEaJwDFE0hNCiwP6pOQPIxeZJ5NEI
-C5+OddQHN+MoDB89tF3gO9l77ZeGFzE+6rU63VoO694TABfRAps/t+tvSmvc
-5mAbcGFf6XFZzQpVmmp5SsJUv16FNtyUC9DZtWHRFcM46UAeazPZ+sJUfi1E
-b+9wvWHLMnl8Hv4FNWnVZP2tVpnz4sK1jSfihZwzi6BDeR1wQGwLz+zJw78V
-maT89xKGDKrVx0cZkG7dlatKiboHBe+KXj/qw/Fq/2BDvHuD/zl4vd6vsJYX
-T38VjOaqUvjjrSxlLbHub5fNsL6tVUVqWMql3JSoD98eH73XhAmLIhvFoeN8
-VbFoKorA9DdVU4U8E4LsIpneVkwNRauBsVwpmAZu8jqzvNxkRLHjUFBzBEGs
-VaWjQTV5/VV8bc8GXcFIXVg4saOWIjADKiC6Dq8hahJPY5mjzT3+9+D4SQtH
-8QrEvWb9r4ij6fOD1xviLyrqgqDxA8d1yy1/mEoP7aTi7aoK6PK8qsoUCECZ
-kHMfryRgCuBJCGgSnMZAzXKpt8Cmt8el3F2IPQea4dAPE6p1mnHNYxYgiuQ8
-pxD2TEG1R313YBbLVo0N+eblcX/Y3/QJbv/kORDqWWV/v4LGDwHigl3e8s4g
-x2psasiefjOJT9gG640zN1AqJLAngtE8WIQsIF4PxsDD16IyrXqVRjmzWbHS
-nFSw0YEsflbG9P4Lxhc8Ps0oltcp7MuAvwyEJEy9b8NxMqPzPMObvBFMS9f/
-bJiPzaENwrwqrGfFQ1N8eKVZY6mnWUkRAfDrfCpjsjTewsK7t39gB4VmqSOR
-qyRAkTQaB0rw68mhHww+j8EKuVoF87czKTOaVEqoIgDMfEz35omRSnBuv0nq
-KtGKMhPwJsnl2AUo6FPtXrbD+ApzUTiZp7yHVdfvxaTnPt/nVBiSMLep9JvC
-A3EzW0YXzDFLsexwmesQB2v9kA52kAL92H/j0QZ2C0YkqPg1CYKVrZbsRnXb
-3evtqCw6e4h9OV0VvSqGU5Pp1E7HFkr6ng+7JpTrsPTuzGY3r9+aal+1fc3E
-By4TLy6Phz+rlMhzZkmmuWO4Noi/WYbxH/KsQO6YOxKDdyEDbeSFfcuFAC26
-g3G03iQM/TEuWr3v7Mgy7UMs075/HmJZwSiHrRaPCvbWGBwspkFNZKGAfuco
-LZCPCjatJhoTvk+x+VC2ZV1Wm6QF1yfRZ9MGkY5ffCGZ3jYHuTxdhDvMwJHu
-q4p1HLAq1zV1vhLBbi/jqpIdYXQS7Z6GXWS76fb1Cfe7kuzvbFZ+g6x8UGHl
-moi3YXSoS3unIn4czdCvmJZOLexaVWlV8vMWHQ0LZHmjXLeXBXGnUzHi3kNn
-TRcbdzZOGiQifPFZJaI1GWeO3pl1kojj5Kb2LoxFQlGCqAtGRaSvRTBaq7my
-YAQY3QRjvWEnwai7VWnWssVuT04tYzZp1rMhIH4ryxyd8wLtSRwS5c6SaeBM
-zxt5ft5oMDwkxTiox7Z2dEqcai+dRQfcRtJF73UfxGlArtPKJUxqXO314upL
-4a98fJjWpOCbB8R20B+KdGoXlD4FFqHnR9ZDrVibmGMGEpbiPaoDLLRsnFp0
-3Wh69fKrAL7Ur3Co+ToyfUId6YHVm8OjgH2P8EecjvIIK0fYHhcK3MnI8RXQ
-Kzzgm6wog5cv9kUaReNCRnxFV5jQJxr76OvDxKux7PLxS/rKVAIJBk4CMyws
-6vBtAl476BsLdBYbKCh9FSP4lE9+5U7Ar4lqre5SLWmuoKHcfa+X2Ed8R9R6
-lBH17mKgLzbRqwSpqSU/xb4OHeWM1LT+q+quGsCqIrNhaJtyUa8uWq0Bhl/F
-wZ70aDifPLxd+/y9Ym6qeL/oEortbxvIHdriICX+UnsT3e4xX3jX50Tyobr4
-ixwAhD3K2vIcFvU8S7wC1mjq03A+Djw3FBKxnW17lSfoA6HDRHwWO7GPVbfP
-8/FKau+5xqZNYVtspy7YLIVtby0DT74IRPRQtFttiuvpaZbQPRHyhjFA+COr
-JeY4o8a45Dne/WQUGW41mc0T5gj1dd8GcFjql4nz6SmLkDF6lEAOStC2EXKO
-sgoOBXwrQ6/JymIddgdeyGXOKxchI2CncUHn0Wk0jp2HzBbCMb7AoxUMk8TZ
-A3LusIfkkMhOQl2eeW9S8ixJgmwyWYV9tq2dbeTy0LPNFu4Ai4dI6Cms5J7o
-nUZlyFpQHpQowdsAyTi0L060eC/EeXYpD5hACEmP4jxEL8TVKHKDj6EZbiTi
-mL44nHw/oLhpjL0CBIDI01C+4mzqBH2GzPRysWmMorLIjwb/Q52GdFfc8Jy0
-PKbwLmH/+IWRyjnlf2htcgWdnf++mnnlvExUD+wLJ3WHeoA5lnd7thdWJWuh
-SwqZTMrOCYgkuMxghabZWZRG2bwQb0+O7SeWPU4KeB5eSFESTs3F56jizAUs
-eSh+MWkzrB4TQ3ZG5xz+EtMKXFNA1ywJR8ALaXRVUgABLkSGLwbchaawM2Va
-jueRSgoJ+m1Kpn0SzuxpT6UF5ahKXOCcBjtLYAdhckHbSWBd5p9jVjmHNpIf
-5/SSlCJAuXZGxX0dpWeUi66amE6tGkqrMLXy6VhLVKebPrrjaoXj/wqRwoSO
-94rZaKVJNFr24Ki6rCA81vZ0pkjQnD7MEDhKwJU15ROvqPPfnCzGF7A06DTh
-qw2AL42vIxkUTtJ79/wFHCXxqMX7FQ0XW+GCGMFVwZSbWQ6nl5ITu3gfwYNc
-w8NwkMExvOVgvuQxkc7PKpUvKhDpMNDnbs3irH5LC/9CpawFYT6XfmLOKOxs
-n+pT9JZ9pA6t/KY8EsFWfzB+zid5/bTdkjwSJwx51tJmMs8xNFXmOO2IwLpx
-RIAArPgQxHFhGV3mNzov8aowHWPrgE3xVlZ+GoegBsagP0yn4icxfLrVfyxO
-fv5dJffukJrh7eHLYHsw+Nv7YDDsD3bFIZ48MbiKzbu9szyiPwU18oZdzksw
-I+6Cryi8ygQzhh+cxeIDtbTxUHec5TUvMrYA/FApOAxoFtvmvMYF0k0tp5JE
-Sy45kUi/lwPOLZ3nMuQ0KO1kRAqisz9wjo1IWHRehlMMEBiklVPumlHKym2L
-PApr28brvSIeWJWBXHbxXikwj1hI2AdplmghG2W1lko+/ZVEzW8N1xfFXZPV
-oWnxIbq844AzJOxfg98EDoWJt0bJfMxUCsUkvoJfpVvAvXtqut3xX3iXWRLl
-ZERxjOfdSbFPzrMLN1CW9iA20t93eMHeFl67z6HaVpQoef8wqUnzQ2pfmoba
-u0jDEPwg6usILrXfd5JF0CHY1FbNbthp6yMex8x/b72QVo5YfM+k3L/ag6XJ
-7qRMdwL77ccX8kkUujR9U7mtuFiXJzvwnO/1Ocu9oJyjd57zoLax5oklK7mP
-NGp7k/8EyQ3WDxih9Ft4tV55BEDnZTaMTBbdxhNzaZ2YWw7HsxCrctNLNOtt
-tTlmuSXJHMdy2TCXxqDdz4e81P83RN7WqtZDMWiuai51cVesgL+NnDUH2ALW
-BBhpTMlUYJ4wLHaw+egVGxtYhWZom6WfRJ3jm/jXL4x11ovVJC+9Q2uQrNzd
-POL24PTMtXDcOwD0Od/0To6lqOJ6sAJnc2W2qNDuWNXfajC7KkiFV7eFlOTm
-jkhZSqp+XXL7pKJyp8tQqo7TrVNqFZzKrAxvEyNrr6tYiPzKyoF6WcnxolLU
-e08m7K6X7/jQD0EKEpN/UvE1dRh3jZVmJaf3sn+r28KORFSrRuOUBrjttTjj
-1Cip9b5DA9RXg+S/RIXPJqRMjaCfN+oXwpZw8KBnejCmz9qb51E4RtJZjauP
-uDoMspgcehp3SJK7ft10iw+ZfCxtJecra/kD6yakRQcD4wsYjQ3ivklc1O6f
-W8JAOAGB9qxpN96s6RbZAFglntO3KIiH3f/NL8cn4ujtiY6gkACr62UgmHVq
-k0Mo+KwVdZL0GNsBK3xmE+ExvRdu7Y4SCzsFxDd3vVGrWq8zwywbTFThIjfQ
-5va5aLE2veuZ0lAd5ll94nKDedaZ2TDS0ryMVZzmxBhW8xb2fWc4lavdXUf5
-QPSwDinOyWQ6XRcnczYpKrxoytEFYYEimpi4u9rw9m9VIGLNyrK6lySZzEbw
-JirPMzcupJb4Wx+qFh+unQfQdvLgRIeFwaaF306zeTrmna56m3OWPJDzm9WQ
-nLzrHmnpjnb889tfXh84spKuLhEHdNk5RWu0IOG7Jtn31FRqnBcq9S5n7Z2q
-YIE4hQNfaGQrGwG0pZY7VS/9QJ9JaAYhEoaeeLMKIb0SglZhWYxV6QWsvFCZ
-slNzobHiAs2DGcAM7c3er3nG7u4rVv9pZXpW8ViNntXdAsIEr9QDk9d5qfO6
-kShioO7mDSArQeKpfqqtWluX+JUS3EWaB9EVAIFzVX5WO4A6l1nqjpeveH0y
-hZOyDxZQeA8mNR7HKnEAj8v4w+e8OUt5qUqH4irVbTFOemF0Ho0+qF0ZFWU8
-pXswrXe8xbHxAqn3Cv673m3ZOAPcohSW3lVz0lVWVoUOIuW5AmBGcVdKzyo4
-u9UbRgXXIhYSRmX8c3D0iguDWJQlXxA5SxqM8SJ0zJfQxBH8oDKJJ36JZ6aA
-cqUo72oWDH3JyYTATmfkiZhloNDRwWCVrNXF88Ikk+yFQUxW//rCwX/gf/8N
-P/fvfdwVf4K5BNewsylYRIBhkUTfrykmPaE8OL/tHb3iuL9o7f69Ipvno4hC
-S2D3fgBr5/s1lKxrwvomBTS+X4ujchIkZAZxPcyfNgeb28FgKxhs93HQNdpu
-fxLHEdiM6LbdlxFMfHUobSMko4WDqcbCd2yg7MfZaE6mkjItQlGAWJiGHKIf
-lmxMcGQWlaQF20gnlsWXMAXKzos4FCknk0e1AUqKgMKuLLMRhnRifBdBCgtx
-9OJk/+3RS/Hx4z+9f7m/s7k9/PQJzbz3L47tL54MtgefPvV5FpIHVFciDcGT
-IZ8F0kEneoIzOLXY0LEcWpeBGR/E6pJPduMp6q4A8pjBHZ9HwEC94+Of1w22
-m1WkNN4OVj+fnLw77oiAO/jJ62MCIsmwvb0DI1orKrP245LT8UxeVdJa4Idl
-niX0hhJQP9rbf6Nwf7KFlCYwsDAX8VhdLXBx3wyDFED8jkq5rvxOOgSpihWL
-ck18GZOrpw3ak9PqhRjrbh0ai/mpSl0NZDQVg5sAKXYxGXL4VTem/MEIejn9
-F9XWF5LqnlVTUc5MI3sNVTYr4vkpGe06djlOLzJSjDh6DicO/F2NK+OUQu9w
-EUcIhxwtCWYXfEx0uAYjd2qvYnb6X9GoLPROtPcpJ7Pj5FywBWVWLURGqVfp
-Uz3KJBwNRkKQT0TwDIdb6zLH+wc0F5iIBfO8yfylHzcCa/JFaagqbGPSOIy5
-1ArYScfG4xV95dAFkkonQ6ajKinaVwO2B72MKe6FIM3LmMu74MjMgSS2Uba8
-f7dvMcWGiqwAhgXLKcR9REKL4BBMik0l2qXZWOVWllNEYiAfbgh5yuU/cFjd
-l5ePnH3EPjBENJkgoWVsnZJ2FqvGEyZYnMp4OvTdMUNNQwwOyOZFcg2UgtOi
-NM6KSBNJAsF6CZjEm0fR4lnnMnDqxzDtpXQm+qq4M5eheNHh3JvlESadVjKK
-+4TkcZByW+19FgeSulVCqgxVVthsgUVKStDPlLdvnqDliKuHYf3Z1NArSi/i
-PKPjdWFvh0Ipsgo9gNmSBF/ozUtFFJrYsD90N7clMh8/fQSag+4Wrk3iIk1L
-YJ5LANpnDXq4d7Tn0Z4vpX1hUlP+8v5QYbB2+OLkpfjrm9fifXQWg9C8XoOh
-f4Sht3aePPn0aYOhnocYEzzmdGTErvr9WxwlY6bxRMWiWSjuIgZsacCkYOBd
-2B55uotmwS659Yrdq2mymxa7aAzs1swFlquMGy4g5eAflbtM68MXx6+oBcwA
-Pjp6uPdM4gensgKxpbmixKFJok1ChT77Cqv7905ckmJmNjiFUBc1ZVuiybPJ
-Gn1G70eBg44Q7hoMyzR0Vs8lAbYETP3zPFLorUSld7AE8RV0TVzayaXa5SLu
-f4UfM3n85AUcxYBHjrIS2rxL8KkmHlgwYp1amzR/2Fo+SWHfkjqrWRQkZgyC
-QJyGow/4O1qY8o1KcBoX0tzbl69WaJcj3KeDp1u0HNY5kJTTZF7OKTe8LP+j
-7iTGeTjh0WAExioaf79GRrkyKvdG6CCEXccpvq1dGs5BT8pcKzg13NK4Nzht
-GD7Mx4/jHIt+jzBXK7oePpA0eZ/BUCx5fo2TUtat0/sZCFGSOL6Io0uCfwJT
-fBdh6S5sSHWhQCUyQigI57k6GU7J1sE+ljkLtn4206QV0rmlG1yG9DIP2ET7
-pj4Ax4z5GuH/AYbx3U0BjwEA
+H4sIAAAAAAAAA+19aVccSZLgd72n/+BDvV0l1UQqExCS0FZXIZBU7AikFtRU
+1xxvXpAZCTGKjMiNg6Oqtb9lf8v+srXDzwiPyAOQ1L3idZcg093c3NzczNzc
+3CwIgocPRtk4Ts93RVVOgmcPHzx8UMZlEu2K/Ww6zVLx297xG3EQlqE4vZlF
+hZhkuXgb3kS5GIjjqLzK8o8F9grPzvLocle8HTg9qdPDB+NslIZTgDrOw0kZ
+xBEMNhqF01mQT0bPB8+3grO4CJKwjIry4YPsrMiSCH7fFfjdwwdFdTaNiyLO
+0hLg7YrDV6evHz7Asc/zrJoBsvt7R+/Fr/ABzEW8wQ9hZgDuPMtvdkVRjh8+
+iGf5rijzqig3B4Png03EuijDdPyfYZKlAPUGMZ3Fu+Lfymy0IYosL/NoUsBv
+N1P+ZQQzi9Ky+A+acVVeZPnuwwdCBPgfIXiKJ1F+HmfiZZRkZRnzN1kOFD7O
+PsYh/51nSOJoHJdZzp9E0zBOAFPq3D/jzj+l2KUPwzZGOSwBa/GyKuwRfq7C
+qyieM0SMPftn0POnC2rvhX8AawSLDLNIonzJSYypL04C+nbM4VVRXsAYbyPx
+Iat+j0f8XZzCur/q1z+m0d/lYXoeOYNFBKQPI1HjnzJq4h1vL4YJizdVZkF8
+XZVVHgEVxGk0ukizJDuPkQ+sEULsdl5lfWTbn87xQwaPmyct8/isKn2M8HOY
+TeMwFf96EaXnLaskh/gdm1xw+85VCdM4SsQ/xw7AX9L4MsqLuLwR2QR2ZzoK
+izKqrUkft8ZPifqyH4761cfGAG/CsxxGiOCXJJ6eRbnDwftxMcocsOfn3O6n
+EX7lX+U0j0cZbMoYmLtlP0ho3LQvm3ZwzsFFXl3Cf7PxTTdhx9iwsXA1aC9j
+kFZRBpLjtyxLLYCvTj8cOuDObm6q9KcI1ryfR/2PeQPUh3gU5mPxL3ESJmVo
+k+70dN8BlVPL/iW3/GlUlqM+M54D8LesArzeRpEF6yScFpXiAAnuBtslUdQv
+rztm+i/xqEQBns2i3ztX4pIa9hNsaK/Dwwdplk/DEhiOGP7w9Jfg9D/f9Hee
+P+tv7jIIqUD+zH8JsTedJfEkjsZiWiVlPLoI0xSYeBylRSSuwktgt/S8vACx
+cRmjjFf9qPUsia5RpoczAAISHb4vxFUMzYsYJywUuGwGoMNEdY5TYPJJOFJ7
+2ZLWetqEvPgQsVgfE3Ah58IN4bMIyXMZ4V4Qm4PhM/4C+TMCDCaZAmP1U0R5
+OnjukuRQI0V6FASXQhsUU5gWM1A5ImWtujTaMJqN9FGYjy4A481BO8ayi8L3
++dOn/aGL8dop4oXSJULtN4PBzoDorWvXsWg44zyaRYBdDrygJj6JwXAQqOHD
+PE5hlBAHKG5ASE2LtaWpQHOw6fA6OsurML9BUgzbSaH7GWIMBjVavAbJKcIR
+LF8hygxxLkYg/YExYErTOA2TQvTe9CfQbF0E4n12BV8Vs2gEi8v8jiIaP4Dt
+wGRZZYKDgT2//1klOLfh8665cRe9WXd2ajPbvwjzcASziAtYlQLVyCxLYEF+
+52Gn2RgWPQbUc1plZAWYTggyohBgQmGHPBpFpIeAr8PSNIlo5bvALU8EmEHL
+Gg871ph6gSEIH/pl2HaD/U/U6p3n8Zh5+NeDI4exQRvhR5M8+l9VlI5uqOkK
+U8LR7Um9AwnMQqdrC+tu9iw2V5nFPn5kbenVp+EIzwNgCyk8B1vd83CE50k1
+297yCSMSksBvh69evRLDwZuXeyevgg8g8NtlKWzLd6fH63NnA2OC6EITX0gE
+VpiJ7mfNZKumCNbeSVRZzoFsKOLzlHYSEB/EIMAF+QnmZRGPo5yXaGn0t563
+bZKdTvSx38MHQRCI8KwoUTDg36cXcSHgIFfRAONoAmjC5gckwcwf0fLDqoz4
+8DfGEyMe1uDUBDNIYd4x/o4zpDMbTK/ArUhKkI6K1AUlQ4JTB0P1HKzuqC9w
+5IjVD0ImoC6cDcAmh908hk2YTQniWRUncM5MLdBNbOAMZ4MRISgitBvSMYAC
+AX8Gf06Rj+DPsxvErUoiKd4IUXUSpoPAJD6veKUIOzhalqjNZuFZnMjZFxWo
+5LAQv5pddgK2zOgCBlAccaxZ9teTd8fFOgJ7+GCCGjXALQlsiLrXAnGgdO+R
+rXt7KJXW9Q7oN5dQH7PFh9f7dNLGWYKKTsIRQtArwxOHgyMyZBnCuo/ZBAsB
+/BX0kOMTYeJ0lFRjXKIxnAzhY5hTxyK4K9lXjDeNx+Mkwr++Q6spBwyIxfAT
+YFwC+Mcf/wSIP33+ZPDpk4iRFf0sJKqC15O+of7ucmG3Dblg/PuHaJrBH+/z
+bBSN4Xwo9sMkYfal/mlWahXO8lTSWUzDFIYk+s7yrMxgdxR63ZGix5Z5t++g
+8V62F73jV6f7745fr8sp7mxuDz996gtxqlZETY2gFLDtgUmRAMUU8IRtTQJS
+7wFDeaI24HUZ4wpNIzSe42LKNjJQiPeRyOhczj2aW4o+78uVcFkqlku1iGBQ
+m5bAzN24cvZqo3ukAMHBLczCVG9hhOrKDlZ7aGbiyml+Ae0ymUh3wytLCvdO
+X62LCditwAgFLuNVBESGf9MsDU5fma96Uf+8vyFmFzeFPooovqgJCLIKYXPb
+7jSlvrTSivkoRAj2oDHLXDC2qhLVAlK1tMkvaaTmh2IHPQIERA3CJJA2KMAi
+Cewuody/HiFFkFoF1R9//IjMOtzZgv34xx+OWQWf4GK5n25++sQaoS7daJxl
+JZwc/ykcwz59IggNHPxMC4KqIEGGtGEix7yxgYFqQrDQIsBITx4X5Sdt0tew
+pJMqpy00jkBcouAoImZEJSt546LEIYciL2VN3KYA+QY2ejACBgACyhNjUU2n
+qMYld/zxB27i86hAF6qcYpuctzF1ZX2MCw//LQQK5jwqb/riENS+lhU1Ue/B
+1+iGWKoCGEvq2BzpkLIAtCTADOFlVQEnGMnbGyAAYEWSInOX5eGD7nWBabfS
+3UchYQlTozWauwG3LRwW9JC29D4yoh4d5AUchiKxB6fuuITNXeWR3rC0lCjJ
+n21tb0oMvvtOnNKpEV2ON7QNjrOSNYrE8EM0QTGcKc7e3t7R+4g+ePIMN5Zy
+JXyMbuggWrDCk3MhSGo+vN2wcWmNjQBgjfEsi7xQI0oBRkwKgpTldFal1nxY
++UqeYwyAPLBua0e/nJyubfC/4vgd/f7h1V9+Ofzw6gB/P/l57+1b/csD2eLk
+53e/vD0wv5me+++Ojl4dH3Bn+FQ4Hz1YO9r7bY1nt/bu/enhu+O9t2vN5UT1
+IA07dMUA/6FtFxYP5PSZbC/33//f/zPclnPcHA6fk0CjBRw+3YY/ri6ilEfL
+UmBe/hPIevMAhG8U5ggFNTGYf+huR8sBhO5FdpUKYM+o/0BywPscOOQaW9MV
+yzGei4/DaaQ44LA2gQ3y45G4oAVKs7FUg6yyLVbOzv4LVYzWijMaCiZYFcq4
+o9sPdFfyd4BjkY3isFTmHbSR1lIO6m2WpWPNHtou1tvv4YO/qenwz98c6eD9
++RuzOJyaI+yeDAKWC/wd3RIlqLfsz93uYLj+FX4ePvhjV3xXhmeBnGbBJ60f
+1t6rv5FInokwemufcAII7RVdZ+BWROfA+yQKi0jKyYiG0qShwdOKToRAOW1y
+1DiOpN80u4z4C7AcmVrfaZXMF2tHTCcwCUvUCF5NZQ5dNmlx+0oDx9HyG0xB
+gmOTsS/BKj0j5QV5BUCTNzQyaFnblFGm2FpjfdZqqoDl/QTMwOxKEZwg5VFV
+kP3lMeN25cyBGXB4gqw++7PYE2e4IMyDfIi40QKQ0CUlHhZN2buzOXjC4lMe
+naUI23n+3CiF0dV4GowugmI2Wmbk/SzM/YcyOZZruOyT4SI91zCWPG91Y65Q
+HK+GIjmp5gwpkW0ZmHkiHU3Olx7XYqfjjDylYh/aoUvqtfabvcnDtEIvIfTu
+He+/frMulJOjlTTu6vEwRZKVwVU8Li9gRA3SoHv68mAXrQs8MJLYn+lDewis
+KQWS6JEVIk8i62qEqE70Dmg4/SQuSvaOSrjOJHhHML/DZ4G8jL9z4MatF7Co
+QnFy98OgUXEf5MnKyoD9M0svdYRhIUMMAnDenf6yIY8wSst5TjzmYPB0oNjn
+z+IkxmU335EjDyTGOItIbgs4cgM/lZG0HrJZlKtTlnRkkf4FXZFGG3W0PrrM
+Wx+EbSy7zWWUjrM8UNcF7inEKHFFG73zNmwgNetB+iBwu6o9Q7NgP02AlsM9
+MF8B5+QkPEO5U4Z5GcDErFEAFKkdaiHo9h74tVUMGhP2PErhgC7DA0Dzztia
+ZfNHqUrC1Iz9mH+PbCP2GVixxAQEh5hLaSOy2RgI4mgWwwJJ+GiwWoTKO4Ys
+7TfJcJHNvgABYNTGpGvzlaC6Z81wGvMDhc3f0wwC8ipbKoLYV9OVzoc2ispy
+sYlgDSIRq7lu2Fxp15hE2zpENHhUB+B9MH7jjHQOd93eHGxxV5sP5DlKWEer
+qG4k4YkanZ7QfIpHQfO1pqAEMgM5MsUYmcLDHEUZzRYkHE8NOxQt9DCmzmFw
+QHEQQQkmLYZdPXv6dCeoZng5UNeghLN/xzK/WjOfy7WsojXXIhDJuKvsWeze
+xcEW73roL8EiEM/etRkOznTx6EIbx+Qb5SMi+3FoviD9wsswToghU2nYjKRh
+oy4EY+0shdUshHPSLKR/dKs/RGDKSYAetI0VxqGDXji+xLAdZdJPfxhuyMlM
+ozCV1xf4DWgcA7UO7Ubwidb6AO0qdtR6GgdDpJHniz8NyTevBmpltIZMXIbH
+FMksHhNLsFm7ZFSQFtMHLZKxMdelJWQLLWx+DRWuLcTp2OELy5sGGix6biVx
+8DTTJmq8yMBR90yvn/EK4iZpExo1NUJgbD4qIpTIZZSQIeezV2qH4vrXGxJw
+pi5j6s58UcDWgHNIpqMj6IQszjI4K5JfJqgNwRDhVPCxaJLKbJYViSRqrLos
+YbC7lyTwxecmRmM3rUqTFqtjcaoYTPzEMd9/bhpZm3xV6iCIJnEW2EJRC6vg
+N5+BDhQNwqFJgX0dLw+TDWJkck58gDOdnbt86R0ARBN0m6yhZinW8DIqGitz
+gV3sJsQPz92ot2UYHR0c+zoKPczH5vzVREu5U7TPlkb0nykpEFFK2Cw/D1MZ
+d2Wf8DonzvEz6RgmbR0POWxLrhOFRLjgC7yh4lMrO7xdTaTVAQf+S6oEMVAj
+zvF4Gig9HeCtl8SfHZtBdI2Gf1wuOAHreBqWHKENxMqjhJzb0FBHi5rhwZyO
+p3gDBuiO0J+Fd1zW8isUiAx3Nj8aAYYFZgnKKoV5sJRom2P93GT1F9yfxZi0
++TDERt7nYmvgx3haTWnHTMNr+l320ibbhn3FTcaUseZkW1L79vLUuGz51ZL+
+a2eLWStHK/PwgRLQen0a3EkRVPZCMZbjYDaF/4MkSaQncP7GR3dtydZ/SNei
+GCuljn7IXcD9Mzm2hNy4QQnFOfBOikGj1bRi7ts/ICzfHx305U2tYlU15mi8
+IQDfDQ1WOofUSaQA/koiuTZVykcI1fYHMentH2wg/HWaPLmMiEgBy27lRWt3
+71gRkpZDlC4inaC2T3RtUqT5fJAtYCjslsHMivEtwAwGEsp0dSg7OzsM5Lvv
+KD7yLek97MC/feDHJw8f1I9x9QuG2smXjgsAT1oZ0SyPChI4nvOVfZMUWljo
+OLH3IfBV7+3J+3WBs5EMRg1B5emjHt/cAt+ocA19AyFO5KGz9+7oZF0cReM4
+FPsyip6eTone0f6bdZZwzix/XE3G4WkOeNYmQnGB16NnUe3mzGoHM6QJQjNF
+P5xgwbPOIzjcBUC7iBrOkCgYZYz/FtE5RcPQStXpG7fqTBmlwpFLaRmfV1lV
+WN1Z+Ix0pPTvHBWIGqPtSM7X+jQu3UewQ6oOEqaYjZRiCj0IV6k5p6Puoqte
+t1mhCe2abh4OG0cgKsZER0VYfXFGW+d7vHZWEpaigtnOwlYb7dTbVKzeTnF0
+kDEwhqvebqjrqF79+o2iH7Ebwq1T2YpV1s4aNK4qvtNvMK/eojTL/w0/6nop
+Cadn4xBE53D76VCkU/EncSyum+hN4SBb5Qwwna4rIDWSHSxMsuFSJDvwkqx+
+HdhJMkvJ35JkE6TW863hYNAfDAbizc+/L0I0aNZNNbTigc3vhnAkT/TmW4ou
+6EhThNmg+5Kx2jAWxHP7xvLk1zcbcqXARhtu9p8gUXyor2+oNxOduLjg8ULU
+gr/T32yHLzDKAaU8bJCbjZaFZe3UWNiTX2Flj2AhYT6+xZuz/Ihm15r7RVSN
+aTYYDBIJsbCjxNmFF1rBVdbZkb6kWE6AW78/uwyTygRpYt+80camOJ64bDTW
+tYg1Wpksgm6NLs+t5JnVUly9wADdVciAJAzaBdWb4VGjrtVbR27yu3Q0RAUY
+k6zm0brcaDureF1zchNsKDQ30O1ZJWPS1xUpVyeOyHPzY8zqnr6YoFApNkzW
+VTBjh4ukBqIpH7wAfW6hGiRpG9Gy6Nhp8ifo8JfmYLz6r0KQDbhP9Y2vn942
+S0QxR1Pb3nz8o+l7txSaYta4VRPrGbcA7bom8EA3Sgvhqqnzg6H1XR1ew1fN
++mTmHkXlZTetDRI6MtSS6CFtiJBtgl+w4I9WoDM5ZBoEMe4KS27L+Tti3YQp
+mXNnbdvUpOb3wh9ponRITSyoszfKuAi2UnkVwRY3WBUvGCi0s0NYJiG+xIWT
+jHpaGaNXZtKhijAAYkyPE+T+1COb5rYXZ2FqKwTD67tGULoibotgfY8qrmuR
+ie0unBaxaOLvLP//hv4TLwKs76TfM2SGDM7ichrOtChvjSBwItCVougWwN4b
+i1UlcBuEpQVwG6BbyF+bcEBey5BYgVAAYHUaNTqvQJ4GjBUpI+aTZYFDH8bP
+k44xw5A6IBWwgS8ElBFZ+G22+nYyp4cXZoSmtPfBXtAmZlNuZ2PzCVmZNcel
+LY+0+1yLFakDQESkftR1aCGGFtM7jDKPIvYPyeQ26H6wX/BwJO8b8yKJ7V4A
+P4rjAHaD9MZFu83g5gcPrGtm36UoWd5/CgLR04p4/UdpjuPnuz02DvBAuK4+
+/xt3oUNi+qPgMB0ab5c/cwCMPF1Hnq6jZlezRTQAia4MG/3RBiA/a5tyNLNm
+awcCLzxh2ujyaOyEvNJEVKhcHk3mzp8gjZaF5CfHtSYHzcgD0APPJeNowgPX
+fub2I6o2e1ZxWj7zLwPeMd+G5+RXnKYjwFNWNcMrOJ60AfM3A4zbrrvfNFnY
++mnhZgsmCYEaSDmpojobhXkO8oFZJf2+A+QiG6Txs9qO6c2lmQWmRjMHNWvr
++ZAyu7Ct67S769Ttek34IMZNdK5desuhvxf/Jn/7j0YPsYj46Ogy9XSZegjo
+Moj9nVE7ZO8WjTbeZq1zcvssOi1Pr7aZeTaxFRuh97Leyl4Jhi1USCSvvpIR
+NgoIw+LmlpNQi0T7Ez3w9pxyflTDDXectr4Dh9vWTN0XbDxfjHUrzYVFgqiL
+hKYA8GG6mKj1Ctl7Fa/zpau72+dL19Up2fjpIK0vFNnP/nO5v6kga5G6Cxkq
+S5soC1koYgELxQVkwkna43xrO32u4WaBcgXhopCWEm3euFGzBnO3Q8tGWF5b
+rqQnPRpyGd24lFZcSh/6NeFcHbic9ltW792GLf6/U3z+uN4HkuuWPHYsf+BY
+4ahhB+ZRoJDZxvjnusObMqqttmfzTDjBc86ozjeNftZ7O3TNYezi9/6p6V60
+dtIlYWQdjWk2QXnxe70XrOLyvWzqlFUqH5r96PQ6r/eCeZXXeoFnmIAuAKSZ
+LPzn+Gy6QJ/wel6ffIVxmn0WGqfMyrDRw9OHGMUT8NhkGk+jhtjEZrW3cRZ7
+1b/ydrdGCZirJiDgEUrLVz4o7Yzawqm6Zzu7tnKe6dvKtPP7trNuK++K+ezr
+5ZGOfppROvu1s/Gy/RYer4WdW/jZiaWsKWeA53zdUM6dTOBdR6frcoLL7rqk
+9HK6Li5Yuru1yha72xJirLvboqMtKszsbibzKi1z0aZFnfB2rU21z5s7/9MD
+B7b7LZhv+A+IpP9osJr8wu/pEqhvMV1Wo1uvzriiRaXzz6qKvdZ7KfVe67vS
+lvnbrXbN3261cVZR/nN7zmHoVQyBuT2XGHPpfdRtGtQG6DAQdEtxCzPBA6TF
+WPD1UH6WOVZEc5DlbIlm/2UtCg+EJe2KJoRlrQsPhCV0/iK92zV/s/cy9sYi
+vZcce2HbQ6h+HRaIsGB32CF2s5VEqwNgFelqA1hJwDoAlpV33Z3niDy789KS
+trvzciMvJ2/tzh7rxfdTN0es7NSUAbH4vqWjkobBn0W//1j/zzVsHkvrZcHB
+PfK/dXz1s+j45jG58+7vgYVH3fSpWzwahO95nwVoWc10i3OrRkk+RAoowMJG
+xvkCP65SgGJ3dd+NWV09eqthhno8UtCzrbX9YznejJAZx5NJQJgF4ygJb+oQ
+xtEongLtNmv9Rhd5hk+nRoFJcP/jnH4j/TYN7G/4I07H0TUb4H+z2tDHP/oB
+2e00gYVNZatN60rYE7Ez9tOC1Cbkm4j1yg5mgn/5pqI//7F7KtjOmcudTIVD
+ocK0DJKs4JyCLMTwT7w5SKsksec0Tuw5wV/eOanP580J2jlzahl78QnqkN/A
+eumnvdz8498bqIzfnRx/6NocRZpbPUAPAAhXkdR7uxqhRfkYgja+8lHX36jJ
+he0dNPk0eguS27OPDPX+YvvkPT++PWLW6yysxoFXOsl+O9s2DbMkCbLJpGu1
+fP3I5JJXS3bokv3TNH3quKrEd83R/byF7VFr++fXji2Nc5FHxUWWtLkafP1g
+kmegI4MMGLaNQi4vZ1UJ5Ozu5fYoa5JEshIoCn5NihD4M9KstgyxuxUfoyvP
+YDavaI0o31dr/T9H37ec71ougVvfnmvX0TLm+rJXHctdctQpEibSKvsakV32
+qLDc2WC5w8By1v8y5n59SWz6UIYzszQt9pvvErFOhfrx1qOh65NbrIs1w+Yx
+2OrSNU2V1R+M/M8y4y5c8igcY8R5DZMW+ixLnE5s8Ga+Ivjm7YwhhTf5aFds
+it5NNWmUEA4mFrx1p8LJa15DG3d8NY5LibVu4ChgoX4OCiCIruFz2AT5Oe8w
+VgoNADNKCOq43tEvUpQg1fEUeO7qGFe1mGZRlthN25ohLYpSt4R/1BtLDFcH
+pgzckHUdxE7FBKwg9iOTRNoJY9fB69hLxa17cnL/gU9CCfKlLA427A9f4IeU
+qpweO61VebqLXXeJN4vd62mymxa72G23mUaaesuc5Cro4wUnL7L1H79FXcNi
+sL4CsAyG8gVhASNq++sb8Wt0tivE/7goy1mx+/gxZmzFEkcfo5ye/vRhhMdX
+548pwcFjVcMQ+r2Ni3JX/A8sj1hmu/T1T6rDn2W+JSHTh8MAnvqp5kdB4Ub9
+l7VCqR5wvqKyTXjcqv+yXj3WA7BeP7YJjFr0X7p1Yj2QPGVOm8BaCpz+mRfJ
+ys8hF8pOUK5eXalMFk6SczeZucqvqapWmNpOnDyK86hYWUTLzNRwoq6v6c1L
+s8YJPzWh9zG9RrZv2ddbpmTdvKfptZZukgCcfuv1ROz1+jB9vRb72ewmj88v
+StEbrWPBuG0qkSxOsdqxTheLZ3d8U6bdNipZLea8oKJiug4JCgmg7F6SCIKL
+uZOKKL+MxmbQD9E4Lljaq7wqVUHZeYqsykeci+csTrFWCdXQ2KCcOLI3iBv8
+C4xwXDpdTGkDnzTPMHFWiY90ZlVeVHBUh3UyxZew4hEVN1A5Q2AxibBc/MKu
+Q8JJAj5g1RI925cnB7CZuQc+ugbcYCUAbZUXZbs/UnQwVHyk0iu+jc5hDd4j
+hxX0RO8DZpWSCYSo/YFMt6x69JSsoeLTUWTkjEScwtTWDWWJoZU0VUV+nNIw
+BaaQpZxBqgLCCyx1ojIBy+IEcVlEyYRE+wQ0tkgIdaxdNYoKezi7cscjrNjx
+aIP/xfob+Luq3IG/U8EO/YuEIdtx1Q7zm+mvi3Xgn7X6HY9kFjgYc++3R5wc
+4ZGq4vFo8SoeOgGmW8tDDLdFD+mBlTzW+Ves47HuLeNhaHgjFivmsUa66fFj
+wfUj+rueehGggiqgvV0yQheGoL66OISEpUDQg2ZVdQffoZr6E5IZZtWZ8pNT
+AwmOVPo0pJwYvRuYBhyXUjBTxuENZXHQQFFcBIPtYGvAutwjjlEgE735KeyY
+pbYweZR0M8WOuyq9FtU1OaKkDQ0Tg8F8Yka08RkGg2fBcKsLn0N84AgUlduk
+GyOseLQsRo+/h1+/F4e6Uh3++Zhx1UUO7JDvLmzVIPrNZTe++GpyV7zB9LVh
+QomGKOlDIRHGZDUBJ4QK9jHkA7hA9e+9Pdlf33CSRqFs+gCCFii1oTe9cCtv
+it5w8zHWtVzfFYtUC9VQvFVD7XW1qEWB6hyCejWeKnoJrh5hk/KF+sZDSyDR
+vnq+uqYbNui4OiWJggbMApS8I1J20LKbmuNbUfPgXqlpICzOmW5xW6Dn4DEW
+wV2anr66vK3ktAKkb0fP1xrQfILiG+NWgqIMZ2BvUGzEqSSxgcFUFA7nfl0E
+1uStZ/bqkpZ2bjCnVM2dS013r7dTTjb4grKT6Lc5SOuMWafrHOYkCLWX+19W
+iqoWX0KaaurWk6h1cWdrIaUvxp1etlx9W7fu6iZXEt2Gg8H5xe81vqxTdA5f
+DmUSsa+KNb+sQiIKPrk9aZ98o6yPsptPbk1ZTjvyjbJ1ebA5uz1tMX/iN+o+
+aBioHiWFZYQrTGAzyyPKI/uiXXkZ47RDhbUZx3LsnZlv7zTQ0wvVhl/b0mNq
+y66l9xNG1yXs0t3W9FeuQ9it5m9l0a9oz98JLy6h9S2Cd/GCXpFF13uZJfl2
+tqqvh/8l8oK7wZ+o7xurS9JenbdotS7SL6rhumn/jcFvhAls9LCzWKOVcArP
+Wh261NrB+5N/ri2o6TnPbYZ9ewcy+It80e8vEMLJRTwpxT9HN3T5Z+C1W01/
+uQUa1Lf3lyoc5yHVnF8ViYP3wW3wUN17B3jP8d6KdxMGOdN+ZVLtHT1bFcVn
+0Fn0noniZnqWwTaxiLY3BRYtq3HE4RAEbb2bVrdARHW3cOmimsHOwFgITRhk
+uLMyY1HnHvz/rui1Oi66v43OYiQTy9Nsa/MWNIPOPfj/XdFsdVx0fxud+2Kz
+ne1bkAw69+D/d0Wy1XHR/W107o5kRkNF872ML12dhlU3Oau0zlX/+tW+at17
+neVXWBTsVZ5jFtcszzmWYV3YpaFVhdBxlMcYytGmFs8x2rtu6EQLHdvfyJKb
+bQiJ3psAEF/vd5s3ysR4/vSJuNzsD6SVMUArQ4GOCPTIgEbFb2AU1dkU1iyN
+YCWLMpoW/XbG4VxRK0/6BLt3TPlkySmDVXU5RNf34ClMeri1+KQv4vMLfPJE
+UfdsYS1DhzRbnQjHGXJkB41HtyBwGcY55YvvIPL+IlTeS9PoWuxh5Iwi+NPB
+c6A1EBxs2cFzacu+O/1lWyQZRsRT8nEDgkJOJuEo6qDjLcj4bhalHbN8R5PU
+CearQiZMNhBeZkW0gfWcqvFFlccUZ/JzNkIr+/wimorey/2f13Gp5lBqPwkx
+nGu409/ub9fptYW7Em3/IdJrExlUpXR+d3psYWORUBNOxXLyD6/Iq7sdoWNt
+bsGG+1mK/quUajUBBUWPea5WQDNMBZ2ahGFbA2QuA1PsHSeOT2FGWKXE9B5n
+FT7Gia4BC6wzeXIQEB7DzWcbFNz0czidcnw4lb5T/Wz1RAoAMEtYGchYSToi
+juSaP3msFuEKI5wwP3dcWEC47KU4OPkZeoFQCamYzahGns+3FV/4ZsrwD+6c
+dZsjqa3y5H6Z2EQdmbcFi5sQurwhB4OCkhCoJB4jMCGBUUVFDjJVUDjAE2M4
+uXypwcoU0dMjqgjKp31UXxYxKNGLuNwiTY7EGD5TkvoTUrK2R+3HE8cf/jXY
+nD15Uw/IME3m7NpTyiefAr5gsqVIh98jTEsDgNf9ZKA6i2c31vogxRRl6hTB
+XVMUAsAJrPnkYXoLkCbRVn+zv2OT6PmT56j3nyGJWO8/W+8QY3USwS4ZfnES
+qbBp5bg/5UKyeSl+SQFKlmNFWdgPiOx6g9U8zLYgMZ8CMWscd0tyDgcWw31x
+vgJslmCrp3fLVvUT6FfKVpvEVptfL1u9O30LllRwsn8renaSrclK1nmIpy7w
+KfANlTkCtgIuV8T1EnXbjt9DRbzO4ceLGeSC7BkDgU6xIT/KQKJOsir3jP82
+RCsKhnvrtebb2H64oMKZt06v3x3uDz/7QqnlsY0svVBoNbwTh8oyID1N67M/
+5PUAA4mIZq0WT2O4+IJZfeXS3Sv1TRyr73lgl11jvZ8p4BfGAVdo3nXVs+e7
+4oTojGR9hUY0P+GgmwoDVdfaVf3rz4Fab4vivCiDCZy/Oycl+cnbZg5n7cly
+uKbOm4HC9jw/L4jGVmgdPwACC/7XPdGz5rmnR10X06i8yDAoIIPzY2H6tg1m
+niHwS0RBGRkWubRaeRXa1sG3EiBMxtn03pbhVFLTpRqe2DStTGuLaIxWstDl
+3mehUxKFBSZCCeEE+LmoxZuW/RYWbfAQbTpdyBpOSZifR1Tor4jH6IrFHJcj
+crKk8hUMfMsTsM5TcfpRhHiq4gc0eB6ncoeU4hx2KL7AUe/oFool+DyrwQ+c
+SYrcowShatOO4MAXTsUoSvkUiKplQ5xF53Ga8oNs0NtUbV7Tl/e8W+d6lmfn
+sExcbC0jJYPER5+k09jaGSBDZEE/evMHfak6qlsgu0Nvy4feX4Rg42gJgjWI
+0EWxOnVvSzDjlyyrO7h4ADuw5UahXQFbXpFdY8iYUIWmFSh3S5uq9Zx31ezm
+eVixZw9O3zvizdnjebvfQlxc7pDZv6PiHdrnYQA0JoSG7XHHJZbnxLX4xDBc
+fgC4fq0z21p5Zluitw325PBrnVn90nHxmW2jjTzsP/tqF20/XXlu0LWXims4
+aT6hIL+vZYLGKwrTUFlu0O/eIRiplQBBi8FWfBNMXehMZwlmjcu7oxOS8jEW
+gU4iehLeJs4YhUIGUAVjtC5M8J6kew3ZOeTHJ8tqWLB7QKGgk5pnoQYSaqDe
+r49//r2DDVQCMe5+X2j1xi+nLhLyFS4+zh1HE/sNbskfycJVCiW+7sZ0ji/a
+VxKP51xgnbO8PTp+hPcbtJDkJsdEAnhq95Qi1TPROrdv3WaddtUu3RCPJo82
+3JrtVjycmIgfxPD51nAw6A/kc5g/iWPYPbU4aNGbgtWOSYfQDMHCp3Z4Ht/Y
+1OD04O8+fIB/n2Kl1Jita95tj8IUTjB5c2qPeJ9xmrCC0xFcylrm+tkoP6Cn
+YTWERzWUH3kq1dcfBDQvFuzj+z/O8ynFuKMvxLjGjJ3HudbhrJVpraMPcO/2
+06FIp4uwbTpdbzKt7C6Zc5Sllyh+MNOd4lELJ2JODcHPpPseJm0ypwbSZNL6
+88puJv3sj/zu8e2pYlMZy/8PLWDxRcHfgVQlNJs8WnttsYG5dZSM1W9ujFnS
+eKgzh6e/RJj/ZxbFsqCcw+PV0kx+1MHkJsbf5uY9O/a/lW2tNj+II2DXk18X
+4lZs1sYt/hcL3zjBSbTu8ANXt+ngh0OVVov8wO5ViAJrY6didBSAw1JQyiVM
+UCZHk7mDVCYfCjOaZEmSXblRXyARYVoJx6RahewLeTnypL/VuJ7pWGsXd32D
+4yVYS0L45UgHm2ic5Y9tWMKCRfOmULcQKzReojMO10f1xyRiML0wwRSYNzYB
+1Bx4RvWKAu0UUDdbm/0nfP+L7P8b/LRlEaqdQw+nszDO8YwThFfoIDvNZlmS
+nd+YmFtfvigcYdl8USKcYKzZOId/A8qlSLkJA3nFGMQGlVIiEXBKR4CCicQw
+fVRxQQm0kHFhyNoK1woF3GZXOCssc+rx4q8b/+LUjl1T/56ahFYyN5vcInRR
+QMmpaoJOc4c9JrsyY8pnNwMJwe5TWEDqHMv7AtWV4myxHbt5pY9SR2hplAl2
+x4b6xk6WrrUTsTq8pNN6G//CJA+JcsE4Pkc3ynPjG8B/qhQ/XAPba22Ooq7J
+fxAN0GlDMAeSGTfcfEKWnN9AsBM8L4v0jhfpN6sg/cZBeohPCG2kecM4+izN
+fegGmy8cZMYvfxr0h+m0C6OeZMp1eQ+Gu+44i4tIfED+F9ogIWMWwMFRTnWG
+XZQllbyoT8dkeMzXP8+fPqVIUDzhbA5B5ZNzDzO+RVZRGfJh6c7WkWas0nFO
+rbSajn1Aew12SwQaJTf3h2qjT+Iz2GsmgJ5Thsower/5kOYqP7JrTKbW20Ul
+OtP8hfNBNJ3pR6OfPt86bFDeQ/Exza5SOjvAriVUpF2L36r+VUrN+v5Ngreq
+zv0STwskjtQghgL4IWrnJ9ZdR4vHEF+VUMMTZUSdUPlu0kWvccy1F6L+o7p/
+agy4veiA22K/KrPJhF8pYkgzj9UOeqsFNMPbEge6fsriMJ90wnwCK58G/4pR
+dasA31mUFjveccjkBjsNWal5g9c18NNFB34qXoJ5EBzCDkdHNRy3WmbVsWFY
+nKCremzxqH8Da/m4rJDfnL9x9yw4cmtRDM0VHBYJiH9baZQWlix1Ib+cfJmL
+phQYaCjx96D2SSwI4+3wyBC3A9gaokOW8HXCeRinfvVlZkw33mJt0O9PQx1/
+5Kra8ct5mpYGwjv9l/PQWXgRTJeVVsHFSpKc32EoWhsiq141YvOlCkJ5TKWO
+FiU7Nf4cZGcEw7IEwSBPffPWwC6UtOAaYJeV16AFxdUWZKlVIJW5mPG2GJ1N
+oZr5ZKbBl6Qz9bkloes4rkZnG8qC1B6fTRejdaeNbCZC2E/njLgkgaHHLcnL
+WM0hqktMBUUCmEtORbgnPnJ2adAnK6umCZoFi6jQJ0ur0CcrEXw+nu06VAFp
+X5HFlWgxXnYRhv7DKkYHLMb3zciC9ycH6013zs2MrEWeyq7Y6j8Xr4Lh9oZ9
+RMEj6a+Pj37+fQFf5fOnA/0k4zk+tAux8sFoFBXkHoJDHCeFzwW75cNEBzn3
+3vQn0HpdBOK9fw6On6eN1Itv5mJ8y23sJ3LbttbWt4+XoGMrJ8ngizeqiMZD
+E32hq9/g/WiCXnysUZaXAVjrXUE0OAf0alhdEEn+M+ISEnR9wiS/YR+Iqfwg
+Ly6pvRXsyN+OLrIYRH4jI3tbKArfPlB5BKr68d/l5QiNiY8jmpmx6QkFta5l
+iRYYSl2PRuEfovWaDJEMMKISWQVLM/R0sViN84bdk3/+fc1N9f3va+tr7git
+Zyia5r+ESWxVODBJ6HHhca7WOw+LBS0GVUV4dnl6TuvWkZe6Ba4h3XrFW0PV
+E0FGQ692F19DovOKysZDE+yTwyYjH4OM7plBRnfNIPtLMcjovhhEsUQN+Wao
+yt8Th1jFfazlopsuTVErL31Nzra4QD5vZIqjDb1aIZp1KQQGS62wCg5e8CjX
+0oJCWUp9XymO1iw1isF3Sf5xXacNEZWj/uKinvacDGJzM6kut7m/btFv1eir
+D9yd1rcBrl0OvDWcokK/6qFjFOGgbj44BKdOrif8qdh8wv8Cr/D9CMXqIEN5
+JvxViwevAiGGGH0+tvsyCmUe27WWPWiAuxXbpVPgurgfAddtDqx7FPkzkfJo
+w9wr04t+nDirNHUnrVr+PbFfh3byKKVo9lXoI8PN9xcnacagUmJbO1swk6P3
+b0/Eu5P3r4PTV/b7QCwsV83oRUI2sSKkNIzWooBOOUDRQ+m17n+C7NG7F1mn
+2lV52kzjhbSvSxaPFl7h7LXaaUuOx18WdCFIAo4yual9/MdigoC7Iw7UXYkB
+d6sSLrJlTSK1nvzwZ+4BqhM3wu8WByn8WfQwVROcnxqzp3t03+SDJC5K9LGo
+ZyK3IgbW8dYvRDZvR6uCiIUhM7emFjErpWgyE/X0l8zToG2rsCe0l4xybEJw
+pFdXbmX107bWtz3MfjsPfubzIAjvr0LzztNI5K2jUqddiqnm3YM5JBS+bqkn
+RUhFlzp4pZFkHdjcS9Zu+9hvHP/7Wq1IXN0ubotk2DMFh41RjEzsGMY14Bbj
+ai7x61JrfhzGaFNJbtXu6gD40213L57t3pEmgE8IWkPhaCXSt7dDG92OYC7T
+aiq4ivgZmD4REM7Ewxd9sJ54AKAfn/acLfnGujvw7gi9K57uPH+2K17n4TSi
+V6MY0vIB5GecS0WEu4OMvABfyI+dYfaB1fIscQ28dsPO6TvfyHNISouJGtJa
+hUk4KrO8sZb8gsFdRnltP3Su7dvWbLjIGu2p8DqM1Fahud6KBhuYI4Z0VK1O
+OKXxUEttuhZsNnNELwYPywgj/NB+RUFUbHaPMddVMqpYfrhPKlq6kJtB/NDQ
+rn56f9+yqRbkuBXODS5vd/KYj6+c7nN5LLy+Rx6jh7+P+uLPPwgQt176PnKh
+UubjYBoVRXheV95H4XV9KWmAM5SwFNyJbwjoOozeb4M1UVvjJvv1W3fH/e6D
+5lSW2gfN7nP3QbNL6z7w8kTbPqihdjhR96jReMM3z5Ylc4Co5fMtGA2BF5nN
+YRwYLm26IP59b+RPXnsMHXvLXtievDte/MbWtNZoullp7s9V8O1KtntkWs3m
+wRbY8h/CNf7tbtWMuy9dYJbrEp9MVKh0QCTBL38Xy/01nWSN5Ly1cxVl5OcX
+h3Kkb97Sz+ItZercu7f0mzv0mzv0H80d+hVJfY9/sUv0H1qCPjzDh+lvwxt8
+htcIWdRc4xH8Xa44TkVtBbss6iXUQS9q9E8WErM8zlyHoD7eP3vRDfe96goH
+HZOi2pCXFiFOqECXBOAc6nqHJ/sH8+r24MJvbw7gnIUnrPbjlcUW1hB0hAre
+51mZjbKkwQA9Orut1+jyNXCfc1pbOZDKY23cT7TUtzipb3FSX8th8Fuc1Lc4
+qX9EM+ULpILT6qg9FnmeC9G6olzUkajxq/f1GVG1LHV1u1t+PceSuZ3B3Tww
+OmXuCjnomZuaaYsrZyg/8gbnq6cbFPjY9Dc1GNpOZCoXdzi+jPIyLuRuMiCm
+PwzVBpxGYVqofFK5U7fAc9JLN2oFecxX5CynJOGebsEQyaa+MCCsJn8aIoX1
+4P2FbLDPmYeMO6l/bxHvp2HcZbyftSFNihpak479+Nrsp9pCKrh6GdqCPd0X
+CNYOnHbvwOmyO3DBnHpfF9ssKDxvH6KpIdas+7kePj/153r2Wrx6dS5xWbF5
+PvW7x4CryqqwUlZamrfuMWuIe/z5GN2oOJPUNR+6QM9Dv25WdcNa1KTC+YB4
+MFNSxC5qK8t0qlksPqdai23ciNm0wqKceRbuRLvdUiVwYxKBBLPByV2UyLkZ
+2VIjIA1WKf1Un2qLx5Cgdq9M+/rPiSldkH/nEMZaVlesdk22DsI/+Q5/ZKfE
++0pV1TIONaOsAp0g8HPEB36LtLuvSLulmNLuvUhonZcxbSDfQuu+hdZ9C637
+Flr3LbTuW2jdHYfWeR9Frnhl0zzaWYds9je3ebXnXh42CgD4bhAdY0K23Zlt
+uvZE+1moI3TF8SS3hxc43K5XxLng2KGaUo7h0V7A8RZnf7HK8d+9XzU1GpZe
+KF3YYe4yUcvGIn1bCu9SOLtzietuKmYally5WV1cMAUtLaXmohWMNQEZiQMS
+69HxI1fLvEY1eh1OQSZtSEdYyLdCshJA6yJZQOxTBwyilmZDvjhyvpyPYzdr
+jLIqGaNmwSMBMYAF5DDlvOLoiNgwmcsIrPLgFBcKQkSzlaWKLShwTitgVFga
+zttuFHYRlaVK2e6sKqicTZewtVXDP5Iik1mywmJhesap9gEvwOq3fRp+uxN4
+i5qiwjOjCJhrfs07IpvuGReU+z4dszf2LDKODV4WuRiqu63UsD6DPfSjQuX5
+V63Rr6RXyEiD6BrvrOKSi+0VF1g/DktkVOfozInGbn5qVYtPRPCfKNcGWcAJ
+UXMsZkBiAJZMJeFzRygj2H1hKS9TEKBlqWT5hgtR9WVKKkp1AzbgqF53RrUt
+xjVKmPzmBLqw3BU+Gqhi3ApEbaaMDw6zC7uGKx5IOeN0s3ljpOJ28GJJ8wCI
+2eyqHspvsxGasuk4BOv1BsBV88oBHrK9HhGKuGSET5NRaMvqOiq2lYbfbtSL
+S8BWpl4yi6K9EPWgFVUjpO7QdkrBvKh9CcszzVDayDbu2F1dYO14RVv84h5I
+fvftnIbUdBKDWQqSzr337/btglSl3epuRT99XTclTbObEiuRbx4BBVY+ePy4
+mzZ+arv710vn1iZ3T2GHT13awvSICA42S9HInlNDuiwRtLLvePxRFHE1FlXh
+CDS4S/7GWVfwmM7hu7nr1Uz93ese8hoD1CfYzioOQTWTYBuMSYBlavKJVK52
+G5KD87StI1HvTes6o9TVrreuzv/PWhfZSOoyo2AVY9Y3Bxxzi5qZ9ysOyZ+X
+G5R7VSs0Cq+gc0GT3UM7osIsD+GmTNz+vDPcQjdxZljviFK9FtZgbreG2KNr
+NvwwcKPoW4Shc/M29Hu9eSqJvhRVGHfjqbypjIon7F5WiPqjdssmLWn0om4+
+edIRYedgeHjQPNT5DNoW3yZJ5zbTW/Ilby4m7mOHx2t/rTVl4p/EWl3mLRWK
+uMeDq8qrurgO8662L+VerndXe7vxzMN+76IYql6GraF9VOwIA21+CxsxxAXU
+D/jgfy6/Pvbwp2eB8Ydcow4oD3WJvu4Q/yaH+GFU5XD2K3vr/9He0zYlG8uC
+P52veHTuZ6o8hgqBIidJ/dbqCRa+3q6itZTB2ovGSjbo0/2+SN14S9wo1zby
+yQJ4Laj+fdq+gaaPzTw24D8+p3kmfaf85jkDLMty98Rxq2F2G7bzRmWQdenR
+oIUyGl3r09OIm8w1IGt2prdwaXs1pEZhUjaW0GI5r0IYsowitjtJ4MsHPMa5
+d1jqOyU4t9jVSskZRzVK6U6EHEDmXuxlcHAy+jW4KX/vXa7LOrXyCFE4higa
+QmhRYP/UnAHkYvMk8miEhU/HOuqDm3EUho8e2i7wney99kvLixgf9Tqdbh2H
+de8JgItogc2f2/U3pTVuc7ANuLCv9LisZo0qbbU8JWHqX69CG27KBejs2rDo
+imGcdCCPtZlsfWEqvxait3e43rJlmTw+D/+cmrRqsv5Wq8x5fuHa1hPxXM6Z
+RdChvAk4ILaDZ/bk4d+KTFL+ewlDBtXq46MMSLfuylWlRN2DgndFrx/14Xi1
+f7Ah3h/hfw7ervdrrOXF018Fo72qFP54K0tZS6z722UzrG8bVZFalnIpNyXq
+w3cnxx80YcKiyEZx6DhfVSyaiiIw/U3VVCHPhCC7SKZ3FVND0WpgLFcKpoWb
+vM4sLzcZUew4FNQcQRBrVeloUE1efxVf27NBVzBSFxZO7KilCMyACoiuw2uI
+msTTWOZoc4//PTh+0sJRvAJxr1n/a+Jo+vzg7Yb4i4q6IGj8wHHdcssfptJD
+O6l5u+oCuryoqzIFAlAm5NzHKwmYAngSApoEZzFQs1zqLbDp7XEpLy7EXgLN
+cOjHCdU6zbjmMQsQRXKeUwh7pqDao747MItl68aGfPPytD/sb/oEt3/yHAj1
+ora/30DjxwBxzi7veGeQYzU2NWRPv5nEJ2yD9daZGyg1EtgTwWgeLEIWEK8H
+Y+DhG1GbVrNKo5zZrFhpTirY6EAWPytjev8F4wsen2YUy+sU9mXAXwZCEqbe
+t+E4mdFFnuFN3gimpet/tszH5tAWYV4X1rPisSk+vNKssdTTrKSIAPi1msqY
+LI23sPDu7R/YQaFZ6kjkOglQJI3GgRL8enLoB4PPY7BCrlfB/N1Myow2lRKq
+CAAzH9O9fWKkEpzbb5K6SrSizAS8SXI5dgEK+lS7l+0wvsJcFE6qlPew6vqD
+mPTc5/ucCkMS5i6Vflt4IG5my+iCOWYplh0ucx3iYK0f0sEOUqAf+2882sBu
+wYgEFb8mQbCy1ZLdqG67e7MdlUVnD7Evp6uiV81wajOduunYQUnf82HXhHId
+lt6d2e7m9VtT3au2r5n4wGXi+eXx8GeVEnnOLMk0dwzXFvE3yzD+Q54VyB1z
+T2LwPmSgjbywb7kQoEV3MI7W24ShP8ZFq/edHVmmfYhl2vcvQiwrGOWw1eJR
+wd4ag4PFNKiJLBTQ7xylBfJRwabVRGPC9yk2H8q2rMsak7Tg+iT6bNoi0vGL
+LyTTu+Ygl2cR4Q4zcKT7qmIdB6zLdU2dr0Sw28u4qmRHGAuJdk/DRWS76fb1
+Cff7kuzvbVY+QlY+qLFyQ8TbMBaoS3uvIn4czdCvmJZOLexGVWlV8vMOHQ1z
+ZHmrXLeXBXGnUzHi3kNnzSI27myctEhE+OKzSkRrMs4cvTNbSCKOk9vauzAW
+CUUJoikYFZG+FsForebKghFgLCYYmw0XEoy6W51mHVvs7uTUMmaTZj0bAuK3
+sszROS/QnsQhUe4smQbO9LyV5+dIg+EhKcZBPba1o1PiVHvpLDrgNpIueq/7
+IE4Dcp3WLmFS42pvFldfCn/l48O0JgXfPCC2g/5QpFO7oPQZsAg9P7IeasXa
+xBwzkLAUH1AdYKFl49Si60bTq5dfB/ClfoVDzdeR6RPqSA+sjg6PA/Y9wh9x
+OsojrBxhe1wocCcjx1dAr/CAb7KiDF6/2hdpFI0LGfEVXWNCn2jso68PE6/G
+ssvHL+krUwkkGDgJzLCwqMO3CXjtoG8s0FlsoKD0VYzgUz75tTsBvyZqtLpP
+taS5goZy971eYh/xHVHrUUbUexEDfb6JXidIQy35KfZ16ChnpLb1X1V3NQDW
+FZkNQ9uU83ototVaYPhVHOxJj4bzycO7tc8/KOamivfzLqHY/raB3KMtDlLi
+L4030d0e87l3fU4kH6qLv8gBQNijrC0vYFEvssQrYI2mPgurceC5oZCI7Wzb
+qzxBHwgdJuLz2Il9rLt9Xo5XUnsvNTZdCttiO3XBZilse2sZePJFIKKHot1q
+U9xMz7KE7omQN4wBwh9ZLTHHGTXGJc/x7iejyHCryaxKmCPU130bwGGpXyZW
+0zMWIWP0KIEclKBtI+QCZRUcCvhWhl6TlcU67A68kMucVy5CRsBO44LOo9No
+HDsPmS2EY3yBRysYJomzB+TcYQ/JIZGdhLo8896k5FmSBNlksgr7bFs728jl
+oWebzd0BFg+R0FNYyT3RO4vKkLWgPChRgrcBknFoX5xo8V6Ii+xKHjCBEJIe
+xUWIXojrUeQGH0Mz3EjEMX1xOPlhQHHTGHsFCACRp6F8xdnWCfoMmenlYtMY
+RW2Rnwz+mzoN6a644TlpeUzhXcL+8QsjlXPK/9Da5Ao6v/h9NfPKeZmoHtgX
+TuoO9QBzLO/2bC+sStZClxQymZSdExBJcJXBCk2z8yiNsqoQ705P7CeWPU4K
+eBFeSlESTs3F56jmzAUseSh+MWkzrB4TQ3ZGFxz+EtMK3FBA1ywJR8ALaXRd
+UgABLkSGLwbchaawM2VajqtIJYUE/TYl0z4JZ/a0p9KCclQlLnBOg50nsIMw
+uaDtJLAu8y8wq5xDG8mPFb0kpQhQrp1Rc19H6TnloqsnplOrhtIqTK18OtYS
+Nemmj+64WuH4v0KkMKHjvWI2WmkSjZY9OKouKwiPtT2dKRI0pw8zBI4ScGVN
++cwr6vw3J/PxBSwNOm34agPgS+PrSAaFk/TevXwFR0k8avF+RcPFVrggRnBV
+MOVmlsPppeTELt5H8CDX8DAcZHAM7ziYL3lMpPOzSuWLCkQ6DPS5W7M4q9/S
+wr9QKWtBmFfST8wZhZ3tU3+K3rGP1KGV35RHItjqD8Yv+SSvn7ZbkkfihCHP
+WtpMqhxDU2WO0wURWDeOCBCANR+COCkso8v8RuclXhWmY2wdsCneyspP4xDU
+wBj0h+lU/CSGz7f6T8Xpz7+r5N4LpGZ4d/g62B4M/vVDMBj2B7viEE+eGFzF
+5t3eeR7Rn4IaecMuqxLMiPvgKwqvMsGM4UdnsfhALW081B3necOLjC0AP1QK
+DgOaxbY5r3WBdFPLqSTRkktOJNLv5YBzS+e5DDkNSjsZkYLo7A+cYysSFp2X
+4RQDBAbp5JT7ZpSydtsij8LatvF6r4gHVmUgl128VwrMIxYS9kGaJVrIRlmj
+pZJPfyVR81vL9UVx32R1aFp8jK7uOeAMCfvX4DeBQ2HirVFSjZlKoZjE1/Cr
+dAu4d09ttzv+C+8yS6KcjCiO8bw/KfbJeXbhBsrSHsRG+vsFXrB3hdfuc6i2
+FSVK3j9MatL+kNqXpqHxLtIwBD+I+jqCS+33nWQRLBBsaqtmN+y08xGPY+Z/
+sF5IK0csvmdS7l/twdJkd1KmO4H99uML+SQKXZq+qdxVXKzLkwvwnO/1Ocu9
+oKzQO895ULtY89SSldxHGrW9yX+C5AbrB4xQ+i28Xq89AqDzMhtGJotu64m5
+tE7MHYfjWYhVueklmvW22hyz3JJkjmO5bJlLa9Du50Ne6v9bIm9rVeuhGDRX
+NZcWcVesgL+NnDUH2ALWBBhpTMlUYJ4wLHaw+eQNGxtYhWZom6WfRJPj2/jX
+L4x11ovVJC+9Q2uRrNzdPOL24PTCtXDcOwD0Od/2To6lqOJ6sAJnlTJbVGh3
+rOpvtZhdNaTC67tCSnLzgkhZSqp5XXL3pKJyp8tQqonTnVNqFZzKrAzvEiNr
+r6tYiPzayoF6VcvxolLUe08m7K6X7/jQD0EKEpN/UvE1dRh3jZV2Jaf3sn+r
+28KORFSnRuOUBrjttTjj1Cip9b5DA9RXg+S/RIXPJqRMjaCfN+oXwpZw8KBn
+ejCmL7qb51E4RtJZjeuPuBYYZD459DTukST3/brpDh8y+VjaSs5XNvIHNk1I
+iw4GxhcwGlvEfZu4aNw/d4SBcAIC7VnTbrxZ2y2yAbBKPKdvURAPu//RLyen
+4vjdqY6gkADr62UgmHXqkkMo+KwVdZL0GNsBK3xmE+Exvedu7QUlFnYKiG/u
+e6PWtd7CDLNsMFGNi9xAm7vnovna9L5nSkMtMM/6E5dbzLPJzIaRluZlrOJU
+EWNYzTvY973hVK52dxPlA9HDOqQ4J5PpdF2cVmxS1HjRlKMLwgJFNDHx4mrD
+279TgYg1K8vqXpJkMhvBUVReZG5cSCPxtz5UzT9cOw+g7eTBiQ4Lg00Lv51l
+VTrmna56m3OWPJDzm9WQnLzrHmnpjnby87tf3h44spKuLhEHdNk5RWu0IOG7
+Jtn3zFRqrAqVepez9k5VsECcwoEvNLKVjQDaUsudqpd+oM8kNIMQCUNPvFmN
+kF4JQauwLMaq9AJWXqhN2am50FpxgebBDGCG9mbv1zxjd/cVq/+0Mj3reKxG
+z/puAWGCV+qByeu81HndSBQxUHfzBpCVIPFMP9VWra1L/FoJ7iLNg+gagMC5
+Kj9vHECdyyx1x8tXvD6ZwknZB3MovAeTGo9jlTiAx2X84XPenKW8VKVDcZ3q
+thgnvTC6iEYf1a6MijKe0j2Y1jve4th4gdR7A/9dX2zZOAPcvBSW3lVz0lXW
+VoUOIuWFAmBGcVdKzyo4v9MbRgXXIhYSRmX8c3D0iguDWJQlXxA5SxqM8SJ0
+zJfQxBH8oDKJJ36JZ6aAcqUo72sWDH3JyYTATufkiZhloNDRwWCVrNXF88Ik
+k+yFQUxW/+bCwX/gf/8bfh4++GNXfAdzCW5gZ1OwiADDIol+WFNMekp5cH7b
+O37DcX/R2sMHRVblo4hCS2D3fgRr54c1lKxrwvomBTR+WIujchIkZAZxPcyf
+Ngeb28FgKxhs93HQNdpu34mTCGxGdNvuywgmvjqUthGS0cLBVGPhOzZQ9uNs
+VJGppEyLUBQgFqYhh+iHJRsTHJlFJWnBNtKJZfElTIGy8zIORcrJ5FFtgJIi
+oLAry2yEIZ0Y30WQwkIcvzrdf3f8Wvzxxz99eL2/s7k9/PQJzbwPr07sL54N
+tgefPvV5FpIHVFciDcGTIZ8F0kEneoIzOLXY0LEcWpeBGR/E6pJPduMp6q4A
+8oTBnVxEwEC9k5Of1w22m3WkNN4OVj+fnr4/WRABd/DTtycERJJhe3sHRrRW
+VGbtxyWn45m8qqS1wA/LPEvoDSWgfry3f6Rwf7aFlCYwsDCX8VhdLXBx3wyD
+FED8jkq5rvxOOgSpihWLck18GZOrpw3ak9PqhRjrbh0ai+pMpa4GMpqKwW2A
+FLuYDDn8qhtT/mAEvZz+q3rrS0l1z6qpKGemkb2GKpsV8fyUjHYduxynlxkp
+Rhw9hxMH/q7GlXFKoXe4iCOEQ46WBLMLPiY63ICRO7VXMTv7r2hUFnon2vuU
+k9lxci7YgjKrFiKj1Kv0qR5nEo4GIyHIJyJ4hsOtdZXj/QOaC0zEgnneZP7S
+jxuBNfmiNFQVtjFpHMZcagXspGPj8Yq+cugCSaWTIdNRlRTtqwHbg17FFPdC
+kKoy5vIuODJzIIltlC0f3u9bTLGhIiuAYcFyCnEfkdAiOASTYlOJdmk2VrmV
+5RSRGMiHG0KecvkPHFb35eUjZx+xDwwRTSZIaBlbp6SdxarxhAkWpzKeDn13
+zFDTEIMDsqpIboBScFqUxlkRaSJJIFgvAZN48yhaPOtcBk79GKa9lM5EXxV3
+5jIULzqce7M8wqTTSkZxn5A8DlJuq73P4kBSt05IlaHKCpstsEhJCfqZ8vZV
+CVqOuHoY1p9NDb2i9DLOMzpeF/Z2KJQiq9EDmC1J8IVeVSqi0MSG/aG7uS2R
++fT5E9AcdLdwYxIXaVoC81wB0D5r0MO94z2P9nwt7QuTmvKXD4cKg7XDV6ev
+xV+P3ooP0XkMQvNmDYb+EYbe2nn27NOnDYZ6EWJM8JjTkRG76vdvcZSMmcYT
+FYtmobiLGLClAZOCgXdhe+TpLpoFu+TWK3avp8luWuyiMbDbMBdYrjJuuICU
+g39U7jKtD1+dvKEWMAP46Pjx3guJH5zKCsSW5ooShyaJNgkV+uwrrB4+OHVJ
+ipnZ4BRCXdSUbYkmzyZr9Bm9HwUOOka4azAs09BZPZcE2BIw9c/zWKG3EpXe
+wxLE19A1cWknl2qXi7j/FX7M5PGTV3AUAx45zkpo8z7Bp5p4YMGIdWpt0vxh
+a/kkhX1L6qxmUZCYMQgCcRaOPuLvaGHKNyrBWVxIc29fvlqhXY5wnw+eb9Fy
+WOdAUk6TqqwoN7ws/6PuJMZ5OOHRYATGKhr/sEZGuTIq90boIIRdxym+rV0a
+VqAnZa4VnBpuadwbnDYMH+bjx3GORb9HmKsVXQ8fSZp8yGAoljy/xkkp69bp
+/QyEKEkcX8bRFcE/hSm+j7B0FzakulCgEhkhFIRVrk6GU7J1sI9lzoKtn800
+aYV0bukGVyG9zAM20b6pj8AxY75G+H9qHRIe6pABAA==
 
 -->
 

--- a/draft-ietf-ccamp-rfc9093-bis.xml
+++ b/draft-ietf-ccamp-rfc9093-bis.xml
@@ -13,7 +13,7 @@
 
 <?rfc comments="yes"?>
 
-<rfc ipr="trust200902" docName="draft-ietf-ccamp-rfc9093-bis-09" category="std" consensus="true" submissionType="IETF" obsoletes="9093" tocInclude="true" sortRefs="true" symRefs="true">
+<rfc ipr="trust200902" docName="draft-ietf-ccamp-rfc9093-bis-latest" category="std" consensus="true" submissionType="IETF" obsoletes="9093" tocInclude="true" sortRefs="true" symRefs="true">
   <front>
     <title abbrev="Yang for Layer 0 Types">A YANG Data Model for Layer 0 Types</title>
 
@@ -48,7 +48,7 @@
       </address>
     </author>
 
-    <date year="2024" month="March" day="04"/>
+    <date year="2024" month="April" day="30"/>
 
     
     <workgroup>CCAMP Working Group</workgroup>
@@ -375,6 +375,30 @@ Please replace XXXX with the RFC number assigned to this document.</t>
    optional penalty associated with a given accumulated CD and PMD.
    This list of triplet cd, pmd, penalty can be used to sample the
    function penalty = f(CD, PMD).</t>
+</li></ul>
+
+<t>modulation-format:</t>
+
+<ul empty="true"><li>
+  <t>TBD: add a description and informative reference to <xref target="ITU-T_G.Sup39"/></t>
+</li></ul>
+
+<t>snr:</t>
+
+<ul empty="true"><li>
+  <t>TBD: add a description and reference to <xref target="ITU-T_G.977.1"/></t>
+</li></ul>
+
+<t>psd:</t>
+
+<ul empty="true"><li>
+  <t>TBD: add a description and reference to <xref target="ITU-T_G.9700"/></t>
+</li></ul>
+
+<t>pmd:</t>
+
+<ul empty="true"><li>
+  <t>TBD: add a description and reference to <xref target="ITU-T_G.666"/></t>
 </li></ul>
 
 <section anchor="wdm-label-and-label-range"><name>WDM Label and Label Range</name>
@@ -768,7 +792,7 @@ module ietf-layer0-types {
 
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-03-04 {
+  revision 2024-04-30 {
     description
       "To be updated";
     reference
@@ -1315,22 +1339,6 @@ module ietf-layer0-types {
         "all elements must use power (dBm)";
     }
 
-  identity operational-mode {
-    description
-      "Base identity to be used when defining organization/vendor 
-      specific modes.
-      
-      The format of the derived identities has to be defined by the 
-      organization which is responsible for defining the 
-      corresponding optical interface specification.";
-    reference
-      "Section 2.5.2 of RFC YYYY: A YANG Data Model for Optical
-      Impairment-aware Topology.";
-  }
-// RFC Ed.: replace YYYY with actual RFC number and remove
-// this note after draft-ietf-ccamp-optical-impairment-topology-yang
-// is published as an RFC
-
 /*
  * Typedefs
  */
@@ -1438,13 +1446,11 @@ module ietf-layer0-types {
 // is published as an RFC
 
   typedef operational-mode {
-    type identityref {
-      base operational-mode;
-    }
+    type string;
     description
       "Identifies an organization (e.g., vendor) specific mode.
       
-      The format of these identities has to be defined by the 
+      The format of the string has to be defined by the 
       organization which is responsible for defining the 
       corresponding optical interface specification.";
     reference
@@ -1481,6 +1487,10 @@ module ietf-layer0-types {
     description
       "(Optical) Signal to Noise Ratio measured over 0.1 nm
       resolution bandwidth";
+    reference
+      "ITU-T G.977.1 (02/2021): Transverse compatible dense
+      wavelength division multiplexing applications for repeatered
+      optical fibre submarine cable systems";
   }
 
   typedef snr-or-null {
@@ -1640,6 +1650,9 @@ module ietf-layer0-types {
       "The power spectral density (PSD).
       
       Typical value : 3.9 E-14, resolution 0.1nW/MHz.";
+    reference
+      "ITU-T G.9700 (07/2019): Fast access to subscriber terminals
+      (G.fast) - Power spectral density specification";
   }
 
   typedef psd-or-null {
@@ -2512,6 +2525,10 @@ module ietf-layer0-types {
       description
         "Maximum acceptable accumulated polarization mode
          dispersion (PMD) on the receiver";
+      reference
+        "ITU-T G.666 (02/2011): Characteristics of polarization
+        mode dispersion compensators and of receivers that
+        compensate for polarization mode dispersion";
     }
     list pmd-penalty {
       config false;
@@ -3051,6 +3068,36 @@ Names" registry <xref target="RFC7950"/>:</t>
   </front>
   <seriesInfo name="ITU-T G.709" value=""/>
 </reference>
+<reference anchor="ITU-T_G.977.1" >
+  <front>
+    <title>Transverse compatible dense wavelength division multiplexing applications for repeatered optical fibre submarine cable systems</title>
+    <author >
+      <organization>ITU-T Recommendation G.977.1</organization>
+    </author>
+    <date year="2021" month="February"/>
+  </front>
+  <seriesInfo name="ITU-T G.977.1" value=""/>
+</reference>
+<reference anchor="ITU-T_G.9700" >
+  <front>
+    <title>Fast access to subscriber terminals (G.fast) - Power spectral density specification</title>
+    <author >
+      <organization>ITU-T Recommendation G.9700</organization>
+    </author>
+    <date year="2019" month="July"/>
+  </front>
+  <seriesInfo name="ITU-T G.9700" value=""/>
+</reference>
+<reference anchor="ITU-T_G.666" >
+  <front>
+    <title>Characteristics of polarization mode dispersion compensators and of receivers that compensate for polarization mode dispersion</title>
+    <author >
+      <organization>ITU-T Recommendation G.666</organization>
+    </author>
+    <date year="2011" month="February"/>
+  </front>
+  <seriesInfo name="ITU-T G.666" value=""/>
+</reference>
 
 
 <reference anchor='RFC7950' target='https://www.rfc-editor.org/info/rfc7950'>
@@ -3339,6 +3386,16 @@ Names" registry <xref target="RFC7950"/>:</t>
   </front>
   <seriesInfo name="ITU-T G.Sup43" value=""/>
 </reference>
+<reference anchor="ITU-T_G.Sup39" >
+  <front>
+    <title>Optical system design and engineering considerations</title>
+    <author >
+      <organization>ITU-T Supplement G.Sup39</organization>
+    </author>
+    <date year="2016" month="February"/>
+  </front>
+  <seriesInfo name="ITU-T G.Sup39" value=""/>
+</reference>
 
 
 <reference anchor='RFC6163' target='https://www.rfc-editor.org/info/rfc6163'>
@@ -3570,410 +3627,418 @@ Names" registry <xref target="RFC7950"/>:</t>
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+19aVMcSZLod5npP8Qy9p6KHrJEcehA2wcCSY2tAI2gt6dn
-d20tqcqCXGVl1suDo9Xa3/J+y/tlz484MyOzDkDSzAqbaUFVhIeHh4cfER7u
-QRA8fDDMRnF6viOqchw8e/jg4YMyLpNoR+yK33aP3oj9sAzFYTaKEjHOcvE2
-vIlysS5Ob6ZRga3Ds7M8utwRv4Xpua/FKBum4QTgjfJwXAZxBMMMh+FkGuTj
-4fP155vBWVwE688fPsjOiiyJyqjYEfj5wwdFdTaJiyLO0hJg7YiDV6evHz64
-yvIP53lWTXfE3t7u4TvxK3wAMxBv8EOYT1hG51l+syOKcvTwQTzNd0SZV0W5
-sb7+fH0DcS7KMB39Z5hkKUC9QSyn8Y74tzIbrokiy8s8Ghfw282Efxlmk0mU
-lsV/0Hyr8iLLdx4+ECLA/wjB0zuJ8vM4Ey+jJCvLmL/JcqDrUfYhDvnvPEPC
-RqO4zHL+JJqEcQKYUuf+GXf+KcUufRi2McpBCViLl1Vhj/BzFV5F8YwhYuzZ
-P4OeP11Qey/8fVgfWD2YRRLlC05iRH1xEtC3Yw6vivICxngbifdZ9Xs85O/i
-FNb9Vb/+MY1+nANzRc5gEQHpw0jU+KeMmnjH241hwuJNlVkQX1dllUdABXEa
-DS/SLMnOY+QDa4QQu51XWR9Z9qdz/JDB45ZJyzw+q0ofI/wcZpM4TMXfLqL0
-vGWV5BC/Y5MLbt+5KmEaw/77l9gB+EsaX0Z5EZc3IhvDtkuHYVFGtTXp49b4
-KVFf9sNhv/rQGOBNeJbDCBH8ksSTsyh3OHgvLoaZA/b8nNv9NMSv/Kuc5vEw
-g00ZA3O37AcJjZv2ZdMOztm/yKtL+G82uukm7AgbNhauBu1lnIrfogwkx29Z
-lloAX52+P3DAnd3cVOlPEax5P4/6H/IGqPfxMMxH4l/jJEzK0Cbd6emeAyqn
-lv1LbvnTsCyHfWY8B+BvWQV4vY0iC9ZJOCkqxQES3A22S6KoX153zPRf42GJ
-kjmbRr93rsQlNewn2NBeh4cP0iyfhCUwHDH8wekvwel/vuk/ef6sv7HDIKTa
-+IH/EmJ3Mk3icRyNxKRKynh4EaYpMPEoSotIXIWXwG7peXkBYuMyRhmv+lHr
-aRJdo0wPpwAEJDp8X4irGJoXMU5YKHDZFECHieocp8Dk43Co9rIlrfW0CXnx
-PmKxPiLgQs6FG8JnEZLnMsK9IDbWB8/4C+TPCDAYZwqM1U8R5en6c5ckBxop
-UpAguBTaoJjCtJiCyhFpVKJmWxjtp6g6DdKHYT68AIw31tsxpi6gGeFD/6Ju
-9QfuDFZOptEQcE3EeR6PeBq/7h86ywPbEz8a59H/qaJ0eENNV5ZYBhjdntEx
-sCSvQtecdDd7FhvLzGIPP7L4c/lpONy0Hw0VN61vds/D4aaTarq1WZvHqeYa
-EPwHr169EoP1Ny93T14F72EHtDNXIXrHp0erM2cDY8IGRJtHSASWmIns9/BB
-EAQiPCsAm2GJf0P704u4EGAZVjTGKBrHKWyOECwtsB2GREKYGZIUfhuhBYoW
-ILRIR4JsPxACvMNhurifyFSlhhM0VVF0gM47BwUe9XG4CGTOCJC8BHEkwWqI
-BEdDFWEekRhJR9C2zMQZ/DlBKsKfZzcIv0qgY3kRljyYsngJjqI9LNF4HA9B
-t53D3GBkwKh3+moVRk/H8XmVM6PghMAaLUGghdPwLE7iUtkhRQUbOSzEr4YV
-T0ACDi8Aj2M5ypFe119Pjo+KVYI3RtkZINsSnH0SuBaUfSlwxaEtaXu4e1c1
-p/S9K6VNdPH+9R5Z6X21wpN4NEoi/OtPKPByIBMtpIRDC/Tx4z9Bv6fPt9c/
-fRIxLrh/yURVMO3pG+rvkg27rUnC8e/vo0kGf7zLs2E0AtNO7IVJAra7Wt80
-K0EZKU2CO1/OVEzCFIak6U3zDHyALCk08ZG3jizJvOeg8U62F72jV6d7x0ev
-V+UUn2xsDT59Ys7jqaupyaWdIkMhAYoJ4An7h7byWRUn4CI1WB7wuoxH8Mck
-Qr0XFxNmEaAQM7XIyKTmHuM8mxDiGhx97l/RWC7VXNtP7iAC0xzF7EEej2ev
-dl3bBsbtBlOLz1O93RCqu0lZQJ+B3seV0/wiNxnBaWy0cRSijV/gMl6BT4L/
-plkanL4yX/Wi/nl/TUwvbgptRSi+qG3UAnUH7DDbxVWbXYvXmK0YQrAHjVmy
-jURWlQUsIFK1tMkvaaTmh9sfjXkCogZhEuDwbE2RxHOXcJhUyB0eSUGQWqXF
-x48/IrMOnmzCfvz40TEA4BNcLPfTjU+f1moyhuULjbOojJHjPwUL6tMngtDA
-wc+04Qi0dxpdEW2YyDFvbGAgrQ6UpFYiwAgvHhfFF23S17Ck4yqnLTSKSrCE
-0fuPmBHzyDJPSeLQWQAvpTMSrszHjzew0YMhMAAQUBp7RTWZhPmN4o6PH3ET
-n0cFnnzYU2yoseZaI1OC0aYnasumQyPI8NCmAEs+ErtgDsYlsG6VR5odCVGU
-U882tzYkBn/6E7jC+SQmX/iGFvkoK1leSgzfR2MUMplat62tJ5pL6IPtZ8g2
-ysb9EN0IMHwBWRLnci4ESc2HmQkbl9bYCAD4eQguNnJNjSgFqMoUxARLIfB/
-rPmwaqH5nEoMgDzALCuHv5ycrqzxv+LomH5//+ovvxy8f7WPv5/8vPv2rf7l
-gWxx8vPxL2/3zW+m597x4eGro33uDJ8K56MHK4e7v63w7FaO350eHB/tvl1p
-LicKP2lioI8wzSO0MsLigZw+k+3l3rv/938HW3KOG4PBc9qutICDp1vwx9VF
-lPJoWZrcyD+BrDcPQLREYY5QUM+AkYHnQKgXQaRcZFepAKaP+g8kB7zLgUOu
-sTUd+x0BvcURuJCKAw5qE1gjB5M2Ay1Qmo2kkGeFZLFydvZfKEC1zJ/SUDDB
-Cj063id4LId+NH8HOBbZMA6RJOT6QRtpC+QgvKdZOtLsoS00uemJBf5Q8+Gf
-P5zN6v35g3kc3JcIuyfrAUtf/o7OLhMUy/bnbncwi/4KPw8ffNwRfyrDs0DO
-s2Dj/fuVd+pvpJJnJnICK59wBgjuFZ204WZEN+1dEoUFSqVpAg4ljaWJQ6On
-FdnmQDutUl2Vwyaac0qL57tIE7BuShRuM6x0m4y4V6WudhTWGlOL4Ngk60uw
-SmRK4UCuGCilhnIBhWFrZWVVrDTWYkWBxMO5ME7ZdhuDRZNdKeISpDyqCjIl
-PBbJjpw5LDwOT5DVZz+IXXGGtGeGGwFNUFsraUfokj4Ki6agfbKxvs2yUrpb
-Ul49ef7caIDh1WgSDC+CYjpcZOS9LMz9Fr4cy9XBe6SD5fkJjBUOaf91Y65Q
-HC2HIp0MzBhSItsyMPNEOhyfLzyuxU5HGSgZsIT2oB2eA7zWhxVvwFeukjDH
-3r2jvddvVoVyjFtJ464eD1MkWRlcxaPyAkbUIA26py/3d9B+Qd+HZPxU+4Eh
-sKYUPqIHQjoT0qheVSNEdaJ3QMPpJ3FBfoWG60yCdwTzO3wWyIugOwduzlIC
-lkooTu5+GLQg7oM8WVkZsD+w9FLWOAsZYhCAc3z6y5q0xpVK8xjvxsZ9uq7Y
-5wdxEuOym+/o9AQkxiiL0G0pBXiPwE9lJE2FbBrlymGQZyCkbEEtpNFaHa0P
-LvPWB2GDym5zGaWjLA8k4kPXoDYaW9FG77w1G0jNVJDuNG5XtWdoFrgmYRKg
-mXAPzFeAy5eEZyh3yjAvA5iYNQqAIrVDLQTdIQG/topBY6+eRyn4mvKSCpTs
-lE1XtnWUqiRMzdiP+ffItlifgclKTEBwiLmUNiIDjYEgjmYxLJCEjwarRag8
-2M3SfpMMF9n0CxAARm1MujZfCap71gynMT9Q2Pw9zSCgk0hLRRD7arrS0Z2N
-orJcbCJYg0jEaqcQbK60a0yibR0iGjyqA/A+WLpxRjqHu25trG9yV5sPpNMk
-LD8qqhtJeDQJ2wWbT9DvM19rCkogU5AjE7ypLTzMUZTRdE7C8dSwQ9FCD2Pq
-HAT7dBsXlGC94sX/s6dPnwTVFA+U6xqUcPbvWOZXa+YzuZZVtOZaBCIZd5k9
-i927ONjiXQ/9JVgE4tm7NsOBAxcPL7RxTMd87A/ykQTNF6RfeBnGCTFkKg2b
-oTRs1C1MrM/9YDUL4biVhTzq2+wPEJg6EcDDoLUlxiGvLhxd4uWxMukn3w/W
-5GQmUZjKU3P8BjSOgVqHdiPYfbU+QLuKzxw9jYMB0sjzxZ8HdMysBmpltIZM
-XITHFMksHhMLsFm7ZFSQ5tMHLZKxMdeFJWQLLWx+DRWuLcTp2OFzy5sGGix6
-biVx0JtpEzVeZMDVPdPrZw4ecZO0CY2aGiEwNh8VEUrkMkrIkPPZKzWnuP71
-mgScqXuF+rm0KGBrgB+SFWoS5CGLswx8RTqECXwXR+gVmIsgQyqzWZYkkqix
-6qKEwe5eksAXn5sYjd20LE1arI75qWIw8RPHfP+5aWRt8mWpgyCaxJljC0Ut
-rILffB460C38MMJYrcC+5DViL6yTJJMzYzfO9HcuieUZAaCbyMOTFVQxxQpe
-sEQjZTfwwbqJOEEHHBV4NpkCJdmDVKiqA9iaL1bHT52u6PNaGtfvYlJ0jBG4
-WX4epvHvfp+vgw4cyZCOgAaWz0gDq8Wj6/nGIAVewrA3q1eEzyuD6Brt+bic
-HwvL8QxLjgCEeedRQmfU0NCORoqBwHHOl0VJPIlLvB6E5Sr4GtBaVYUITcfW
-/bbmr5KRuhstwH5XvoC8UfpR6zuOraVzungckLEf4J2UWQMaGvABzgjKKgX4
-LBs6SFB3mCwQgkGw/JLGHs9fXUtiB2DBeFJNaLdMwmv6XXbU5tqafVOrDClj
-zMnmpPVrK1njqqUWVh5iOzvMWmRaQT4/loJaL2WDIXGS9TXdxb1adiys8u0W
-W8vhKJhO4P8gphI6ZoTP5pQqeCJc8rBAb7SdccrSu0Q2lyc0cmZyiMalTCjO
-gYnBBBwOq0nFO2Fvn2jw7nC/by4S1M5RIw9HawJwX9OQ5SmUcnmAy6dJZBih
-StldUc2/F+Pe3v4ajrKqbjDREX5LCgPH59/ec+zwwwd1/6d+Ml9zGcnOBnhS
-PUfTPCpoM3scE/u2JWQsTt4JNIwldegj0AqiJ70hvsmEGR8fnojDvTer+tKS
-drcZuLjAi7uzqHajY7VTQ0EzhTMOVfD4eQSeSAD4RtQQhP4FikT6t4jO9ZXQ
-bn1OcatEl9EBHDGSlvF5lVWF1Z13yPAixIgvcIJ+58gplIBt/iNfONO4dHjO
-pyd1kDDFbKhkbehBuEqNU4nimC4h3WaFJrRrZ3hWdRQBr42Ijoqw+paHxMp3
-eCGqxADFDbJRgK3W2qm3odirneJ4msPAGK4Kd1V3J736XRGHfkE3hFunshXN
-qE8W0ACo+La5vi1+1NuCZvnf8KPuQpJwcjYKYe8Ntp4ORDoRfxZH4rqJHnj7
-RZUzwHSyqoDUSLY/N8kGC5Fs30uy+t1VJ8ksrXRLko2RWs83B+vr/fX1dfHm
-59/nIRo066YampzA5ndDOJInevMtRBc89VGEWaPD/ZHaMBbEc/t67eTXN2ty
-pcCuGGz0t5EoPtRXZVDDuBsXFzze3lnwn/Q32uELvH7HczDYIGyAeBaWNUJj
-YU9+hZU9hIWE+fgWb8byI5pda+4XUTWmWWMwSCTEwo6G5fOm0Ar7sRwd+pJi
-6ABu/bLnMkwqExyHffNGG5vi6A/YaBhdZvQxaeFuLSqdLDpG1FJcxWiD7ipk
-qAwGS1ZTkaHpXNevrSM3+V16xVEBBglbFmih1LbSjHMkuQnWFJprlkEXVqRc
-nQgXzzWFMdB6+hSdgnjYRFhVQWQd/nwNRFM+eAH6zjBqkKSVQsuiY1bJ+dWx
-Gs3BePVfhSAbcJ/q60k/vW2WiGKOYrWPnvGP5kGxpdAUs8atmljPuAVo15m2
-B7pRWghXTZ2fFKzu6FgQvhfVHoTrPsmbWVobJHRkqCXRQ9oQIdsEv2DBHy1B
-55B9kRpBjBttyW05f0esm5ga4x/Vtk1Nan4n/GERSofUxIJyFlHGRbCVyqsI
-trjBqnjBQKGdHW8xDvHx0g7IBPmEKMbTgnGHKsLb+hEFhcv9qUc2ze3Thbmp
-rRAMr+8aQek73xbB+h5VXNciExvXHrPEogkWsw6r1/SfeGptfScP6UJmyOAs
-LifhVIvy1utuJ/JXKYpuAew9Xl9WArdBWFgAtwG6hfy1CQfktQyJJQgFAJan
-UaPzEuRpwFiSMmI2WeZw+jBenHSMGYbUAakA2LKlNiILv81W307Ge3hhRmhK
-ex/sOW1iNuWerG1sk5VZO2mz5ZE+3NViReoAEBGpH3UdB4cxrxT/XuZR9IkD
-TckWPcXjh0ZyAH6xzy9B2O4F8MM4DmA3PHzA0UY7zajbBw+sAzTfDR5Z3n8O
-AtHTinj1R2mO4+c7PTYO0CFcVZ//wV3ISUx/FBxTQuPt8GcOgKGn69DTddjs
-araIBiDRlTGOP9oA5GdtU46m1mztqNW5J0wbXbrGTnwmTUTFdeXReOb8CdJw
-UUh+clxrctCMPAA98FwyDsc8cO1nZj+iarNnFaflM/8y4IXobXhOfsUvmwP0
-sqopXhbxpA2YPwwwbrvqftNkYeunhZstmCQEaiDlpIrqbBjmOcgHZpX0uw6Q
-82yQxs9yO6Y3k2YWmBrNHNSsredDyuzCtq6T7q4Tt+s14YMYN9G5dukth/5O
-/Jv87T8aPcQ84qOjy8TTZeIhoMsg9ndG7ZC9WzTaeJu1zsntM++0PL3aZubZ
-xNZFvt7Leit7JRi2UPF7vPpKRtgoIAyLm1s8oRaJ9md6WOvxcn5Uww2eOG19
-Dofb1kzdFxk7W4x1K825RYKoi4SmAPBhOp+o9QrZexWvs6Wru9tnS9flKdn4
-6SCtL27Wz/4zub+pIGthpXMZKgubKHNZKGIOC8UFZIId2oNSazt9puFmgXIF
-4byQFhJt3iBHswYzt0PLRlhcWy6lJz0achHduJBWXEgf+jXhTB24mPZbVO/d
-hi3+xyk+fxDqA8l1C7odizscS7gadggZxbSYbYx/rjq8KWOuans2z9zoLmdU
-55tGP+txGB7NYaDdd/6p6V60dvJIwsg6GtNsgvLi93ovWMXFe9nUKatUvor6
-0el1Xu8F8yqv9QJPsyskbSxFGv85OpvM0Se8ntUnX2KcZp+5ximzMmz08PQh
-RvHE4jWZxtOoITaxWe0hl8Ve9a+83a1RAuaqMQh4hNLylQ9KO6O2cKru2c6u
-rZxn+rYy7ey+7azbyrtiNvt6eaSjn2aUzn7tbLxov7nHa2HnFn52wv5qyhng
-OV83lHMnE3jX0em6mOCyuy4ovZyu8wuW7m6tssXutoAY6+4272jzCjO7mwpr
-BsuWgpLbtKgTiK21qT7z5s7/9MCB7X4L5hv+AyLpPxqsJr/wn3QJ1LeYpqjR
-rVdnXNGi0vlnWcVe672Qeq/1XWrL/HGrXfPHrTbOMsp/Zs8ZDL2MITCz5wJj
-LryPuk2D2gAdBoJuKW5hJniAtBgLvh7qnGWGFdEcZDFbotl/UYvCA2FBu6IJ
-YVHrwgNhAZ0/T+92zd/svYi9MU/vBcee2/YQql+HBSIs2B12iN1sKdHqAFhG
-utoAlhKwDoBF5V135xkiz+68sKTt7rzYyIvJW7uzx3rx/dTNESt/LWWeK75r
-6aikYfCD6Pcf6/+5hs1jab3MObhH/reOr37mHd88k3Eepj2w8KibPnWLR4Pw
-vTyzAC2qmW7ht2qU5EuWgAIsbGScL/DjKgUodlf3iZPV1aO3Gmao50QKera1
-tn+sgzcjZEbxeBwQZsEoSsKbOoRRNIwnQLuNWr/hRZ7ha84hQCimmMk+c46U
-Zb8nW1a/oX7rBPY3G95/WN9pggmbalabVsraiE0zPJuUS0fc6CLoQ8x6hdXE
-DL90ULsTzDhSKUzLIMkKzkXHMgb/xIP9tEoSG8VR0oEifOmg2AJqfnx1gG1A
-kTyMsz5T7uJEVH3HJ0fvu1ixSHOrB0hdAOGK7XpvV/62iPpW+jRa6nlruHPS
-ycOeZtp/sY+uPT++vWQIfRZWo8C7iX0sm2dJEmTjcReZff3IMpE3MHaEj/3T
-tBDquKpkZs3R/UyB7VG5+efXji2Nc5FHxUWWtHnkvn4wyTNQJUEGnNZGIZcJ
-s6oEcnb3cnuUtR0tWQnkKSe1Qgj8GSkgey/b3YoP0ZVnMHtWWnHIF7NaTc5Q
-iy1uUMtdaevLYn3CsohVu+iNwGJ3AXWKhIk0Xr5GZBe1qBczoRezmRczkhex
-iutLYtOHHj+bpWkxc3x3bXUq1L1Aj6asT26+LtYMm96i1aVrmirpONjCn2XG
-XbjkUTjCwOwaJi30WZQ4ndjgBXZF8M0TE0MKb0LJrhAOvZtq0ighHEzIdOtO
-BQdlVkMbd3xcjUuJNS/AYrZQPwcFEETX8DlsgvycdxgrhQaAKSV5dE6o8fig
-KEGqo7N07uoYV7WYZlGW2E3bmiEtilK3hH/UU0SM6gamDNzIbh3rTbnOrVjv
-Q5MYuFEsjmK8sZcK7/bkVP6ILycJ8iWb3GLQH7zADynXNL0JWqnydAe77hBv
-FjvXk2QnLXaw204zNTD1lkmlVWzEC86gYOs/frK5gmXmfKXlGAzlgBmWsu2v
-b8Sv0dmOEP98UZbTYufxY8zCiaVOPkQ5vZDpwwiPr84fUy6Hx6o6EvR7Gxfl
-jvhnLLxUZjv09U+qww8yvYOQ2Z9hAE9lNvOjoHCj/staCTYPOF+5uiY8btV/
-Wa9L5wFYr0zXBEYt+i/dCnQeSJ4Cak1gLaXTfuBFslKGyoWyk06rx0mqLoKT
-uNpNUC2H1wU4TJkYTgjEKSuszJBl5pSDEeI1PQ1plmDgFxn0jKTXyOAs+3qr
-KKyaZye91touEoDTr14dplG+oq/XYi+b3uTx+UUpesNVrLy0RcUXxSnWUdQp
-QNElxqdX+nRDJSDF1BBUXEiXSRiqLCiJILiYNaeI8stoZAZ9H4GbzdJepXqt
-Csq0UmRVPuS8KmdxiqUUqAjCGmUgkb1B3OBfYITj0ulaL2v48neKOZBKfMsy
-rfKiApcZ1snUhsGCLJSdXqXWgMUkwnL1Apn1iV688Fv691gTQs/25ck+bGbu
-gW+TATdYCUD7RCZY3OoPFR0MFR+plHlvo3NYg3fIYQW9ZHuP+YRkxhZqvy9T
-6KoePSVrqKxlFBk5IxGnaK5VQ1liaCVNVQ0Sp3JFgWlBKT2LymD/AitgyP4q
-t3xcFlEyJtE+Bo0tEkIdS+sMo8Iezi698AhLLjxa43+xgAL+rkov4O9UcUH/
-ImHIdlx2wfxm+utqC/hnrQDDI5nZC8bc/e0R5xB4pMowPJq/DIOEUi/GIAZb
-oof0wFIMq/wrFmJY9dZhMDS8EfNVY1gh3fT4seD0//0dT7p/UEEV0N7O+A+j
-5tEku4yoL80QliaSsBQIevcra5pQQS9TPkAyw7Q6U8fJ1ECCI5UOtgIyS+8G
-pgHuUgpmyii8oWQHGiiKi2B9M1jfYl3uEccokIne/GJ0xFJbmHTOuplix7nq
-0TKYT8yINj6DYP1ZMNjswucA3wECReU26cYIS8csitHj7+DX78QB26hc5eu7
-x4yrTlxvR0Z3YasG0U8Tu/HFx4U74g2mJA0TysdDuREKiTDmdAm4ZFCwh5ER
-wAWqf+/tyd7qmsylwG1QNr0HQQuUWtObXrgl7ERvsPEYC8St7oh5yu5pKN7y
-e/a6WtSieG6O1LwaTRS9BFcEsEn5Qn3joSWQaE+98lzRDRt0XJ6SREEDZg5K
-3hEpO2jZTc3Rrai5f6/UNBDm50y3SiTQc/0xVpNcmJ6+Apet5LTiiG9Hz9ca
-0GyC4lPcVoKiDGdgb1BsxKkksYHBVBQO535dBNbkrSfA6pKWdgotp/zInUtN
-d6+3U042+IKyk+i3sZ7WGbNO1xnMSRBqD9y/rBRVLb6ENNXUreca6+LO1uI4
-X4w7vWy5/LZu3dVNriS6DdbXzy9+r/FlnaIz+HIgc219Vaz5ZRUSUXD79qTd
-/kZZH2U3tm9NWc7O8Y2ydXmwMb09bTHN4DfqPmgYqB4lhVVOK8zzMs0jSrf6
-ol15GeO0Q4W1Gcdy7CdT395poKcXqg2/tqXHDJBdS+8njK4116W7rekvXVuu
-W83fyqJf0p6/E15cQOtbBO/iBb0i8673Ikvyzbeqr4f/we6cu8Gfz+4bq0vS
-Xp23aLUu0s+r4bpp/43Bb4SJSPSws1ihlXCKiVodutTa/ruTf6ktqOk569gM
-+/b2ZfAXnUW/u0AIJxfxuBT/Et3Q5Z+B1241/eUWaFDf3l+qcJSHVDR8WST2
-3wW3wUN17+3jPcc7K95NGORM+6VJtXv4bFkUn0Fn0XsmipvJWQbbxCLa7gRY
-tKxGEYdDELTVblrdAhHV3cKli2oGOwNjLjRhkMGTpRmLOvfg/3dFr+Vx0f1t
-dOYjmVicZpsbt6AZdO7B/++KZsvjovvb6NwXmz3ZugXJoHMP/n9XJFseF93f
-RufuSGY0VDT7lPGlq9OwkiInX9Yp3V+/2lOte6+z/AorO73Kc0x2imXqKZZh
-VdjlflXVx1GUxxjK0aYWzzHau27oRHO57W9kGcU2hETvTQCIr/a7zRtlYjx/
-ui0uN/rr0spYRytDgY4I9NCARsVvYBTV2QTWLI1gJYsymhT9dsbhlEpLT/oE
-u3dM+WTBKYNVdTnAo+/1pzDpweb8k76Izy/wZRBF3bOFtQgd0mx5IhxlyJEd
-NB7egsBlGOeUVr2DyHvzUHk3TaNrsYuRM4rgT9efA62B4GDLrj+Xtuzx6S9b
-IskwIp5ydBsQFHIyDodRBx1vQcbjaZR2zPKYJqnzsFeFzCtsILzMimhN7F2E
-1eiiymOKM/k5G6KVfX4RTUTv5d7Pq7hUMyi1l4QYzjV40t/qb9XptYm7Em3/
-AdJrAxlUZT4+Pj2ysLFIqAmnYjn5h1fk1d2O0LE2t2DDvSzF86uUShoBBUWP
-ea5WFDFMBXlNwrCtATKTgSn2jvOrpzAjLOZheo+yCh/jRNeABZYMPNkPCI/B
-xrM1Cm76OZxMOD58FPVNP1s9kQIAzBJWBjJWklzEoVzz7cdqEa4wwgnTWMeF
-BYSLGIr9k5+hFwiVkGq+DGvk+Xxb8YVvpgx//85ZtzmS2irb98vEJurIvC2Y
-34TQ9eQ4GBSUhEAl8RiBCQmMquNxkKmCwgGeGMPJlSgNVnpNddsVFUH5tI/q
-yyIG5UMRl5ukyZEYg2dKUn9CStb2qP144uj934KN6fabekCGaTJj155S2vUU
-8AWTLUU6/B5h9hYAvOonA5W0O7ux1gcppihTpwjumqIQAE5gaSQP01uANIk2
-+xv9JzaJnm8/R73/DEnEev/ZaocYq5MIdsngi5NIhU2rg/tTrgOal+KXFKBk
-ORYEhf2AyK42WM3DbHMS8ykQs8ZxtyTnYN1iuC/OV4DNAmz19G7Zqu6BfqVs
-tUFstfH1stXx6VuwpIKTvVvRs5NsTVay/CGeusCnwDdUDQjYCrhcEddL1C07
-fg8V8SqHH89nkAuyZwwE8mJDfpSBRB1nVe4Z/22IVhQM99Zrzbex/WBOhTNr
-nV4fH+wNPvtCqeWxjSy9UGg1HIsDZRmQnqb12RvweoCBRESzVounMZh/way+
-cunulfomjtX3PLDLrrHezxTwC+OAKzTruurZ8x1xQnRGsr5CI5qfcNBNhYHK
-1x+wUqp//TlQ621RnBdlMAb/u3NSkp+8bWZw1q6sGmvKoRkobM/z84JoZIXW
-8QMgsOB/3RU9a567etRVMYnKiwyDAjLwHwvTt20w8wyBXyJi5avoep5Lq6VX
-oW0dfCsBwmSUTe5tGU4lNV2qocemaWVaW0RjtJK5Lvc+C52SKCwwIUkIHuDn
-ohZvWj63sGiDTrTpdCFLHSVhfh5RPbwiHuFRLKaCHNIhSypfwcC3PAHLn8La
-zSF6VfyABv1xqgpImcBhh+ILHPWObq5Ygs+zGvzAmaTIPUoQKsrsCA584VQM
-o5S9QFQta+IsOo9TWfId9LYq7M305T3vloOe5tk5LBPXJMtIySDx8UzSaWzt
-DJAhsu4dvfmDvlRE1K0j3aG35UPvL0KwUbQAwRpE6KJYnbq3JZg5lyyrO7h4
-ADuw5UahXQFbpyI7xpAxoQpNK1DuljZV6/F31exmnbBizx5430/Em7PHs3a/
-hbi4fEJm/xMV79A+DwOgMSE0bI86LrE8Htf8E8Nw+XXA9Wud2ebSM9sUvS2w
-Jwdf68zql47zz2wLbeRB/9lXu2h76dJzg669VFyDp7lNQX5fywTNqShMQ2W5
-wXP3DsFIrQQIWgy24ptg6kI+nSWYNS7Hhyck5WOslZxE9CS8TZwxCoUMoApG
-aF2Y4D1J9xqyM8iPT5bVsGD3gELBQ2qehRpIqIF6vz7++fcONlAJxLj7faHV
-G72ctC5VPa/jQkffZ2qdLqJUlhGtJZl8zCXT9fJpdUdZpvRdivr31DywlrkC
-pA60VSMZsTR4rZi5gmIjINVsTLkWpmBaxqqgusbX7kp3wNiOTRCpP/Xtgcaf
-YDcP7TWplBO/0d/moy60d3+Dn7YH07UtdzCZhnGOyxmEV2gLnGbTLMnOb0x4
-ge9pPI6w6NN4EY7xWm2Uw78BpY2hNCyBnHwQG1RKiUTA2WsACuZMwJfyxQXl
-CkBfDYa0XnrjA3CgtP3Ou+SPZA0xxXAcUoGZNV+0cyDyB9e650yCj44eIQrE
-hHQVg8kq8GTIUxVW7xZt1/WtG9PTrjKya+LR+BEl0TAcZ8VcirH4Xgyebw7W
-1/vr8snVn8URSOharL3oTcAzxMRWaOpiDVo7BJRvBWtwevB3Hz7Av0+xaG3M
-HhxL9EdhCl5y3pzaI5blnIqu4JQXl7KsvH6azEkaaFgN4VEN5UfurHlP1h6d
-dOwDWdP3H+OJnmLc4RdiXOMqzeJc6wCglWkt9xq4d+vpQKSTedg2naw2mVZ2
-l8w5zNJLFNeoVRSPWjgRc2oIfibd8zBpkzk1kCaT1p/wdjPpZ39Ieo/vmxWb
-yvci/9ACFl+t/B1IVUKzyaO1Fz1rmL9JyVj9rsuYvo3HYDN4+ks8JfnMoljW
-9nN4vFqYyQ87mNy8I7G5edd+X9LKtlab78UhsOvJr3NxKzZr4xb/q5hvnODk
-vHf4gQsNdfDDgUrdRvare92mwNrYqTgwbayXgtJ6YRI8OZo0wpUzQ6Fs4yxJ
-sis3shAkIkwr4bhntd6Y7E36D9v9zcYVYMdau7jrW0IvwVpy8y9GOnbvHjse
-lwWL5k3hlCEWy7zEA19cH+2pVeTohQmmWb2xCaDmwDOqF3f45ni1O17WCrf4
-9nb0OqaJrR9E1bqZk4P5NpDDDDLFI/PJquv/z3b/i+ib4//3y39OdmCH+XRW
-dsN64zwkygWj+BzP9p67bFel+OEKGGsrMzR7TWGALIFOa4L5kOy+wcY2mX5+
-i8LOOr4o0k+8SL9ZBuk3DtIDfNdqI83bxlGAab4ouhtedEcvf1rvD9JJF849
-ybar8voW9+VRFsN+fY87RGgbh+xjAAfeoeoM+yxLKhlfko7IlvGr9DRXebFd
-Aw9rRphZsaZK8xfOB9Fkqh8Ld4iuu57IGh+Gfkizq5TsedgYhIq0NfFb1b9K
-qVnfz4d4m+7cK/K0YFNL8WwogB+ixty27rhaTorxNRE1PFGGzQlVNyf98BrH
-XHkh6j+q+6fGgFvzDrgl9qoyG4/5dSqGsvNY7aA3W0AzvE2xr8vRzA9zuxPm
-Nqx8GvwNoymXAf5kXlo88Y5DZjBoO2Sl5s1t18BP5x34qXgJejg4SAu6oAAX
-qGVWXbqeDDI0FEYWjxZeHtaFWm4pmHx47Fpw5Nai2KkrcOAIiH9baZTmliy6
-x1LyZSaaUmCgLcLfg2YlsSDMCYRHhrgdQJ2LDlnC10jnYZz6FiKwpAZFOoiV
-9X5/Euq4s7p6mKXMaCCM5Xg5C525F8F0WWoVXKwkyfn9jaK1IbLqVSM2X6Yh
-lMdUampeslPjz0F2RjAsSxAM0hObtQZ2Zas51wC7LL0GLSgutyALrQKpTP8y
-vFiKzqZA0Wwy0+AL0pn63JLQdRyXo7MNZU5qj84m89G608g0EyHsJzNGXJDA
-0OOW5GWsZhDVJaaCIgHMJKci3LaPnF0adHtp1TRGs2AeFbq9sArdXorgs/Fs
-16EKSPuKzK9Ei9GiizDw+4MYFTIf3zcjSt6d7K82z01upmQt8lR2xGb/uXgV
-DLbWbBcFfbpfHx/+/Hvr9ObfQMXollvHP7G2raQtXt/6QcfW1ZNBCG9UwZKH
-JgpBVxrCe8IET7OxHlxeBmAhdwXB4BzQWbe6IJL8Z8TlOugagU+Mbti1N1U2
-5AUetbcCS/nb4UUWg5htZL9vC/vhU3gqRUEVVv63vCSgMfEhSjMLOT1Xoda1
-jNwCw9brURn8Q7RekaE4AUavIqtgGYyerl+rcV6ze/LPv6+4adX/fWV1xR2h
-1W+haf5rmMRWNQmT8B8XHudqvamxWNBiUFXwaIen57RuHXmh29Aa0q1XnTVU
-PdF6NPRyd9I1JDqvamw8NME+OWwy9DHI8J4ZZHjXDLK3EIMM74tBFEvUkG+G
-bPw9cYhVSMlaLrrx0RS1agDU5GzLscPnjdBwtKFXK0TTLoXAYKkVVhzC2wt1
-nDOnUJZS31f2pDUjkGLwHZJ/XENrTUTlsD+/qKc9J4O53Ky1i23ur1v0ey+6
-+Kc7hXIDXLsceGs4RYVA1UOo6KZfHehzKEqdXNv8qdjY5n+BV/jYn2JWkKE8
-E/6qxYNXgRBDDD8f230ZhTKL7VpLTDTA3Yrt0glwXdyPgOs21q27C/kzlvJo
-zVyXUvYEnDirNHXVqlr+PbFfh3byKKVo+lXoI8PN9xcvaMagsm2bTzZhJofv
-3p6I45N3r4PTV/ZbTCziV03p9Uc2tiKFNIzWAoxO6UXRQ+m16n/u7dG7F1mn
-2lU58UzjubSvSxaPFl7C91rO25Lj8ZcFXcKRgKOseWoff5xPEHB3xIG6KzHg
-blXCRbasSaRWzw9/ZjpQnbgRfrdwpPBnXmeqJjg/NWZPD5V9kw+SuCgxq596
-knMrYmDNdP0aZ+N2tCqIWBgJcmtqEbNSOiwzUU9/yTwN2rYKe0J7wWi/JgRH
-enXlsVY/bWt9W2f2mz/4mf1BEN5fheadpZHotI7KynYpptrpHswhoTBuSz0p
-Qiq61MErjSRr7uZesnbbx37j+N9XagX56nZxW/TArinubIxiZGLHMK4BtxhX
-c4lfl1rz4+g8m0pyq3ZXYsCfbrt7/soCjjQBfELQGgpHq2iBvR3a6HYIc5lU
-E8EV28/A9ImAcCYuvOiD9cQDAP3Y23O25Bt9Xs8/3t2vYryf7YjXeTiJ6IUu
-hpG8B/kZ51IR4e4gIy/Ah5wjZ5g9YLU8S1wDr92wc/rONvIcktJiooa0VmEc
-Dsssb6wlR/K7yyivygfOVXnbmg3mWaNdNguAwWGnyWen/uoRa5iPh3RUrSY7
-pUxRS226Fmw2c6AqRsbKqB780H5NQFRsdo8xr1gyrFh+uE8LWrrQMYP4vqFd
-/fT+rmVTzclxS/gNLm938piPr5zuM3ksvL5HHqNH1o/64ofvBYhbL30fuVAp
-y3QwiYoiPK8r78Pwur6UNMAZStgoLDmWnq7D6K08WBO1NW6yX791d9zvPmhO
-ZaF90Ow+cx80u7TuAy9PtO2DGmoHYxUGHo3WfPNsWTIHiFo+34LREHiR2RzG
-geHSpgvi3/dG/uS1x/Bgb9EL25Pjo/lvbE1rjaabAej+jgq+Xcl2j0yr2XRs
-gS3/IY7Gv92tmnH35BGYdXQ5zCbTCpUOiCT45e9iub8mT9ZIzlsfrqKM/Pzi
-UI707bT0s5yWMnXu/bT023Hot+PQf7Tj0K9I6nvOF7tE/4El6MMzfKD9NrzB
-p2+NkEXNNR7B33UUx2m/rWCXeU8JddCLGv2ThcQ0jzP3QFC7989edMN9p7qC
-o2PSgRvy0iLECRVDkwAcp653cLK3P6tGEi781sY6+FnoYbW7VxZbWEOQCxW8
-y7MyG2ZJgwF65Lut1ujyNXCf460tHUjlsTbuJ1rqW5zUtzipr8UZ/BYn9S1O
-6h/RTPkCKdG0OmqPRZ51hGhdUc57kKjxq/f1GVG1bG11u1t+PcOSuZ3B3XQY
-nZKChRz0zE1RtMlVStQ58hrXBqAbFPjY9Df1Lto8MpX3PBxdRnkZF3I3GRCT
-7wdqA06iMC1UXqXcqRHh8fTStVrxI/MVHZZTQnZPt2CAZFNfGBBWkz8PkMJ6
-8P5cNtjnzMfFndS/t4j30zDuMt7P2pAm8wqtScd+fG32U20hFVy9DG3Bnu4L
-BGsHTrp34GTRHThnbrmvi23mFJ63D9HUEGvW/cwTPj/1Z57stZzq1bnEZcWm
-f+o/HgOuKqvCSt1oad76iVlD3OPPh+hGxZmkrvnQBXoW+nWzqhvWvCYVzgfE
-g5mSInZRW1mmU81i8R2qtdjGjZhNKyzKmWfhTrT7WKoEbkwikGA2OLmLEjk3
-I1tqBKTBKqWf6lNtOTEkqN0r077+M2JK5+TfGYSxltUVq12TrYPwT77jPLJT
-4n2lqmqRAzWjrAKd/e5zxAd+i7S7r0i7hZjS7j1PaJ2XMW0g30LrvoXWfQut
-+xZa9y207lto3R2H1nkfRS55ZdN07Swnm8+b2061Z14eNhLh+24QHWNCtn0y
-3XDtiXZfqCN0xTlJbg8vcLhdr4hzwfGE6nc5hkd7scxb+P5iGfffvV81tQoW
-Xihd4GDmMlHLxiJ9WwrvUji7c4HrbiocG5ZcJVtdXDAFLS2l5qIVjDUBGYkD
-EuvR0SNXy7xGNXodTkAmrcmDsJBvhWRG/NZFsoDYXgcMopZmTb44cr6cjWM3
-awyzKhmhZkGXgBjAAnKQcrpsPIhYM9nCCKw6wSkuFISIZivLQltQwE8rYFRY
-Gk5HbhR2EZWlykTurCqonA2XsLVVwz+SIpNZssJibnrGqT4DnoPVb/s0/HYe
-eIuaogIswwiYa3Z9QSKb7hkXlNI9HfFprKpfh7zOyyIXQ3W3lRrWKbCHflSo
-JPaqNZ4r6RUy0iC6xjuruOTChsUF1urDUhHVOR7myPJ5Coaueygi+E+Ua4Ms
-4CSkOWbnJzEAS6YS37kjlBHsvrCUlykI0LJUsnzNhaj6MiUVpboBG3BUGz2j
-Gg+jGiUwWBcoBxKOQBfWcYWPBqrwuQJRmynjg8PswK7hRP5SzjjdbN4Yqrgd
-vFjSPABiNruqh/LbbISmbDoKwXq9AXDVrNKLB2yvR4QiLhnh02QU2rK6noht
-peG3a/XKCbCVqZfMXGgvRD1oRdXKqB9oOyVRXtS+hOWZZChtZBt37K4usHa8
-oi3n4h5I/uPbGQ2p6TgGsxQknXvv3322C1KVdqu7Ff30dY8paZrdlFiKfLMI
-KDCh/+PH3bTxU9vdv146tza5ewo7fOrSFqZHRHCwWYhG9pwa0mWBoJU958Qf
-RREZEbrSD2hwl/wNX5fLl7rOd3PXq5n6u9dPyGsMUJ9gO6s4BNVMgm0wJgGW
-qcknUrnabUgOztK2jkS9N63rjFJXu96iMf+TtS6ykdRlRsEqxqxvDnBzi5qZ
-9ysOyZ+Xa5R7VSs0Cq8gv6DJ7qEdUWGWh3BTJm5/lg83102cGdY7olSvhTWY
-260h9uiaDT8M3Cj6FmHo3LwN/KfePJVEX4oqjLvxVKepjIon7F4WE/tYu2WT
-ljSeom5sb3dE2DkYHuw3nTqfQdtytknSuc30lnzJm4uJ+9jh8dpfK02Z+Gex
-Upd5C4Ui7vLgqgKpgiR5V9uXci/Xu6u93XjmYb93UQxVL0fW0D4qdoSBNr+F
-jRjiAuoHfPA/l18fe/jTs8D4Q0ejDigPdYm+7hD/Jof4fljl4PuVvdX/aO9p
-m5KNZcGfzlc8OvczFdRChUCRk6R+a3X1Cl9vV9FaymDlRWMlG/Tpfl+kbrwl
-blRhDPlkDrzmVP8+bd9A08dmHhvwH5/TPJO+U37z+ACLstw9cdxymN2G7bxR
-GWRdejRooYxG1/r0NOImMw3Imp3pLeDZXoGoUaCTjSW0WM6rEIYso4jtThL4
-8gGPOdw7KPWdEvgtdtVOOoyjWp10J0IHQOZe7GWwfzL8Nbgpf+9drsp6rdKF
-KBxDFA0htCiwf2p8ALnYPIk8GmIB0JGO+uBmHIXho4e2C3yevdd+aXkR46Ne
-56Fbh7Pu9QC4cBXY/LldUFJa4zYH24AL+0qPa0bWqNJW01ISpqV25UK04aZc
-9M2ukYpHMYyTDuSxNpOtL0wF1EL0dg9WW7Ysk8d3wj+jNquarL/VMnOeXcC1
-1SOeyTnTCDqUNwEHxHbwzK50/q3IJHV+L2HIoFrtPsqAdOuuXN5gmB4UvCt6
-/agP7tXe/pp4d4j/2X+72q+xlhdPfxWM9hIg+NNWzYx/vLWeLAbQ0O2iGta3
-jTpFLQu90CEmasvjk6P3mmxhUWTDOHSOZlWkmooxMP1NqVAhPUaQbCTxu8qb
-oeA1MBYrztLCa96jLi+vGUHtHDeoOYKY1orU0a+avP4Ctva5B13QSE1ZOJGl
-lpowAyoguvisIWoST2KZwc09HOiBc0oLR9EMxNtm/a+J3+nz/bdr4i8qJoOg
-8fPHVevQ/iCV57fj2llYXXyXF3VFp0AAyoSc+7QlAUMB/SSgSXAWAzXLhV4K
-m96eA+f5RdxLoBkO/RgBCgaoxIsiOc8phD1TUDVQ3w2ZxbJ1U0S+iHnaH/Q3
-fGLdP3mnXr0pGguNHwPEGbu84xVCjvXR1JA9/aISH7itr7bO3ECpkcCeCMb6
-YFmwgHg9GAEP34jatJp1E+XMpsVSc1KhSPuyHFkZ0+swGF/w+DSjWF628EkH
-/GUgJGHqfTmOkxle5Bne8w1hWroip3c+rrDvEvUtgr4uyKfFY1NrdymKhMNh
-NC0plgB+rSYymkvPSVhz6u3t2+GkWepI6zp5UFwNR4FSCh+XQPJ4KkVHm2YJ
-VZiAQd10b58DaQbnipyEr5KwKDoBdRJgjvGA8j7VZ9B2rF9hbhPHVcpbWXX9
-Xox77ht/zpcxqlsLbfZCt8Uwy2bosBp8b2pdy8E9xfMyXfvZp9+IaI90RMmz
-pxdt31202XXa8GeZWm3OLMleday5ll0/zTAoQhrQdEbxBXb/fWx9e2LCvhZC
-gNaagL2wOo8MmE6+pBBozKY5h3mkAUzCEQfLygEcsC4IkEB/r5LgvsTAO3vZ
-DnHZ9mvL1pAHNow5qmneqzwYRVM8mUlLp4JvoxauKpp4h87YjM3dutHtZUHc
-yXNA3Hvo7s61z0fJZ9/nomWje+cw1z4fJbdV+zAWbXUJorndgU7+7d7BGHe3
-uxaR/pqMNgTEb+mdot+6o8rEIXG3LJj+yfS8lU93qMHwkHS3qR7Z2bfScar9
-b4sOyBLyaM7rGMRpQIcitcPX1ByxNQsZL4S/8t4xnUHBJ46I7Xp/INKJXbz1
-DFiEnh1YDzTisdrLIwYSluI9CjEssGrcVbpmML16+XUAX+roe2q+ijI0oY70
-sOLw4CjgU4UQS3QP8wgzxtu+FF3YZ+TSBvT6BvgmK8rg9as9kUbRqJCRHtE1
-JvKIRj76+jDxylm7VPOCXrB6OM7AafOHhUUdPkXE40Z9UonHQAYKShLFCD6R
-mV+7E7hv+amXnEZzN7VePx9l7bhmn9Tk0uxz2EezLaQ6TRrys0G0LmFqlfa2
-ZKNv592t/fJeUfodojHrINMtoY4/92irAD/+pfHqrvvUZeZ5sRMrgoLpL3IA
-ECu4q8sLkEcXWeLdykYnnIXVKPCccs3lQA08BGH0X46WErAvNTZdqsFiO3VI
-a6kGe+MYePLNCaKHQsRqU9xMzrKEzhqRN4yq44+slphFhxrjkud4fphR7KHV
-ZFolzBHq674N4KDUb1+qyRm/LQTfqASRXUrQtrq7QNcBTCk+2aP3CmWxCrsD
-D3UzJ45ayBirSVyQvT6JRrHzVM5COMY3HrSCYZI4e0DOHfaQHBLZSagDWO9p
-XJ4lSZCNx8uwz5bX/x54ttnMHWDxEBnNCiu5J3pnURmySJbmJaUQWkcyDuwD
-Nn2XVoiL7Eoa4EAISY/iIkQv7XoYueFt0Aw3EnFMXxyMv1+XVdGja0AAiDwJ
-5Tuhtk7QZ8BMLxebxihqi7y9/r/USbDuihue0+LGFEAg7B+/MFJZTfxP+Uw2
-ivOL35dT5M7bF/WEs3Aeh6snPiN5PmwHOap0ABQaJtOV2FmnkARXGazQJDuP
-0iirCnF8emI/4ulx2qmL8FKKknBiDs9hYyEnRjluvWEhAEseit/k2Ayrx8RL
-4eEFX7DGtAI3FDIwTcIh8EIaXZd0CYULkWFMqrvQFNigjJhRFam0Y6DfJmRE
-JuHUnvZEqnNHVeIC5zTYeQI7CNNX2a6VdSF0gXmLHNpIfqzorRLFGHF29tBd
-uyg9p2xH9dRHatVQWoWplbHBWqIm3fSLL1ytcPRfIVKY0PFeUxitNI6Gi7oo
-qssSwmNlV+ciA83pwwyBowRcWlM+84o6/1HjbHwBS4NOG77aAPjS+DqSQeEk
-TzdevgKnBY163q9ouNgKF8QIrgomdctyMKVLTh3gfWYJcg3driADh6/DBVzQ
-ISFPTSWLRAUiXVPt4WkWZ/VbWvgXKikiCPNKnqNxzkpn+9QfO3bsI+Ue8avF
-SASb/fXRS/YZ9eNJS/JInDCoTkubcZVj8JPMojcnAqvG5QUBWPNWxUlhGV3m
-t1MSfLQqTMfYcuXozt7KgOAQ1MAA3xpc65/E4Plm/6k4/fl3lT52jse/xwev
-g6319b+9D9YH/fUdcYBuEF7Qs3m3e55H9KegRt7AnqoEM+I++Iqu6E24TPjB
-WSz27qSNh7rjPG+cvWELwA+VgsOAZrFtzmtdIN3UOr6QaMklJxLpFxnAuaUT
-kE0erJPuQkF09gfOsRUJi86LcIoBAoN0csp9M0pZO42WrrC2bbznJMQDyzKQ
-yy7eg1jmEQsJ25FmiRayUdZoqeTTX0nU/NZy6FvcN1kdmhYfoqvbXfPd0W0e
-kv+vwW8CEcIEMMOkGjEtQ1nFWh4euCf4bSfn/iuyMkuinEwtjia6P1n3yQn/
-dUOyaKdiI/39HC8puwK59jhk0IpHogMrfFzf/qDP91y48T7HsA0H5n8dYUz2
-OyOyG+YIa7IVuBvg1BlM7jgD762XeursEOPq1YmlPufSZHdS9zoBpnYQsAzN
-z1L/VO4qAsvlyTl4zvcKkqVjUFZ4Wsz5+GbGQEuJyn2k6dsb/yfId7CRwFSl
-38Lr1VowKnnVbD6ZbI6tfnVp+dUdLvQ0xOqw9CLCeuNnnDG3NE5pl9MpW+bS
-Gh72+ZCXVsItkbd1r/VgAZqr2h/zHGosgb+NnDUH2ALWBBhpTA1SYL4aTLq9
-sf2GTRKshjCwjddPosnxbfzrF8b69fVykpfeQ7RIVu5uHhN6cHrh2kHuTQGe
-TN/2joilqOJ6sBWnlTJuVBBhrOrAtBhnNaTC67tCSnLznEhZSqp5qXL3pKKy
-e4tQqonTnVNqGZzKrAzvEiNrr6u7+fzaysV3Vcs1oFIle/0XPtQPaxXXMQkd
-FQFSLrtrrLQrOb2X/VvdFnYkojo1Gj+txW2vxRk/0U+tSGINUMei0yknKnw2
-IeUTXf3MRr9Us4SDBz3TgzF90d08j8IRks5qXH8uMMcgs8mhp3GPJLnvOPo7
-DJn3sbSVJKps5LFqmpAWHQyML2A0toj7NnHRuKXuCEvgh7D6/E0f9k3b7poN
-gGWi4nyLgnjY/Q9/OTkVR8en+tJfAqyvl4Fg1qlLDqHgs1bUSRZhbAesNJeN
-hcf0nrm155RY2CkgvrnvjVrXenMzzKLBLTUucmND7p6LZmvT+54pDTXHPOtR
-5beYZ5OZDSMtzMtYTaQixrCad7DvO8OpXHXpJsrXRY8qlMPfJuPeqjit2KSo
-8aIpixSEBYpoYuL51Ya3f6cCEStWtr/dJMnkq9jDqLzI3OiRRgJa7VTNdq6d
-p3Z2EstERzLBpoXfzrIqHfFOV72NnyUdcn4dFdJR8KpHWrqjnfx8/MvbfUdW
-0gUn4oBHdk7xBC1I+EZK9j0zFcOqQqWA5OyRExVSEKfg8IVGtrIRQFtqMa96
-4aegTEIzCJEQdTwrf9O6RkivhKBVWBRjlQIcM4DXpuzk/m7N/E3zYAYwQ3uz
-SGuesbv7iiZ/WpqedTyWo2d9t4AwwYv3wOQXXchfNxJFrKsbfAPIStR1ph8F
-qtbWVX+tFGyR5kF0DUDAr8rPGw6oc+WlboL5ItgnUzg58PoMCu/CpEajWD1R
-5XEZf/icN2cpr17JKa5T3RbjpBeGF9Hwg9qVUVHGE7ot03rHW6QVr5l6b+C/
-q/MtG2cimpVKzbtqTtq02qqQI1JeKABmFHel9KyC8zu9h1RwLWIhYVTmKQdH
-r7gwiEVZ8gWRs6TBCK9LR3xVTRzBOfOSeOyXeGYKKFeK8r5mwdAXnEwI7HRO
-JxHTDBQ6HjBYpRN1EacwySR7YaiT1b+5cPAf+N9/w8/DBx93xJ9gLsEN7GwK
-KRFgWCTR9yuKSU8pH8Nvu0dvODowWnn4oMiqfBhRAArs3g9g7Xy/gpJ1RVjf
-pIDG9ytxVI6DhMwgrsv208b6xlawvhmsb/Vx0BXabn8SJxHYjHhsuyfjnPiC
-UdpGSEYLB1MVgO/YQNmPsmFFppIyLUJRgFiYhBwyHpZsTHD8FpVGBNtIJzjE
-lxkFys7LOBQpJzVGtQFKioBOZSXngqLACFJYiKNXp3vHR6/Fx4//9P713pON
-rcGnT2jmvX91Yn/xbH1r/dOnPs9C8oDqSqQheDIwtEA66IQj4INTizUd8aF1
-GZjxQawu+WQ3nqLuCiBPGNzJRQQM1Ds5+XnVYLtRR0rj7WD18+npu5M5EXAH
-P317QkAkGba2nsCI1orK7NG45OSeyatKWgv8sMyzhF6iAepHu3uHCvdnm0hp
-AgMLcxmP1NUCF5nMMJQBxO+wlOtKLABOJDiNmFZbE19G7uppg/bk9E4hJli0
-nMaiOlMpVIGMpnJlGyDFLiYXQ0H0w+QSQCxJddXbtL6UVPesmoqFZhrZa6iy
-qhDPT8ho1xHOcXqZkWLE0XPwOPB3Na6MZgq9w0UcRxxyTCWYXfAx0eEGjNyJ
-vYrZ2X9Fw7LQO9Hep5xUiZPEwBaU2V0QGaVe5ZnqUSbhaDASgnzVgD4cbq2r
-HO8f0FxgIhbM8yYDjX44BqzJF6WhqvSKyYswMlMrYCctEI9X9NWBLpBUHjJk
-OvaSYoI1YHvQq5iiYwhSVcZcZgBHZg4ksY2y5f27PYsp1lT8BTAsWE4h7iMS
-WgSHYFIEK9EuzUYqx6ecIhID+ZBKaiOF+A8cVvfl5aPDPmIfGCIaj5HQMgJP
-STuLVeMxEyxOZdQdnt0xQ01CDA7IqiK5AUqBtyiNsyLSRJJAMG83JpPlUbR4
-RvzNkqmNy7SX0pnoq6LTXIbiRQe/N8sjTH6qZBT3CenEQcpttfdZHEjq1gmp
-cqFYwbUFJssvQT9T/qgqQcsRVw+D/7OJoVeUXsZ5Ru51YW+HQimyGj2A2ZIE
-X4xVpSIKTWzQH7ib2xKZT59vg+agu4UbkyJD0xKY5wqA9lmDHuwe7Xq052tp
-X5gUab+8P1AYrBy8On0t/nr4VryPzmMQmjcrMPSPMPTmk2fPPn1aY6gXIUYO
-jzjxDbGrfo8VR8mIaTxWEWsWijuIAVsaMCkYeAe2R57uoFmwQ8d6xc71JNlJ
-ix00BnYa5gLLVcYNF5ByQQ/LHab1wauTN9QCZgAfHT3efSHxA6+sQGxprihx
-aJJok1DBub7C6uGDU5ekmAMIvBDqoqZsSzTpm6zQZ/SeETjoCOGuwLBMQ2f1
-XBJgS8DUP88jhd5SVHoHSxBfQ9fEpZ1cqh0uJvxX+DGTx09egSsGPHKUldDm
-XYJPB9Fhwbh2am0SSmFr+XCFz5aUr2ZRkJgxCAJxFg4/4O9oYcqXLMFZXEhz
-b0++baFdjnCfrz/fpOWw/EBSTuOqrChHsSxDoe4kRnk45tFgBMYqGn2/Qka5
-Mip3h3hACLuOU81auzSsQE/mhbZqcEvj3uAENfjoGT+Ocyw+O8ScgXj08IGk
-yfsMhmLJ82uclLJ+kt7PQIiSxPFlHF0R/FOY4rsIS8hgQ6pPAiqREUJBWOXK
-M5yQrYN9LHMWbP1sqkkr5OGWbnAFexOsFWATfTb1AThmxNcI/x88XdUlLoUB
-AA==
+H4sIAAAAAAAAA+19aXcUSZLgd97jP/io3y6pakWSKQkBYuoQElDaAUEj1VRX
+z8ybF8qMlGKIjMiNQ0dRzG/Z37K/bO3wM8Ij8pAEdC963YWU6W5ubm5uZm5u
+bhYEwf17o2wcp2e7oionwZP79+7fK+MyiXbFnvht7+iVOAjLULzJxlEiJlku
+XofXUS4G4uR6FhXYOjw9zaOLXfFbmJ75WoyzURpOAd44DydlEEcwzGgUTmdB
+Phk9HTzdCk7jIkjCMirK+/ey0yJLIvh9V+B39+8V1ek0Loo4S0uAtysOX5y8
+vH/vMss/nOVZNdsV+/t7b96JX+EDmIV4hR/CnADcWZZf74qiHN+/F8/yXVHm
+VVFuDgZPB5uId1GG6fg/wyRLAeo1YjqLd8W/ldloQxRZXubRpIDfrqf8yyib
+TqO0LP6D5lyV51m+e/+eEAH+Rwie4nGUn8WZeB4lWVnG/E2WA22Psg9xyH/n
+GRI3GsdllvMn0TSME8CUOvdPufNPKXbpw7CNUQ5LwFo8rwp7hJ+r8DKK5wwR
+Y8/+KfT86Zzae+EfwBrBCsIskihfchJj6ouTgL4dc3hRlOcwxutIvM+q3+MR
+fxensO4v+vWPafS3OTBY5AwWEZA+jESNf8qoiXe8vRgmLF5VmQXxZVVWeQRU
+ECfR6DzNkuwsRj6wRgix21mV9ZFtfzrDDxk8bpu0zOPTqvQxws9hNo3DVPzt
+PErPWlZJDvE7Njnn9p2rEqYx7MF/iR2Av6TxRZQXcXktsglsvXQUFmVUW5M+
+bo2fEvVlPxz1qw+NAV6FpzmMEMEvSTw9jXKHg/fjYpQ5YM/OuN1PI/zKv8pp
+Ho8y2JQxMHfLfpDQuGlfNu3gnIPzvLqA/2bj627CjrFhY+Fq0J7HqfgtykBy
+/JZlqQXwxcn7Qwfc6fV1lf4UwZr386j/IW+Aeh+Pwnws/jVOwqQMbdKdnOw7
+oHJq2b/glj+NynLUZ8ZzAP6WVYDX6yiyYB2H06JSHCDBXWO7JIr65VXHTP81
+HpUonbNZ9HvnSlxQw36CDe11uH8vzfJpWALDEcMfnvwSnPznq/7O0yf9zV0G
+IVXHD/yXEHvTWRJP4mgsplVSxqPzME2BicdRWkTiMrwAdkvPynMQGxcxynjV
+j1rPkugKZXo4AyAg0eH7QlzG0LyIccJCgctmADpMVOc4BSafhCO1ly1pradN
+yIv3EYv1MQEXci7cED6LkDwXEe4FsTkYPuEvkD8jwGCSKTBWP0WUx4OnLkkO
+NVKkJEFwKbRBMYVpMQOVI9KoRM22NNowmo30mzAfnQPGm4N2jGUXhe/Tx4/7
+QxfjtRPEC6VLhNpvBoOdAtFb165j0XDGeTSLALsceEFNfBKD6SBQw4d5nMIo
+IQ5QXIOQmhZrS1OB5mDT4WV0mldhfo2kGLaTQvczxBgMarR4CZJThCNYvkKU
+GeJcjED6A2PAlKZxGiaF6L3qT6DZugjEu+wSvipm0QgWl/kdRTR+ANuBybLK
+BAcDe37/q0pwbsOnXXPjLnqz7uzUZrZ/HubhCGYRF7AqBaqRWZbAgvzOw07B
+9IM1BtRzWmVkBZhOCDKiEGBCYYc8GkWkh4Cvw9I0iWjlu8AtTwSYQcsaDzvW
+mHqBIQgf+mXYdoP9j9XqneXxmHn414M3DmODNsKPJnn0v6soHV1T0xWmhKPb
+k3oLEpiFTtcW1t3sWWyuMot9/Mja0qtPwxGeB8AWUngOtrrn4QjP42q2veUT
+RiQkgd8OX7x4IYaDV8/3jl8E70Hgt8tS2JZvT47W584GxgTRhSa+kAisMBPd
+z5rJVk0RrL2VqLKcA9lQxGcp7SQgPohBgAvyE8zLIh5HOS/R0uhvPW3bJDud
+6GO/+/eCIBDhaVGiYMC/of3JeVwIOMtVNMY4mgCmsP8BT7D0R8QBsDDIEfDb
+GM+MeF5jCUEnNZgU62NYLdR+dLikhigSEpwzWKhnYG5HfRwuKlDX5LBTxwqs
+hkhwNFQRghZBpZ+OoS1I51P4c4pMAH+eXiP8KomkbKLB1BmV4CjWAQ6bgGwG
+S9SsQu/kxTouxSQ+q3gpaEJwdixRXc3C0ziJS3VqKCpQu2EhfjU76RjsldE5
+4KFW/Uiz5a/Hb4+KdYI3QaUZ4K4jOAekYi0oB0rFvrFVbA+Fz7pm9L53pfSB
+Wrx/uU9n6r5a4Wk8HicR/vUnNE9yIBMtpIRDC/Tx4z9Bv8dPHw0+fRIxLrh/
+yURVMO3pG+rvkg27bUjC8e/vo2kGf7zLs1E0hoOY2A+TBE7aan3TrNS6kgWX
+nKmYhikMSdOb5Rmc2DPQvor4yFtHlh2176DxTrYXvaMXJ/tvj16uyynubG4P
+P31izuOpq6nJpZ0hQyEBiingCfuHJNFpFSdlEDdYHvC6gO1biGmEVmpcTJlF
+gELM1CKjAzD3mOTZlBDX4Ohz/4rGcqkW2n5yBxGY5ihmD/J4PHu169o2MG43
+llp6uyFUd5OyfkF7DldO84vcZASnsdEmYCACIxS4jJcREBn+TbM0OHlhvupF
+/bP+hpidXxfa5ld8UduoZH7BDrOdUmqza+0Q85mDEOxBY5ZsYNVUJcpfpGpp
+k1/SSM0Ptz8evQmIGoRJII09gEUSz13CUVIhd3gkBUFqlRYfP/6IzDrc2YL9
++PGjY7/AJ7hY7qebnz5t1GQMyxcaZ1kZI8d/DOedT58IQgMHP9OGYzA+0uiS
+aMNEjnljAwNpdaAktRIBRnjxuCi+aJO+hCWdVDltoXFUwrkVfXURM2IeWYdJ
+kjjkueOldEbClfn48Ro2ejACBgACyqNZUU2nqC8ld3z8iJv4LCrQV2lPsaHG
+mmuNTAk2p56oLZveGEGGbtYCbOpI7MHhLS6Bdas80uxIiKKcerK1vSkx+NOf
+xAkdPtBzdU2LfJSVLC8lhu+jCQqZTK3b9vaO5hL64NETZBt1Iv0QXdN5pmBx
+LudCkNR8mJmwcWmNjQCAn/FIhFxTI0oBqjIFMcFSKKtSaz6sWmg+JxIDIA8w
+y9qbX45P1jb4X3H0ln5//+Ivvxy+f3GAvx//vPf6tf7lnmxx/PPbX14fmN9M
+z/23b968ODrgzvCpcD66t/Zm77c1nt3a23cnh2+P9l6vNZcThZ80MfBEP8sj
+tDLC4p6cPpPt+f67//t/httyjpvD4VParrSAw8fb8MfleZTyaFkKpzj+E8h6
+fQ9ESxTmCAX1DBgZ6LVFvQgi5Ty7TAUwfdS/JzngXQ4ccoWtyVF/hMero3Aa
+KQ44rE1gg9xBtBlogdJsLIU8KySLlbPT/0IBqmX+jIaCCVbof+F9gk509Hrx
+d4BjkY3iEElCjhpoI22BHIT3LEvHmj20hSY3PbHAH2o+/POHs1m9P38wj8Pp
+K8LuySBg6cvf0W1DgmLZ/tztDmbRX+Hn/r2Pu+JPZXgayHkWbLF/v/ZO/Y1U
+8sxETmDtE84Awb0gvzhuRjxlvkuisECpNEvCUURjaeLQ6GlFRwugnVaprsph
+E825V8EbGaQJWDclCrc5VrpNRtyrUlc7CmuDqUVwbJL1JVglMqVwoJMkKKWG
+cgGFYWtlZVWsNdZiTYFEV3oYp2y7TcCiyS4VcQlSHlUFmRIei2RXzhwWHocn
+yOqzH8SeOEXaM8ONgSaorZW0I3RJH4VFU9DubA4esayUxy0pr3aePjUaYHQ5
+ngaj86CYjZYZeT8Lc7+FL8dydfA+6WDp7YSxwhHtv27MFYrj1VAkx8acISWy
+LQMzT6SjydnS41rsdJSRd03sQzt0Y7zUvpZXcNSv0LMEvXtH+y9frQt1MG4l
+jbt6PEyRZGVwGY/LcxhRgzTonjw/2EX7Bc8+JONn+hwYAmtK4SN6IKQzIY3q
+dTVCVCd6BzScfhIXJXvUJFxnErwjmN/hs0Be3d46cOMKClgqoTi5/WHQgrgL
+8mRlZcD+wNJLWeMsZIhBAM7bk182pDWuVJrHeDc27uOBYp8fxHGMy26+I+cP
+SIxxFuGxpRRwegR+KiNpKmSzKFcHBukDIWULaiGNNupofXCZtz4IG1R2m4so
+HWd5oFzMrkFtNLaijd55GzaQmqkgj9O4XdWeoVngmoRJgGbCHTBfAUe+JDxF
+uVOGeRnAxKxRABSpHWoh6MYX+LVVDBp79SxK4awpr5RByc7YdGVbR6lKwtSM
+/ZB/j2yL9QmYrMQEBIeYS2kjMtAYCOJoFsMCSfhosFqESr90lvabZDjPZl+A
+ADBqY9K1+UpQ3bNmOI35gcLm72kGAXkiLRVB7KvpSq47G0VludhEsAaRiNW8
+EGyutGtMom0dIho8qgPwPli6cUY6h7tubw62uKvNB/LQJKxzVFQ3ktA1CdsF
+m0/x3Ge+1hSUQGYgR6YYV1F4mKMoo9mChOOpYYeihR7G1DkMDujuPCjBesVQ
+nSePH+8E1QwdynUNSjj7dyzzqzXzuVzLKlpzLQKRjLvKnsXuXRxs8a6H/hIs
+AvHsXZvh4AAXj861cUxuPj4PskuC5gvSL7wI44QYMpWGzUgaNuoSKdZ+P1jN
+QjjHykK6+rb6QwSmPALoDNpYYRw61YXjCwz1UCb99PvhhpzMNApT6TXHb0Dj
+GKh1aNeCj6/WB2hXsc/R0zgYIo08X/x5SG5mNVArozVk4jI8pkhm8ZhYgs3a
+JaOCtJg+aJGMjbkuLSFbaGHza6hwbSFOxw5fWN400GDRcyOJg6eZNlHjRQaO
+uqd6/YzjETdJm9CoqRECY/NREaFELqOEDDmfvVI7FNe/3pCAM3WvUPdLiwK2
+BpxDMn2jTidkcZrBWZGcMIHv4ghPBeYiyJDKbJYViSRqrLosYbC7lyTwxecm
+RmM3rUqTFqtjcaoYTPzEMd9/bhpZm3xV6iCIJnEW2EJRC6vgN5+HDhREwBEt
+gX3Ja8ReWCdJJmfGxzjT37kklj4CQDeRzpM1VDHFGl6wRGNlN7Bj3cSH4QEc
+FbiMwaITpEJVOWBrZ7E6fsq7ov21NK7/iEmxbEbgZvlZmMroncaZr4MOHIiR
+joEG1pmR43/k4tH1fGOQAi9h+DSrV4T9lUF0hfZ8XC6OhXXwDEuO14V551FC
+PmpoaMcOxkDgOOfLoiSexiVeD8JyFXwNaK2qQoSmY+t+W/NXyVjdjRZgv6uz
+gLxR+lHrO46GJz9dPAnI2A/wTsqsAQ0N+ABnBGWVAnyWDR0kqB+YLBCCQbD8
+ksYez19dS2IHYMF4Wk1pt0zDK/pddtTm2oZ9U6sMKWPMyeak9WsrWeOqlRZW
+OrGdHWYtMq0g+4+loNZL2WBIir6preke7tWyY2HV2W65tRyNg9kU/g9iKiE3
+I3y2oFRBj3DJwwK90XbGKcvTJbK59NDImckhGpcyoTgDJk4xnLGaVrwT9g+I
+Bu/eHPTNRYLaOWrk0XhDAO4bGrL0QqkjD3D5LIkMI1QpH1dU8+/FpLd/sIGj
+rCtykIeK1iJgVbGQQ8mK47NcsHTP6YReffqk5GSaLwS4BRiFiGpgs2J8M2CD
+gYE1vRGsnZ0dBvWnP1Fc32vSvdiBf3vPjybu36sfJeuXHLXTNx1ZAJ60dKJZ
+HhUkFz1nPPviKmQsjt8JxFsyGn0EClb05MGSL4WBed6+ORZv9l+t6/tfEpRm
+4OIc70BPo9rlmNVODQXNFM44VMHj5xEc6gLAN6KGoD/PUbvQv0V0pm/X9upz
+iluVowy04OCbtIzPqqwqrO4sbEY6qvZ3DkJDZdJ2FOe7exqX7iHYEVUHCVPM
+RkpthR6Eq9Scz1Gz0X2u26zQhHZNNs+qjiPYtmOioyKsvjAjjv0O75aVRKUI
+UravsNVGO/U2FXu1UxwdYwyM4ao4f3UN1atfu3EUHXRDuHUqW3Gt2kmDtlTF
+F/f1bfGj3hY0y/+GH3WtlITT03EIYmy4/Xgo0qn4szgSV030pnCArXIGmE7X
+FZAayQ4WJtlwKZIdeElWvwbsJJml4G9IsglS6+nWcDDoDwYD8ern3xchGjTr
+phpa78Dmt0M4kid68y1FF3SgKcJs0D3JWG0YC+KZfVN5/OurDblSYKINN/uP
+kCg+1Nc3VHx9Jy4ueLwIteDv9Dfb4QuMZECXImwQtuU8C8saobGwx7/Cyr6B
+hYT5+BZvzvIjml1r7hdRNabZYDBIJMTCDixm111oRVBZZ0b6ksIRAW793uwi
+TCoTZ4h980Ybm+J4tLLRMLrM6GPSwt1aVJ5XySOrpbiK1gfdVcioI4w7rWYi
+w1NIXb+2jtzkd+lgiAqw7dhIQ2OvtpXmuOTkJthQaG5YtnFYkXJ1goU8Nz7G
+1u3pCwmKh2ITYV3F43W4RmogmvLBC9DnDqpBklYKLYsO/yU/gg57aQ7Gq/8i
+BNmA+1Tf9PrpbbNEFHNAsO3Fxz+aPndLoSlmjVs1sZ5xC9Cu6wEPdKO0EK6a
+Oj8uWd/VYTV8xawPY+5JVF5y09ogoSNDLYke0oYI2Sb4BQv+aAU6h3ysqxHE
+eCQsuS3n74h1E55kjpq1bVOTmt8Jf4SJ0iE1saDO3SjjIthK5WUEW9xgVTxj
+oNDODl2ZhPhqE04P6hlejI6XSYcqwsCHMcXXy/2pRzbNbUfNwtRWCIZXt42g
+dEPcFMH6HlVc1yITGzdI88Siibuz/P4b+k+8ALC+k/7OkBkyOI3LaTjTorw1
+csAJolaKolsAe28qVpXAbRCWFsBtgG4gf23CAXktQ2IFQgGA1WnU6LwCeRow
+VqSMmE+WBQ59GHpPOsYMQ+qAVABs2VIbkYXfZqtvJ3N6eGZGaEp7H+wFbWI2
+5XY2Nh+RlVlzWtrySPvJtViROgBEROpHXYcUYvgwPSUo8yhinwzboifofmhk
+RuFUJfyohu1eAD+K4wB2w/17HLi12wxgvnfP8kX6LkPJ8v5zEIieVsTrP0pz
+HD/f7bFxgAfCdfX5H9yFDonpj4LDc2i8Xf7MATDydB15uo6aXc0W0QAkujJc
+9EcbgPysbcrRzJqtHQC88IRpo8ujsRPqShNRIXJ5NJk7f4I0WhaSnxxXmhw0
+Iw9ADzyXjKMJD1z7mduPqNrsWcVp+cS/DHi3fBOek19xSocAT1nVDO/deNIG
+zB8GGLddd79psrD108LNFkwSAjWQclJFdToK8xzkA7NK+l0HyEU2SONntR3T
+m0szC0yNZg5q1tbzIWV2YVvXaXfXqdv1ivBBjJvoXLn0lkN/J/5N/vYfjR5i
+EfHR0WXq6TL1ENBlEPs7o3bI3i0abbzNWufk9ll0Wp5ebTPzbGIrJkLvZb2V
+vRIMW6hQSF59JSNsFBCGxc0tJ6EWifZneqPsOeX8qIYb7jhtfQcOt62Zui/I
+eL4Y61aaC4sEURcJTQHgw3QxUesVsncqXudLV3e3z5euq1Oy8dNBWl8Isp/9
+53J/U0HWInQXMlSWNlEWslDEAhaKC8jEjbTH99Z2+lzDzQLlCsJFIS0l2rzx
+omYN5m6Hlo2wvLZcSU96NOQyunEprbiUPvRrwrk6cDntt6zeuwlb/H+n+Pzx
+vPck1y157Fj+wLHCUcOOxqPwILON8c91hzdl+Fptz+aZGyjnjOp80+hnvbND
+1xzGLH7nn5ruRWsnXRJG1tGYZhOU57/Xe8EqLt/Lpk5ZpfKB2Y9Or7N6L5hX
+eaUXeIbJygJAmsnCf45Ppwv0Ca/m9clXGKfZZ6FxyqwMGz08fYhRPGGNTabx
+NGqITWxWexNnsVf9K293a5SAuWoCAh6htHzlg9LOqC2cqnu2s2sr55m+rUw7
+v28767byrpjPvl4e6einGaWzXzsbL9tv4fFa2LmFn50IyppyBnjO1w3l3MkE
+3nV0ui4nuOyuS0ovp+vigqW7W6tssbstIca6uy062qLCzO5msnTSMhdtWtSJ
+adfaVPu8ufM/3XNgu9+C+Yb/gEj6jwaryS/8ni6B+hYzPjW69eqMK1pUOv+s
+qthrvZdS77W+K22ZP260a/640cZZRfnP7TmHoVcxBOb2XGLMpfdRt2lQG6DD
+QNAtxQ3MBA+QFmPB10P5WeZYEc1BlrMlmv2XtSg8EJa0K5oQlrUuPBCW0PmL
+9G7X/M3ey9gbi/RecuyFbQ+h+nVYIMKC3WGH2M1WEq0OgFWkqw1gJQHrAFhW
+3nV3niPy7M5LS9ruzsuNvJy8tTt7rBffT90csTIZUxK/4ruWjkoaBj+Ifv+h
+/p9r2DyU1suCg3vkf+v46mfR8c2LI+eN3z0Lj7rpU7d4NAjfIz4L0LKa6Qbn
+Vo2SfBQUUICFjYzzBX5cpQDF7uq+FrO6evRWwwz1eKSgZ1tr+8dyvBkhM44n
+k4AwC8ZREl7XIYyjUTwF2m3W+o3O8wwfMI0Ckwz9x2a/nW2r30g/GwP7mw3v
+P6zvNMGETTWrTStlbcTsbO1E4BqCPsSsB21NzPBLB7VbwYwjlcK0DJKs4LR+
+LGPwT3Tsp1WS2CiOkw4U4UsHxRZQi+OrA2wD64Gb9il3cSKqvrfHR++7WLFI
+c6sHSF0A4Yrtem9X/raI+lb6NFrqeWu4C9LJw55m2n+xXdeeH99eMoQ+Datx
+4N3EPpbNsyQJssmki8y+fmSZyBsYO8LH/mlaCHVcVV645uh+psD2qNz882vH
+lsY5z6PiPEvaTuS+fjDJU1AlQQac1kYhlwmzqgRydvdye5S1HS1ZCeQpP3RE
+CPwZKSB7L9vdig/RpWcwe1ZaccjHx1pNzlGLLceglrvS1kfa2sOyjFW77I3A
+cncBdYqEiTRevkZkl7WolzOhl7OZlzOSl7GK60ti04fekZulaTFzfHdtdSrU
+T4EeTVmf3GJdrBk2T4tWl65pqvztYAt/lhl34ZJH4RgDs2uYtNBnWeJ0YoMX
+2BXBN09MDCm8uTm7Qjj0bqpJo4RwMCHTrTsVDijzGtq44+NqXEosHwIWs4X6
+GSiAILqCz2ET5Ge8w1gpNADMKF+m46FG90FRglTHw9KZq2Nc1WKaRVliN21r
+hrQoSt0S/lFPETGqG5gycCO7daw3pY23Yr3fmBzLjUqZFOONvVR4tyc99Ud8
+OUmQL2S9pWF/+Aw/pLTd9CZorcrTXey6S7xZ7F5Nk9202MVuu80sy9Rb5udW
+sRHPOOWArf/4yeYa1tf01dRkMJROZ1TKtr++Er9Gp7tC/PN5Wc6K3YcPMaEp
+Vo35EOX0QqYPIzy8PHtIaTEeqrJw0O91XJS74p+x4lyZ7dLXP6kOP8h8CEIm
+0oYBPCUpzY+Cwo36z2u1Jz3gfHU6m/C4Vf95vSCnB2C9JGcTGLXoP3dLb3og
+eSpHNoG11Iz8gRfJSh0hF8rO360eJ6kSE04OcDfXtxxe1zIxFXc4txJn/7CS
+bJaZU1lHiJf0NKRZzYJfZNAzkl4jGbbs6y1IsW6enfRay+RIAE6/eqGdRiWQ
+vl6L/Wx2ncdn56XojdaxBtc2VZ0VJ1hAVmdTxSMxPr3S3g2VyxVTQ1CdJl1x
+YqQSyiSC4GICoiLKL6KxGfR9BMdslvYq5UdVUNKaIqvyEaeoOY1TrEpB9SQ2
+KJmL7A3iBv8CIxyXTpfN2cCXvzNMJ1XiW5ZZlRcVHJlhnUyZHaxtQ4n+VWoN
+WEwiLBeCkAm06MULv6V/j+U19GyfHx/AZuYe+DYZcIOVALSPZa7K7f5I0cFQ
+8YHKPvg6OoM1eIccVtBLtveYmkkmv6H2BzIbserRU7KG6vlGkZEzEnGK5lo3
+lCWGVtJUlXNxioAUmGGVMt2oYgDPsJiI7K/S9MdlESUTEu0T0NgiIdSxStEo
+Kuzh7CoWD7B6xYMN/hdrUeDvqooF/k7FK/QvEoZsxxUszG+mvy5cgX/Walk8
+kEnSYMy93x5wDoEHqqLFg8UrWkgo9boWYrgtekgPrGqxzr9iTYt1b0kLQ8Nr
+sVhhizXSTQ8fCq6k0N/1VE4AFVQB7e3iCZQiZ5pdRNSXZghLE0lYCgS9+5Xl
+Yag2mqnEIJlhVp0qdzI1kOBIpYOtgMzSu4ZpwHEpBTNlHF5TsgMNFMVFMNgO
+tgasyz3iGAUy0ZtfjI5ZaguT4kc3U+y4UDFuBiPzCtn4DIPBk2C41YXPIb4D
+BIrKbdKNEVbhWRajh9/Br9+JQ7ZRuWDadw8ZV10DwI6M7sJWDaKfJnbji48L
+d8UrzO4aJpSPh3IjFBJhzOkScPWlYB8jI4ALVP/e6+P99Q2ZS4HboGx6D4IW
+KLWhN71wixmK3nDzIZYKXN8VixRg1FC8hRjtdbWoRfHcHKl5OZ4qegkurmCT
+8pn6xkNLING+euW5phs26Lg6JYmCBswClLwlUnbQspua4xtR8+BOqWkgLM6Z
+br1QoOfgIdYVXZqevlKnreS04ohvRs+XGtB8guJT3FaCogxnYK9QbMSpJLGB
+wVQUDud+XQTW5K0nwOqSlnYKLaeSy61LTXevt1NONviCspPotzlI64xZp+sc
+5iQItQfuX1aKqhZfQppq6tZzjXVxZ2udoS/GnV62XH1bt+7qJlcS3YaDwdn5
+7zW+rFN0Dl8OZa6tr4o1v6xCIgo+ujlpH32jrI+ym49uTFnOzvGNsnV5sDm7
+OW0xzeA36t5rGKgeJYUFYyvM8zLLI0q3+qxdeRnjtEOFtRnHcuydmW/vNNDT
+C9WGX9vSYwbIrqX3E0aX7evS3db0Vy7T163mb2TRr2jP3wovLqH1LYJ38YJe
+kUXXe5kl+Xa2qq+H/8HugrvBn8/uG6tL0l6etWi1LtIvquG6af+Nwa+tlPse
+dhZrtBJOXVarQ5daO3h3/C+1BTU957nNsG/vQAZ/kS/63TlCOD6PJ6X4l+ia
+Lv8MvHar6S83QIP69v5SheM8pPrrqyJx8C64CR6qe+8A7zneWfFuwiBn2q9M
+qr03T1ZF8Ql0Fr0norienmawTSyi7U2BRctqHHE4BEFb76bVDRBR3S1cuqhm
+sDMwFkITBhnurMxY1LkH/78teq2Oi+5vo7MYycTyNNvavAHNoHMP/n9bNFsd
+F93fRueu2Gxn+wYkg849+P9tkWx1XHR/G53bI5nRUNF8L+NzV6dhUUpOvqxT
+ur98sa9a915m+SUWyXqR55jsNMtzjmVYF3blZFVAcxzlMYZytKnFM4z2rhs6
+0ULH9leyImUbQqL3KgDE1/vd5o0yMZ4+fiQuNvsDaWUM0MpQoCMCPTKgUfEb
+GEV1OoU1SyNYyaKMpkW/nXE4pdLKkz7G7h1TPl5yymBVXQzR9T14DJMebi0+
+6fP47BxfBlHUPVtYy9AhzVYnwlGGHNlB49ENCFyGcU5p1TuIvL8IlffSNLoS
+exg5owj+ePAUaA0EB1t28FTasm9PftkWSYYR8ZSj24CgkJNJOIo66HgDMr6d
+RWnHLN/SJHUe9qqQeYUNhOdZEW2I/fOwGp9XeUxxJj9nI7Syz86jqeg93/95
+HZdqDqX2kxDDuYY7/e3+dp1eW7gr0fYfIr02kUFV5uO3J0cWNhYJNeFULCf/
+8Iq8uN0ROtbmBmy4n6Xov0qppBFQUPSY52r1JcNU0KlJGLY1QOYyMMXecX71
+FGaExTxM73FW4WOc6AqwwOqLxwcB4THcfLJBwU0/h9Mpx4ePo77pZ6snUgCA
+WcLKQMZK0hFxJNf80UO1CJcY4YRprOPCAsL1IMXB8c/QC4RKSDVfRjXyfL6t
++Mw3U4Z/cOus2xxJbZVHd8vEJurIvC1Y3ITQpfk4GBSUhEAl8RCBCQmMCg1y
+kKmCwgGeGMPJRT0NVqa+mx5RRVA+7qP6sohB+VDExRZpciTG8ImS1J+QkrU9
+aj+eOHr/t2Bz9uhVPSDDNJmza08o7XoK+ILJliIdfo8wewsAXveTgaoDnl5b
+64MUU5SpUwR3TVEIACewNJKH6S1AmkRb/c3+jk2ip4+eot5/giRivf9kvUOM
+1UkEu2T4xUmkwqaV4/6ES6rmpfglBShZjrVVYT8gsusNVvMw24LEfAzErHHc
+Dck5HFgM98X5CrBZgq0e3y5b1U+gXylbbRJbbX69bPX25DVYUsHx/o3o2Um2
+JitZ5yGeusCnwNdUDQjYCrhcEddL1G07fg8V8TqHHy9mkAuyZwwEOsWG/CgD
+iTrJqtwz/usQrSgY7rXXmm9j++GCCmfeOr18e7g//OwLpZbHNrL0QqHV8FYc
+KsuA9DStz/6Q1wMMJCKatVo8jeHiC2b1lUt3p9Q3cay+54Fddo31fqaAXxgH
+XKF511VPnu6KY6IzkvUFGtH8hINuKgxUvv6AlVL968+BWm+L4rwogwmcvzsn
+JfnJ22YOZ+3JqrGmHJqBwvY8Py+IxlZoHT8AAgv+1z3Rs+a5p0ddF9OoPM8w
+KCCD82Nh+rYNZp4h8EtErHwVXS1yabXyKrStg28lQJiMs+mdLcOJpKZLNTyx
+aVqZ1hbRGK1kocu9z0KnJAoLTEgSwgnwc1GLNy37LSza4CHadDqXpY6SMD+L
+qB5eEY/RFYupIEfkZEnlKxj4lidgnaewdnOIpyp+QIPncaoKSJnAYYfiCxz1
+jm6hWILPsxr8wJmkyB1KECrK7AgOfOFUjKKUT4GoWjbEaXQWpyk/yAa9rWqk
+M315z7vloGd5dgbLxDXJMlIySHz0STqNrZ0BMkTWvaM3f9CXioi6daQ79LZ8
+6P1FCDaOliBYgwhdFKtT96YEM37JsrqFiwewA1tuFNoVsOUV2TWGjAlVaFqB
+cre0qVrPeVfNbp6HFXv24PS9I16dPpy3+y3ExcUOmf07Kt6hfR4GQGNCaNge
+dVxieU5ci08Mw+UHgOvXOrOtlWe2JXrbYE8Ov9aZ1S8dF5/ZNtrIw/6Tr3bR
+9tOV5wZde6m4gpPmIwry+1omaLyiMA2V5Qb97h2CkVoJELQYbMU3wdSFznSW
+YNa4vH1zTFI+xlrJSURPwtvEGaNQyACqYIzWhQnek3SvITuH/PhkWQ0Ldg8o
+FHRS8yzUQEIN1Pv14c+/d7CBSiDG3e8Krd74+dRFQr7Cxce542hiv8Et+SNZ
+30mhxNfdmPXwWftK4vGc65BzlrcHRw/wfoMWktzkmEgAT+2eip16Jlrn9q3b
+rJOuEp8b4sHkwYZb2tyKh2svPV+Lg25WobfD8/jGpganB3/34QP8+wQLisZs
+XfNuexCmcILJm1N7wPuM04QVnI7gQpb81s9G+QE9DashPKih/MBT0L3+IKB5
+sWAf3/9xnk8pxh19IcY1Zuw8zrUOZ61Max19gHu3Hw9FOl2EbdPpepNpZXfJ
+nKMsvUDxg5nuFI9aOBFzagh+Jt33MGmTOTWQJpPWn1d2M+lnf+R3h29PFZvK
+WP5/aAGLLwr+DqQqodnk0dpriw3MraNkrH5zY8ySxkOdOTz9JcL8P7MolnXX
+HB6vlmbyNx1MbmL8bW7es2P/W9nWavO9eAPsevzrQtyKzdq4xf9i4RsnOPnI
+HX7gIjAd/HCo0mqRH9i9ClFgbexUjI4CcFgKSrmECcrkaDJ3kMrkQ2FGkyxJ
+sks36gskIkwr4ZhUq957IS9HHvW3GtczHWvt4q5vcLwEa8mbvhzpYBONs/yh
+DUtYsGjeFOoWYiHDC3TG4fqo/phEDKYXJpgC89omgJoDz6ieeL+dAupma7P/
+iO9/kf1/g5+2LEK1c+jhdBbGOZ5xgvASHWQn2SxLsrNrE3PryxeFIyybL0qE
+E4w1G+fwb0C5FCk3YSCvGIPYoFJKJAJO6QhQMJEYpo8qzimBFjIuDFlb4Vo+
+/ZvsCmeFZU49Xvx141+c2rFr6t8Tk9BK5maTW4QuCig5VU3Qae6wx2RXZkz5
+7GYgIdh9CgtInWN5X6C6UpwttmM3r/RR6ggtjTLB7thQ39jJ0rV2IlaHl3QC
+bONfmOQhUS4Yx2foRnlqfAP4T5Xih2tge63NUdQ1+Q+iATptCOZAMuOGm4/I
+kvMbCHaC52WR3vEi/WoVpF85SA/xCaGNNG8YR5+l+bLobnrRHT//adAfptMu
+nHuSbdflTRnuy6MsLiLxHneI0CYLmbsADg57qjPssyyp5FV+OibTZL6Gevr4
+McWK4hlocwhGAbn/MCdcZFVnIS+X7mwdesYqYefUSrzpWBC0G2E/RaBzcnPD
+qETBJD6F3WhC7DmpqAy09xsYaa4yKLvmZmq9blTCNc2fOR9E05l+Vvrp863D
+BmVGFB/S7DKl0wXsa0JFWr74repfpdSs799GeO/q3EDxtEAmSR1jKIAfov5+
+ZN2GtPgU8d0JNTxWZtYx1cEmbfUSx1x7Juo/qvunxoDbiw64LfarMptM+B0j
+Bj3zWO2gt1pAM7wtcaALlywO81EnzEew8mnwN4y7WwX4zqK02PGOQ0Y5WHLI
+Ss07vq6BHy868GPxHAyI4BB2OLqy4UDWMquODcPiBJ3ZY4tH/RtYl/S4oVz1
+4bFnwZFbi6JsLuE4SUD820qjtLBk0T1Wki9z0ZQCA00p/h4MAxILwvhDPDLE
+7QDWiOiQJXzhcBbGqW8hAktq0J24WBv0+9NQRyjVtds8XUwD4a3/83noLLwI
+pstKq+BiJUnOLzUUrQ2RVa8asfnaBaE8pKJEi5KdGn8OsjOCYVmCYJDnwnlr
+YNdAWnANsMvKa9CC4moLstQqkMr0L8OzlehsStnMJzMNviSdqc8NCV3HcTU6
+21AWpPb4dLoYrTttZDMRwn46Z8QlCQw9bkhexmoOUV1iKigSwFxyKsI98pGz
+S4M+Wlk1TdAsWESFPlpahT5aieDz8WzXoQpI+4osrkSL8bKLMPQfZzF+YDG+
+b8YevDs+WG86fK5nZC3yVHbFVv+peBEMtzfsIwoeSX99+Obn3xfwZj59PNCP
+Np7iU7wQayOMRlFBDiQ4xHHa+Fyw4z5MdBh071V/Aq3XRSDe+efgeILaSL34
+Zi7GN9zGfiK3bWttfft4CTq2cpIMz3ilymzcN/EZuj4O3qAm6OfHKmZ5GYC1
+3hVmg3NAv4fVBZHkPyMuMkEXLEzya/aSmNoQ8mqT2lvhkPzt6DyLQeQ3cra3
+Bavw/QQVUKC6IP9TXp/QmPh8opk7mx5ZUOtaHmmBwdb1eBX+IVqvySDKAGMu
+kVWweENPV13VOG/YPfnn39fcZOD/vra+5o7Qeoaiaf5rmMRWDQSTph4XHudq
+vQSxWNBiUFWmZ5en57RuHXmpe+Ia0q2XwDVUPTFmNPRqt/U1JDovsWw8NME+
+OWwy8jHI6I4ZZHTbDLK/FIOM7opBFEvUkG8Gs/w9cYhV/sdaLroL0xS1MtfX
+5GyLC+Tzxq442tCrFaJZl0JgsNQK6+TgFZByLS0olKXU9xXraM1joxh8l+Qf
+V37aEFE56i8u6mnPyTA3N9fqcpv76xb9VhW/+sDdiX8b4NrlwGvDKSo4rB5c
+RjEQ6m6Eg3Tq5HrEn4rNR/wv8ArfoFA0DzKUZ8JftXjwKhBiiNHnY7svo1Dm
+sV1rYYQGuBuxXToFrov7EXDd5sC6R5E/EymPNszNM735x4mzSlO31qrl3xP7
+dWgnj1KKZl+FPjLcfHeRlGYMKja2tbMFM3nz7vWxeHv87mVw8sJ+QYil56oZ
+vVnIJlYMlYbRWjbQKRgoeii91v2PlD169zzrVLsqk5tpvJD2dcni0cIrnL1W
+O23J8fjLgi4EScBRrje1jz8uJgi4O+JA3ZUYcLcq4SJb1iRS68kPf+YeoDpx
+I/xucJDCn0UPUzXB+akxe7pH900+SOKiRB+LekhyI2JgpW/9hmTzZrQqiFgY
+VHNjahGzUhInM1FPf8k8Ddq2CntCe8k4yCYER3p1ZV9WP21rfdPD7Lfz4Gc+
+D4Lw/io07zyNRN46KobapZhq3j2YQ0IB7pZ6UoRUdKmDVxpJVorNvWTtto/9
+xvG/r9XKyNXt4rZIhj1TktgYxcjEjmFcA24xruYSvy615seBjjaV5Fbtrh+A
+P9129+L58B1pAviEoDUUjlaqfXs7tNHtDcxlWk0F1xk/BdMnAsKZiPmiD9YT
+DwD049OesyVfWXcH3h2hd8XjnadPdsXLPJxG9K4UQ1reg/yMc6mIcHeQkRfg
+G/qxM8w+sFqeJa6B127YOX3nG3kOSWkxUUNaqzAJR2WWN9aS3zi4yyiv7YfO
+tX3bmg0XWaM9FV6HsdwqeNdb82ADs8iQjqpVEqdEH2qpTdeCzWaO+cXwYhlh
+hB/a7yyIis3uMWbDSkYVyw/30UVLF3IziO8b2tVP7+9aNtWCHLfCucHl7U4e
+8/GV030uj4VXd8hj9DT4QV/88L0Aceul7wMXKuVGDqZRUYRndeX9JryqLyUN
+cIoSloI78ZUBXYfRC2+wJmpr3GS/fuvuuNt90JzKUvug2X3uPmh2ad0HXp5o
+2wc11A4n6h41Gm/45tmyZA4QtXy+BaMh8CKzOYwDw6VNF8S/7438yWuPoWNv
+2Qvb47dHi9/YmtYaTTdvzd25Cr5dyXaPTKvZPNgCW/5DuMa/3a2acfelC8xy
+XeKTiQqVDogk+OXvYrm/ppOskZw3dq6ijPz84lCO9M1b+lm8pUydO/eWfnOH
+fnOH/qO5Q78iqe/xL3aJ/kNL0Ien+HT9dXiNz/AaIYuaazyCv8sVx8mqrWCX
+Rb2EOuhFjf7JQmKWx5nrENTH+yfPuuG+U13hoGOSWBvy0iLECZXwkgCcQ13v
+8Hj/YF5lH1z47c0BnLPwhNV+vLLYwhqCjlDBuzwrs1GWNBigR2e39Rpdvgbu
+c05rKwdSeayNu4mW+hYn9S1O6ms5DH6Lk/oWJ/WPaKZ8gWRxWh21xyLPcyFa
+V5SLOhI1fvW+PiOqlseubnfLr+dYMjczuJsHRqcQXiEHPXWTN21xbQ3lR97g
+jPZ0gwIfm/6mSkPbiUxl6w7HF1FexoXcTQbE9Puh2oDTKEwLlXEqdyobeE56
+6UatZI/5ipzllEbc0y0YItnUFwaE1eTPQ6SwHry/kA32OTOVcSf17w3i/TSM
+24z3szakSWJDa9KxH1+a/VRbSAVXL0NbsKf7AsHagdPuHThddgcumHXv62Kb
+BYXnzUM0NcSadT/Xw+en/lzPXotXr84lLis2z6d+9xhwVVkVVlJLS/PWPWYN
+cY8/H6JrFWeSuuZDF+h56NfNqm5Yi5pUOB8QD2ZKithFbWWZTjWLxedUa7GN
+GzGbVliUM8/CnWi3W6oEbkwikGA2OLmLEjk3I1tqBKTBKqWf6lNt8RgS1O6V
+aV//OTGlC/LvHMJYy+qK1a7J1kH4J9/hj+yUeF+pqlrGoWaUVaBTCH6O+MBv
+kXZ3FWm3FFPavRcJrfMypg3kW2jdt9C6b6F130LrvoXWfQutu+XQOu+jyBWv
+bJpHO+uQzf7mNq/23MvDRokA3w2iY0zItjuzTdeeaD8LdYSuOJ7k9vACh9v1
+ijgXHDtUdcoxPNpLPN7g7C9WOf6796umisPSC6VLP8xdJmrZWKRvS+FdCmd3
+LnHdTeVOw5JrO6uLC6agpaXUXLSCsSYgI3FAYj04euBqmZeoRq/CKcikDekI
+C/lWSNYKaF0kC4h96oBB1NJsyBdHzpfzcexmjVFWJWPULHgkIAawgBymnHkc
+HREbJnMZgVUenOJcQYhotrKYsQUFzmkFjApLw5ndjcIuorJUSd2dVQWVs+kS
+trZq+EdSZDJLVlgsTM841T7gBVj9pk/Db3YCb1FTVJpmFAFzza+KR2TTPeOC
+suOnY/bGnkbGscHLIhdDdbeVGlZwsId+UKhKAKo1+pX0ChlpEF3hnVVccjm+
+4hwrzGERjeoMnTnR2M1Prar1iQj+E+XaIAs4IWqO5Q5IDMCSqSR87ghlBLsv
+LOVlCgK0LJUs33Ahqr5MSUWpbsAGHFX0zqj6xbhGCZPfnEAXlrvCRwNVrluB
+qM2U8cFhdmHXcE0EKWecbjZvjFTcDl4saR4AMZtd1kP5bTZCUzYdh2C9XgO4
+al7BwEO21yNCEZeM8GkyCm1ZXWnFttLw2416+QnYytRLZlG0F6IetKKqiNQd
+2k6xmGe1L2F5phlKG9nGHburC6wdr2iLX9wDye++ndOQmk5iMEtB0rn3/t2+
+XZCqtFvdreinr+umpGl2U2Il8s0joMDaCA8fdtPGT213/3rp3Nrk9ins8KlL
+W5geEcHBZika2XNqSJclglb2HY8/iiKu16JqIIEGd8nfOOsKHtM5fDd3vZqp
+v3vdQ15jgPoE21nFIahmEmyDMQmwTE0+kcrVbkNycJ62dSTqnWldZ5S62vVW
+3vn/WesiG0ldZhSsYsz65oBjblEz837FIfnzcoNyr2qFRuEVdC5osntoR1SY
+5SHclInbn3eGW+gmzgzrHVGq18IazO3WEHt0zYYfBm4UfYswdG7ehn6vN08l
+0ZeiCuNuPJU3lVHxhN3LGlIfa7ds0pJGL+rmo0cdEXYOhocHzUOdz6Bt8W2S
+dG4zvSVf8uZi4j50eLz211pTJv5ZrNVl3lKhiHs8uKrNqovrMO9q+1Lu5Xp3
+tbcbzzzs9y6KoeqF2hraR8WOMNDmt7ARQ1xA/YAP/ufy60MPf3oWGH/INeqA
+8lCX6OsO8W9yiO9HVQ5nv7K3/h/tPW1TsrEs+NP5ikfnfqbaZKgQKHKS1G+t
+4mDh6+0qWksZrD1rrGSDPt3vi9SNt8SNcm0jnyyA14Lq36ftG2j62MxjA/7j
+c5pn0rfKb54zwLIsd0cctxpmN2E7b1QGWZceDVooo9G1Pj2NuMlcA7JmZ3pL
+m7ZXQ2qULmVjCS2WsyqEIcsoYruTBL58wGOce4elvlOCc4tdz5SccVTFlO5E
+yAFk7sWeBwfHo1+D6/L33sW6rGQrjxCFY4iiIYQWBfZPzRlALjZPIo9GWBp1
+rKM+uBlHYfjooe0C38nea7+0vIjxUa/T6dZxWPeeALiIFtj8uV2hU1rjNgfb
+gAv7So8Lb9ao0lbtUxKm/vUqtOGmXIDOrh6LrhjGSQfyWJvJ1hemNmwhenuH
+6y1blsnj8/DPqVqrJutvtcqc55e2bT0Rz+WcWQQdyuuAA2I7eGZPHv6tyCTl
+v5cwZFCtPj7KgHTrrlxVStQ9KHhX9PpRH45X+wcb4t0b/M/B6/V+jbW8ePqr
+YLSXI8Gftspq/OOtO2UxgIZuF9Wwvm3UTGpZ6KWcmKgt3x4fvddkC4siG8Wh
+45pVkWoqxsD0N1VXhTwxgmQjid9Vag0Fr4GxXKGYFl7zurq8vGYEteNuUHME
+Ma0VqaNfNXn9VYBtvwdd0EhNWTiRpZaaMAMqILqOryFqEk9jmcHNdQ704HBK
+C0fRDMTbZv2viN/p84PXG+IvKiaDoPHzx3XLaX+YSv/tpOYLq4vv8ryu6BQI
+QJmQc5+2JGAo4DkJaBKcxkDNcqmXwqa3x+G8uIh7DjTDoR8mVAk145rJLF4U
+yXlOIeyZgiqT+m7ILJatmyLyRczj/rC/6RPr/slzmNSz2v5+BY0fAsQ5u7zj
+FUKOtdrUkD39ohIfuA3WW2duoNRIYE8EY32wRFlAvB6MgYevRW1azRqOcmaz
+YqU5qVCkA1karYzpdRiML3h8mlEsL1vY0wF/GQhJmHpfjuNkRud5hvd8I5iW
+rg7qnY8r7LtEfYugrwvyWfHQlC1eiSJYJGpWUiwB/FpNZTSXnpOw5tTbP7DD
+SbPUkdZ18qC4Go0DpRQ+roDk25kUHW2aJVRhAgZ10719DqQZnCtyEr5KwqLo
+BNRJgDnGA8r7VPug7Vi/wtwmTqqUt7Lq+r2Y9Nw3/pwvY1y3FtrshW6LYZ7N
+0GE1+N7UupaD68XzMl2779NvRLRHOqLk2deLduAu2vyacfizSt04Z5ZkrzrW
+XMuun2UYFCENaPJRfIHdfxdb356YsK+FEKC1JmAvrLfJAH9QiNZ4OzuyrvkQ
+65rvn4dIiyiH7RePCnZvGBwshkLhbKGAjtooLZDHCrY2JhoTvoCweVS2ZfHe
+mKQF1yfIZtMvKcm6sJULsYhIg0k4Mm1VYYYD1qUZEujvVZzdlSx7Zy/bG1y2
+g9qyNYSaDWOB8qR3KtTG0QzdS2nplERuFBdWlR9v8UQ5R0K1Sit7WRB3Ov4g
+7j08sy9isMzGyWff56Jlo3vnsNA+Hyc3tV1gLNrqEkRzuwOd/Nu9gzFub3ct
+o8I0GW0IiN/KO0U/2Ee9j0Piblkyh5XpeaOD6RsNhoekC1r1UtC+Wo9T7USw
+6IAsIf2L3tNNnAbk2al5kFPjJ2xWhl4Kf+WCwJwMBbtNEdtBfyjSqV0N9xRY
+hN5OWK9MYq3uxwwkLMV7FGJYJdacuemuxPTq5VcBfKmfEFDzdZShCXWk1yFv
+Do8Cdo2EWPN8lEeY9t4+EFLUQUbn8oCeEAHfZEUZvHyxL9IoGhcyXCW6wmwk
+0dhHXx8mXjlr175e8iivXr8zcNr8YWFRh12h6DPV7lb0ZRkoKEkUI/hEZn7l
+TuCu5adechrN3dR6/XyUtYOzfVKTa90vYB/Nt5DqNGnIzwbRuoSpVSvdko2+
+nXe79st7RWkqDD3PG+vWpMefO7RVgB//0ng62O06muv0dgJeUDD9RQ4AYgV3
+dXkO8ug8S7xb2eiE07AaBx5X3UKnwKGHIIz+8/FKAva5xqZLNVhspzzNlmqw
+N46BJx/OIHooRKw2xfX0NEvIYYq8YVQdf2S1xFRA1BiXPEcnaEYBlFaTWZUw
+R6iv+zaAw1I/4Kmmp/xAcoznSNiUErSt7s7x6ACmFLsn6dFFWazD7kDPdOYE
+gwsZKDaNC7LXp9E4dt77WQjH+FCFVjBMEmcPyLnDHpJDIjsJ5UX2uhTzLEmC
+bDJZhX22vU6EoWebzd0BFg+R0aywknuidxqVIYtkaV5SHqQBknFoewn1hWAh
+zrNLaYADISQ9ivMQT2lXo8iN0YNmuJGIY/ricPL9QJZ2j64AASDyNJSPndo6
+QZ8hM71cbBqjqC3yo8H/UO5s3RU3POf2jSkKQtg/fmGkUrP43yOalBpn57+v
+psidBzzqHWrhvHBX75TG0slt+15UTgOKb5M5V+zUWUiCywxWaJqdRWmUVYV4
+e3Jsv0Tqce6s8/BCipJwam4ARjUXDmDJQ/HDIpth9Zh4sz0651vimFbgmuIe
+Zkk4Al5Io6uSbtJwITIMrHUXmqIzlBEzriKVOw3025SMyCSc2dOeSnXuqEpc
+4JwGO0tgB2EOLvtoZd1qnWPyJYc2kh8renBFgVKcYr7mtIrSM0rZVM/fpFYN
+pVWYWmknrCVq0k0/W8PVCsf/FSKFCR3vXYvRSpNotOwRRXVZQXis7emEaqA5
+fZghcJSAK2vKJ15R5/eXzscXsDTotOGrDYAvja8jGRRO0rvx/AUcWtCo5/2K
+houtcEGM4KpgZrosB1O65PwH3reiINfw2BVkcODrOAIueSChk5rKeIkKRB5N
+9QlPszir39LCv1CZHUGYV9KPxok3ne1Tf7HZsY/U8YifXkYi2OoPxs/5zKhf
+gFqSR+KEkYFa2kyqHCO4ZCrABRFYN0deEIC106o4Liyjy/x2QoKPVoXpGFtH
+OQo8sNI4OAQ1MOBsDUfrn8Tw6Vb/sTj5+XeVA3eBF8xvD18G24PB394Hg2F/
+sCsO8RiEUQZs3u2d5RH9KaiRNzqpKsGMuAu+ojgDE/MTfnAWi0930sZD3XGW
+N3xv2ALwQ6XgMKBZbJvzWhdIN7XcFxItueREIv2sBDi3dKLK6QTr5OxQEJ39
+gXNsRcKi8zKcYoDAIJ2ccteMUta80fIorG0br5+EeGBVBnLZxeuIZR6xkLAP
+0izRQjbKGi2VfPoriZrfWpy+xV2T1aFp8SG6vNld5S1dSSL5/xr8JhAhzGIz
+Sqox0zKUpbil88D14Ld5zv1XZGWWRDmZWhwSdXey7pMTw+zGldFOxUb6+wWe
+g3ZFo+1z3KMVVEUOK8wQ0P4q0ffmufHIyLANvy74OmKx7MdSZDcsEJtlK3A3
+SqszIt45DLy3nhsq3yE+DlAeS+3n0mR38g87UbJ2JLN8X5Cl/qncVhiZy5ML
+8JzvKSdLx6Cs0FvMSQXnBnJLicp9pOnbm/wnyHewkcBUpd/Cq/VaRC2dqtl8
+MikpW8/VpXWu7jhCz0IscUvPOqyHiuYw5tb3Ke2aQGXLXFpj3D4f8tJKuCHy
+tu61Xl1Ac1XAZBGnxgr428hZc4AtYE2Akcb8JgUm3cHM4ZuPXrFJgiUdhrbx
++kk0Ob6Nf/3CWD8hX03y0qOOFsnK3c2LSA9Oz1w7yL0pQM/0Te+IWIoqrgdb
+cVYp40ZFQsaqmE2LcVZDKry6LaQkNy+IlKWkmpcqt08qqh24DKWaON06pVbB
+qczK8DYxsva6upvPr6yEgpe1hAkq37P3/MJO/bBWNh4z6VElI3Vkd42VdiWn
+97J/q9vCjkRUp0bj98G47bU44zwDqRUOrQHqgHrycqLCZxNSvjPWb4X0cztL
+OHjQMz0Y02fdzfMoHCPprMb1Nw8LDDKfHHoad0iSu34McItx/z6WtjJdlY1k
+XE0T0qKDgfEFjMYWcd8mLhq31B1hCfyaV/vftLNv1nbXbACsEhXnWxTEw+7/
+5pfjE3H09kRf+kuA9fUyEMw6dckhFHzWijoZL4ztgOXysonwmN5zt/aCEgs7
+BcQ3d71R61pvYYZZNrilxkVubMjtc9F8bXrXM6WhFphnPTT+BvNsMrNhpKV5
+GUuiVMQYVvMO9n1nOJVLR11H+UD0qMw6/G3SBq6Lk4pNihovmtpOQVigiCYm
+XlxtePt3KhCxZqUs3EuSTD7tfROV55kbPdLIoqsPVfMP1857QTsTZ6IjmWDT
+wm+nWZWOeaer3uacJQ/k/MQrJFfwukdauqMd//z2l9cHjqykC07EAV12TgUI
+LUj4Rkr2PTVlz6pC5bHkFJhTFVIQp3DgC41sZSOAttRyp+ql37MyCc0gRELU
+8az8TesaIb0SglZhWYxVHnNMY16bspPAvDV9Oc2DGcAM7U2FrXnG7u6r/Pxp
+ZXrW8ViNnvXdAsIEL94DkyR1qfO6kShioG7wDSAr29ipftmoWltX/bV6tkWa
+B9EVAIFzVX7WOIA6V17qJpgvgn0yhTMcD+ZQeA8mNR7H6p0tj8v4w+e8OUt5
+9UqH4jrVbTFOemF0Ho0+qF0ZFWU8pdsyrXe8lWbxmqn3Cv67vtiycTqlefng
+vKvm5H6rrQodRMpzBcCM4q6UnlVwdqv3kAquRSwkjEqf5eDoFRcGsShLviBy
+ljQY43XpmK+qiSP4sVUST/wSz0wB5UpR3tUsGPqSkwmBnc7IEzHLQKGjg8Gq
+/6grUYVJJtkLQ52s/s2Fg//A//4bfu7f+7gr/gRzCa5hZ1NIiQDDIom+X1NM
+ekJJJX7bO3rF0YHR2v17RVblo4gCUGD3fgBr5/s1lKxrwvomBTS+X4ujchIk
+ZAZxcbmfNgeb28FgKxhs93HQNdpufxLHEdiM6Lbdl3FOfMEobSMko4WDKW3A
+d2yg7MfZqCJTSZkWoShALExDDhkPSzYmOH6L6juCbaSzNOLLjAJl50UcipQz
+M6PaACVFQGeyHHVBUWAEKSzE0YuT/bdHL8XHj//0/uX+zub28NMnNPPevzi2
+v3gy2B58+tTnWUgeUF2JNARPBoYWSAedNQXO4NRiQ0d8aF0GZnwQq0s+2Y2n
+qLsCyGMGd3weAQP1jo9/XjfYbtaR0ng7WP18cvLueEEE3MFPXh8TEEmG7e0d
+GNFaUZkCG5ecjmfyqpLWAj8s8yyhl2iA+tHe/huF+5MtpDSBgYW5iMfqaoEr
+ZWYYygDid1TKdeU3lCFIVSz/kWviy8hdPW3QnpyjKsQskdahsahOVR5YIKMp
+v9kGSLGLSSjBLz4xQwYQS1Jd9TatLyTVPaumYqGZRvYaqtQwxPNTMtp1hHOc
+XmSkGHH0HE4c+LsaV0Yzhd7hIo4jDjmmEswu+JjocA1G7tRexez0v6JRWeid
+aO9TzgzFmW5gC8oUNYiMUq/Sp3qUSTgajIQgXzXgGQ631mWO9w9oLjARC+Z5
+k0ZHPxwD1uSL0lCVq8UMTBiZqRWwk9uIxyv6yqELJJVOhkzHXlJMsAZsD3oZ
+U3QMQarKmGsl4MjMgSS2Uba8f7dvMcWGir8AhgXLKcR9REKL4BBMimAl2qXZ
+WCUqlVNEYiAfUl1wpBD/gcPqvrx85Owj9oEhoskECS0j8JS0s1g1njDB4lRG
+3aHvjhlqGmJwQFYVyTVQCk6L0jgrIk0kCQSTj2NGXB5Fi2f9ztkpxsC0l9KZ
+6Kui01yG4kWHc2+WR5jBVcko7hOSx0HKbbX3WRxI6tYJqRK6WMG1BWb8L0E/
+UxKsKkHLEVcPg/+zqaFXlF7EeUbH68LeDoVSZDV6ALMlCb4Yq0pFFJrYsD90
+N7clMh8/fQSag+4Wrk2eD01LYJ5LANpnDXq4d7Tn0Z4vpX1h8rz98v5QYbB2
++OLkpfjrm9fifXQWg9C8XoOhf4Sht3aePPn0aYOhnocYOTzm7D3Ervo9Vhwl
+Y6bxREWsWSjuIgZsacCkYOBd2B55uotmwS659Yrdq2mymxa7aAzsNswFlquM
+Gy4gJbQelbtM68MXx6+oBcwAPjp6uPdM4gensgKxpbmixKFJok1CVfP6Cqv7
+905ckmIiIziFUBc1ZVuiybPJGn1G7xmBg44Q7hoMyzR0Vs8lAbYETP3zPFLo
+rUSld7AE8RV0TVzayaXa5YrIf4UfM3n85AUcxYBHjrIS2rxL8OkgHlgwrp1a
+m6xY2Fo+XGHfkjqrWRQkZgyCQJyGow/4O1qY8iVLcBoX0tzbl29baJcj3KeD
+p1u0HNY5kJTTpCorSrQsa2moO4lxHk54NBiBsYrG36+RUa6Myr0ROghh13G+
+XGuXhhXoSZmHAaeGWxr3BmfZwUfP+HGcYwXdESY+RNfDB5Im7zMYiiXPr3FS
+yiJQej8DIUoSxxdxdEnwT2CK7yKsg4MNqcgKqERGCAVhlauT4ZRsHexjmbNg
+62czTVohnVu6wSXsTbBWgE20b+oDcMyYrxH+H4+tr7WmiQEA
 
 -->
 

--- a/draft-ietf-ccamp-rfc9093-bis.xml
+++ b/draft-ietf-ccamp-rfc9093-bis.xml
@@ -48,7 +48,7 @@
       </address>
     </author>
 
-    <date year="2024" month="April" day="30"/>
+    <date year="2024" month="May" day="21"/>
 
     
     <workgroup>CCAMP Working Group</workgroup>
@@ -371,15 +371,6 @@ frequency tuning steps.</t>
 range in case of operational mode and explicit mode.</t>
 </li></ul>
 
-<t>cd-pmd-penalty:</t>
-
-<ul empty="true"><li>
-  <t>A YANG grouping to define the triplet used as entries in the list
-optional penalty associated with a given accumulated CD and PMD.
-This list of triplet cd, pmd, penalty can be used to sample the
-function penalty = f(CD, PMD).</t>
-</li></ul>
-
 <t>modulation-format:</t>
 
 <ul empty="true"><li>
@@ -671,26 +662,22 @@ module: ietf-layer0-types
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               decimal-2
     +--ro max-chromatic-dispersion?           decimal-2
-    +--ro cd-penalty* [cd-index]
-    |  +--ro cd-index?        decimal-2
-    |  +--ro cd-value         union
+    +--ro cd-penalty* [cd-value]
+    |  +--ro cd-value         decimal-2
     |  +--ro penalty-value    union
     +--ro max-polarization-mode-dispersion?   decimal-2
-    +--ro pmd-penalty* [pmd-index]
-    |  +--ro pmd-index?       decimal-2
-    |  +--ro pmd-value        union
+    +--ro pmd-penalty* [pmd-value]
+    |  +--ro pmd-value        decimal-2
     |  +--ro penalty-value    union
     +--ro max-polarization-dependant-loss     power-loss-or-null
-    +--ro pdl-penalty* [pdl-index]
-    |  +--ro pdl-index?       decimal-2
-    |  +--ro pdl-value        power-loss-or-null
+    +--ro pdl-penalty* [pdl-value]
+    |  +--ro pdl-value        power-loss
     |  +--ro penalty-value    union
     +--ro available-modulation-type?          identityref
     +--ro min-OSNR?                           snr
     +--ro rx-ref-channel-power?               power-dbm
-    +--ro rx-channel-power-penalty* [rx-channel-power-index]
-    |  +--ro rx-channel-power-index?   decimal-2
-    |  +--ro rx-channel-power-value    power-dbm-or-null
+    +--ro rx-channel-power-penalty* [rx-channel-power-value]
+    |  +--ro rx-channel-power-value    power-dbm
     |  +--ro penalty-value             union
     +--ro min-Q-factor?                       decimal-2
     +--ro available-baud-rate?                decimal64
@@ -799,7 +786,7 @@ module ietf-layer0-types {
 
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-04-30 {
+  revision 2024-05-21 {
     description
       "To be updated";
     reference
@@ -2494,37 +2481,21 @@ module ietf-layer0-types {
         on the receiver";
     }
     list cd-penalty {
-      key cd-index;
+      key cd-value;
       config false;
       description
         "Optional penalty associated with a given accumulated
         chromatic dispersion (CD) value.
 
-        This list of pair cd and penalty values can be used to
+        This list of pair CD and penalty values can be used to
         sample the function penalty = f(CD).";
-      leaf cd-index {
-        type decimal-2 {
-          range "0..max";
-        }
-        description
-          "The identifier of one entry of the cd-penalty list.
-              
-          It may be equal to the cd-value attribute, when the
-          cd-value attribute is present.";
-      }
       leaf cd-value {
-        type union {
-          type decimal-2 {
-            range "0..max";
-          }
-          type empty;
-        }
+        type decimal-2;
         units "ps/nm";
         config false;
         mandatory true;
         description
-          "The Chromatic Dispersion (CD), when the value is known 
-          or an empty value when the value is not known.";
+          "The Chromatic Dispersion (CD).";
       }
       uses penalty-value;
     }
@@ -2543,37 +2514,23 @@ module ietf-layer0-types {
         compensate for polarization mode dispersion";
     }
     list pmd-penalty {
-      key pmd-index;
+      key pmd-value;
       config false;
       description
         "Optional penalty associated with a given accumulated
         polarization mode dispersion (PMD) value.
 
-        This list of pair pmd and penalty can be used to
+        This list of pair PMD and penalty can be used to
         sample the function penalty = f(PMD).";
-      leaf pmd-index {
+      leaf pmd-value {
         type decimal-2 {
           range "0..max";
-        }
-        description
-          "The identifier of one entry of the pmd-penalty list.
-              
-          It may be equal to the pmd-value attribute, when the
-          pmd-value attribute is present.";
-      }
-      leaf pmd-value {
-        type union {
-          type decimal-2 {
-            range "0..max";
-          }
-          type empty;
         }
         units "ps";
         config false;
         mandatory true;
         description
-          "The Polarization Mode Dispersion (PMD), when the value 
-          is known or an empty value when the value is not known.";
+          "The Polarization Mode Dispersion (PMD).";
       }
       uses penalty-value;
     }
@@ -2586,31 +2543,21 @@ module ietf-layer0-types {
         dependent loss (PDL) on the receiver";
     }
     list pdl-penalty {
-      key pdl-index;
+      key pdl-value;
       config false;
       description
         "Optional penalty associated with a given accumulated 
         polarization dependent loss (PDL) value.
 
-        This list of pair pdl and penalty values can be used to
+        This list of pair PDL and penalty values can be used to
         sample the function PDL = f(penalty).";
-      leaf pdl-index {
-        type decimal-2 {
-          range "0..max";
-        }
-        description
-          "The identifier of one entry of the pdl-penalty list.
-              
-          It may be equal to the pdl-value attribute, when the
-          pdl-value attribute is present.";
-      }
       leaf pdl-value {
-        type power-loss-or-null;
+        type power-loss;
         config false;
         mandatory true;
         description
           "Maximum acceptable accumulated polarization dependent
-          loss.";
+          loss (PDL).";
       }
       uses penalty-value;
     }
@@ -2641,32 +2588,21 @@ module ietf-layer0-types {
         and min-OSNR";
     }
     list rx-channel-power-penalty {
-      key rx-channel-power-index;
+      key rx-channel-power-value;
       config false;
       description
         "Optional penalty associated with a received power
-          lower than rx-ref-channel-power.
-          This list of pair power and penalty can be used to
-          sample the function penalty = f(rx-channel-power).";
-      leaf rx-channel-power-index {
-        type decimal-2 {
-          range "0..max";
-        }
-        description
-          "The identifier of one entry of the
-          rx-channel-power-penalty list.
-              
-          It may be equal to the rx-channel-power-value attribute,
-          when the rx-channel-power-value attribute is present.";
-      }
+        lower than rx-ref-channel-power.
+
+        This list of pair power and penalty can be used to
+        sample the function penalty = f(rx-channel-power).";
       leaf rx-channel-power-value {
-        type power-dbm-or-null;
+        type power-dbm;
         units "dBm";
         config false;
         mandatory true;
         description
-          "The Received Power, when the value is known or an empty 
-          value when the value is not known.";
+          "The Received Power.";
       }
       uses penalty-value;
     }
@@ -3662,427 +3598,420 @@ Names" registry <xref target="RFC7950"/>:</t>
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+19aVccSZLgd72n/+BDvV0l1UQqExCS0FZXIZBU7AikFtRU
-1xxvXpAZCTGKjMiNg6Oqtb9lf8v+srXDzwiPyAOQ1L3idZcg093c3NzczNzc
-3CwIgocPRtk4Ts93RVVOgmcPHzx8UMZlEu2K/Ww6zVLx297xG3EQlqE4vZlF
-hZhkuXgb3kS5GIjjqLzK8o8F9grPzvLocle8HTg9qdPDB+NslIZTgDrOw0kZ
-xBEMNhqF01mQT0bPB8+3grO4CJKwjIry4YPsrMiSCH7fFfjdwwdFdTaNiyLO
-0hLg7YrDV6evHz7Asc/zrJoBsvt7R+/Fr/ABzEW8wQ9hZgDuPMtvdkVRjh8+
-iGf5rijzqig3B4Png03EuijDdPyfYZKlAPUGMZ3Fu+Lfymy0IYosL/NoUsBv
-N1P+ZQQzi9Ky+A+acVVeZPnuwwdCBPgfIXiKJ1F+HmfiZZRkZRnzN1kOFD7O
-PsYh/51nSOJoHJdZzp9E0zBOAFPq3D/jzj+l2KUPwzZGOSwBa/GyKuwRfq7C
-qyieM0SMPftn0POnC2rvhX8AawSLDLNIonzJSYypL04C+nbM4VVRXsAYbyPx
-Iat+j0f8XZzCur/q1z+m0d/lYXoeOYNFBKQPI1HjnzJq4h1vL4YJizdVZkF8
-XZVVHgEVxGk0ukizJDuPkQ+sEULsdl5lfWTbn87xQwaPmyct8/isKn2M8HOY
-TeMwFf96EaXnLaskh/gdm1xw+85VCdM4SsQ/xw7AX9L4MsqLuLwR2QR2ZzoK
-izKqrUkft8ZPifqyH4761cfGAG/CsxxGiOCXJJ6eRbnDwftxMcocsOfn3O6n
-EX7lX+U0j0cZbMoYmLtlP0ho3LQvm3ZwzsFFXl3Cf7PxTTdhx9iwsXA1aC9j
-kFZRBpLjtyxLLYCvTj8cOuDObm6q9KcI1ryfR/2PeQPUh3gU5mPxL3ESJmVo
-k+70dN8BlVPL/iW3/GlUlqM+M54D8LesArzeRpEF6yScFpXiAAnuBtslUdQv
-rztm+i/xqEQBns2i3ztX4pIa9hNsaK/Dwwdplk/DEhiOGP7w9Jfg9D/f9Hee
-P+tv7jIIqUD+zH8JsTedJfEkjsZiWiVlPLoI0xSYeBylRSSuwktgt/S8vACx
-cRmjjFf9qPUsia5RpoczAAISHb4vxFUMzYsYJywUuGwGoMNEdY5TYPJJOFJ7
-2ZLWetqEvPgQsVgfE3Ah58IN4bMIyXMZ4V4Qm4PhM/4C+TMCDCaZAmP1U0R5
-OnjukuRQI0V6FASXQhsUU5gWM1A5ImWtujTaMJqN9FGYjy4A481BO8ayi8L3
-+dOn/aGL8dop4oXSJULtN4PBzoDorWvXsWg44zyaRYBdDrygJj6JwXAQqOHD
-PE5hlBAHKG5ASE2LtaWpQHOw6fA6OsurML9BUgzbSaH7GWIMBjVavAbJKcIR
-LF8hygxxLkYg/YExYErTOA2TQvTe9CfQbF0E4n12BV8Vs2gEi8v8jiIaP4Dt
-wGRZZYKDgT2//1klOLfh8665cRe9WXd2ajPbvwjzcASziAtYlQLVyCxLYEF+
-52Gn2RgWPQbUc1plZAWYTggyohBgQmGHPBpFpIeAr8PSNIlo5bvALU8EmEHL
-Gg871ph6gSEIH/pl2HaD/U/U6p3n8Zh5+NeDI4exQRvhR5M8+l9VlI5uqOkK
-U8LR7Um9AwnMQqdrC+tu9iw2V5nFPn5kbenVp+EIzwNgCyk8B1vd83CE50k1
-297yCSMSksBvh69evRLDwZuXeyevgg8g8NtlKWzLd6fH63NnA2OC6EITX0gE
-VpiJ7mfNZKumCNbeSVRZzoFsKOLzlHYSEB/EIMAF+QnmZRGPo5yXaGn0t563
-bZKdTvSx38MHQRCI8KwoUTDg36cXcSHgIFfRAONoAmjC5gckwcwf0fLDqoz4
-8DfGEyMe1uDUBDNIYd4x/o4zpDMbTK/ArUhKkI6K1AUlQ4JTB0P1HKzuqC9w
-5IjVD0ImoC6cDcAmh908hk2YTQniWRUncM5MLdBNbOAMZ4MRISgitBvSMYAC
-AX8Gf06Rj+DPsxvErUoiKd4IUXUSpoPAJD6veKUIOzhalqjNZuFZnMjZFxWo
-5LAQv5pddgK2zOgCBlAccaxZ9teTd8fFOgJ7+GCCGjXALQlsiLrXAnGgdO+R
-rXt7KJXW9Q7oN5dQH7PFh9f7dNLGWYKKTsIRQtArwxOHgyMyZBnCuo/ZBAsB
-/BX0kOMTYeJ0lFRjXKIxnAzhY5hTxyK4K9lXjDeNx+Mkwr++Q6spBwyIxfAT
-YFwC+Mcf/wSIP33+ZPDpk4iRFf0sJKqC15O+of7ucmG3Dblg/PuHaJrBH+/z
-bBSN4Xwo9sMkYfal/mlWahXO8lTSWUzDFIYk+s7yrMxgdxR63ZGix5Z5t++g
-8V62F73jV6f7745fr8sp7mxuDz996gtxqlZETY2gFLDtgUmRAMUU8IRtTQJS
-7wFDeaI24HUZ4wpNIzSe42LKNjJQiPeRyOhczj2aW4o+78uVcFkqlku1iGBQ
-m5bAzN24cvZqo3ukAMHBLczCVG9hhOrKDlZ7aGbiyml+Ae0ymUh3wytLCvdO
-X62LCditwAgFLuNVBESGf9MsDU5fma96Uf+8vyFmFzeFPooovqgJCLIKYXPb
-7jSlvrTSivkoRAj2oDHLXDC2qhLVAlK1tMkvaaTmh2IHPQIERA3CJJA2KMAi
-Cewuody/HiFFkFoF1R9//IjMOtzZgv34xx+OWQWf4GK5n25++sQaoS7daJxl
-JZwc/ykcwz59IggNHPxMC4KqIEGGtGEix7yxgYFqQrDQIsBITx4X5Sdt0tew
-pJMqpy00jkBcouAoImZEJSt546LEIYciL2VN3KYA+QY2ejACBgACyhNjUU2n
-qMYld/zxB27i86hAF6qcYpuctzF1ZX2MCw//LQQK5jwqb/riENS+lhU1Ue/B
-1+iGWKoCGEvq2BzpkLIAtCTADOFlVQEnGMnbGyAAYEWSInOX5eGD7nWBabfS
-3UchYQlTozWauwG3LRwW9JC29D4yoh4d5AUchiKxB6fuuITNXeWR3rC0lCjJ
-n21tb0oMvvtOnNKpEV2ON7QNjrOSNYrE8EM0QTGcKc7e3t7R+4g+ePIMN5Zy
-JXyMbuggWrDCk3MhSGo+vN2wcWmNjQBgjfEsi7xQI0oBRkwKgpTldFal1nxY
-+UqeYwyAPLBua0e/nJyubfC/4vgd/f7h1V9+Ofzw6gB/P/l57+1b/csD2eLk
-53e/vD0wv5me+++Ojl4dH3Bn+FQ4Hz1YO9r7bY1nt/bu/enhu+O9t2vN5UT1
-IA07dMUA/6FtFxYP5PSZbC/33//f/zPclnPcHA6fk0CjBRw+3YY/ri6ilEfL
-UmBe/hPIevMAhG8U5ggFNTGYf+huR8sBhO5FdpUKYM+o/0BywPscOOQaW9MV
-yzGei4/DaaQ44LA2gQ3y45G4oAVKs7FUg6yyLVbOzv4LVYzWijMaCiZYFcq4
-o9sPdFfyd4BjkY3isFTmHbSR1lIO6m2WpWPNHtou1tvv4YO/qenwz98c6eD9
-+RuzOJyaI+yeDAKWC/wd3RIlqLfsz93uYLj+FX4ePvhjV3xXhmeBnGbBJ60f
-1t6rv5FInokwemufcAII7RVdZ+BWROfA+yQKi0jKyYiG0qShwdOKToRAOW1y
-1DiOpN80u4z4C7AcmVrfaZXMF2tHTCcwCUvUCF5NZQ5dNmlx+0oDx9HyG0xB
-gmOTsS/BKj0j5QV5BUCTNzQyaFnblFGm2FpjfdZqqoDl/QTMwOxKEZwg5VFV
-kP3lMeN25cyBGXB4gqw++7PYE2e4IMyDfIi40QKQ0CUlHhZN2buzOXjC4lMe
-naUI23n+3CiF0dV4GowugmI2Wmbk/SzM/YcyOZZruOyT4SI91zCWPG91Y65Q
-HK+GIjmp5gwpkW0ZmHkiHU3Olx7XYqfjjDylYh/aoUvqtfabvcnDtEIvIfTu
-He+/frMulJOjlTTu6vEwRZKVwVU8Li9gRA3SoHv68mAXrQs8MJLYn+lDewis
-KQWS6JEVIk8i62qEqE70Dmg4/SQuSvaOSrjOJHhHML/DZ4G8jL9z4MatF7Co
-QnFy98OgUXEf5MnKyoD9M0svdYRhIUMMAnDenf6yIY8wSst5TjzmYPB0oNjn
-z+IkxmU335EjDyTGOItIbgs4cgM/lZG0HrJZlKtTlnRkkf4FXZFGG3W0PrrM
-Wx+EbSy7zWWUjrM8UNcF7inEKHFFG73zNmwgNetB+iBwu6o9Q7NgP02AlsM9
-MF8B5+QkPEO5U4Z5GcDErFEAFKkdaiHo9h74tVUMGhP2PErhgC7DA0Dzztia
-ZfNHqUrC1Iz9mH+PbCP2GVixxAQEh5hLaSOy2RgI4mgWwwJJ+GiwWoTKO4Ys
-7TfJcJHNvgABYNTGpGvzlaC6Z81wGvMDhc3f0wwC8ipbKoLYV9OVzoc2ispy
-sYlgDSIRq7lu2Fxp15hE2zpENHhUB+B9MH7jjHQOd93eHGxxV5sP5DlKWEer
-qG4k4YkanZ7QfIpHQfO1pqAEMgM5MsUYmcLDHEUZzRYkHE8NOxQt9DCmzmFw
-QHEQQQkmLYZdPXv6dCeoZng5UNeghLN/xzK/WjOfy7WsojXXIhDJuKvsWeze
-xcEW73roL8EiEM/etRkOznTx6EIbx+Qb5SMi+3FoviD9wsswToghU2nYjKRh
-oy4EY+0shdUshHPSLKR/dKs/RGDKSYAetI0VxqGDXji+xLAdZdJPfxhuyMlM
-ozCV1xf4DWgcA7UO7Ubwidb6AO0qdtR6GgdDpJHniz8NyTevBmpltIZMXIbH
-FMksHhNLsFm7ZFSQFtMHLZKxMdelJWQLLWx+DRWuLcTp2OELy5sGGix6biVx
-8DTTJmq8yMBR90yvn/EK4iZpExo1NUJgbD4qIpTIZZSQIeezV2qH4vrXGxJw
-pi5j6s58UcDWgHNIpqMj6IQszjI4K5JfJqgNwRDhVPCxaJLKbJYViSRqrLos
-YbC7lyTwxecmRmM3rUqTFqtjcaoYTPzEMd9/bhpZm3xV6iCIJnEW2EJRC6vg
-N5+BDhQNwqFJgX0dLw+TDWJkck58gDOdnbt86R0ARBN0m6yhZinW8DIqGitz
-gV3sJsQPz92ot2UYHR0c+zoKPczH5vzVREu5U7TPlkb0nykpEFFK2Cw/D1MZ
-d2Wf8DonzvEz6RgmbR0POWxLrhOFRLjgC7yh4lMrO7xdTaTVAQf+S6oEMVAj
-zvF4Gig9HeCtl8SfHZtBdI2Gf1wuOAHreBqWHKENxMqjhJzb0FBHi5rhwZyO
-p3gDBuiO0J+Fd1zW8isUiAx3Nj8aAYYFZgnKKoV5sJRom2P93GT1F9yfxZi0
-+TDERt7nYmvgx3haTWnHTMNr+l320ibbhn3FTcaUseZkW1L79vLUuGz51ZL+
-a2eLWStHK/PwgRLQen0a3EkRVPZCMZbjYDaF/4MkSaQncP7GR3dtydZ/SNei
-GCuljn7IXcD9Mzm2hNy4QQnFOfBOikGj1bRi7ts/ICzfHx305U2tYlU15mi8
-IQDfDQ1WOofUSaQA/koiuTZVykcI1fYHMentH2wg/HWaPLmMiEgBy27lRWt3
-71gRkpZDlC4inaC2T3RtUqT5fJAtYCjslsHMivEtwAwGEsp0dSg7OzsM5Lvv
-KD7yLek97MC/feDHJw8f1I9x9QuG2smXjgsAT1oZ0SyPChI4nvOVfZMUWljo
-OLH3IfBV7+3J+3WBs5EMRg1B5emjHt/cAt+ocA19AyFO5KGz9+7oZF0cReM4
-FPsyip6eTone0f6bdZZwzix/XE3G4WkOeNYmQnGB16NnUe3mzGoHM6QJQjNF
-P5xgwbPOIzjcBUC7iBrOkCgYZYz/FtE5RcPQStXpG7fqTBmlwpFLaRmfV1lV
-WN1Z+Ix0pPTvHBWIGqPtSM7X+jQu3UewQ6oOEqaYjZRiCj0IV6k5p6Puoqte
-t1mhCe2abh4OG0cgKsZER0VYfXFGW+d7vHZWEpaigtnOwlYb7dTbVKzeTnF0
-kDEwhqvebqjrqF79+o2iH7Ebwq1T2YpV1s4aNK4qvtNvMK/eojTL/w0/6nop
-Cadn4xBE53D76VCkU/EncSyum+hN4SBb5Qwwna4rIDWSHSxMsuFSJDvwkqx+
-HdhJMkvJ35JkE6TW863hYNAfDAbizc+/L0I0aNZNNbTigc3vhnAkT/TmW4ou
-6EhThNmg+5Kx2jAWxHP7xvLk1zcbcqXARhtu9p8gUXyor2+oNxOduLjg8ULU
-gr/T32yHLzDKAaU8bJCbjZaFZe3UWNiTX2Flj2AhYT6+xZuz/Ihm15r7RVSN
-aTYYDBIJsbCjxNmFF1rBVdbZkb6kWE6AW78/uwyTygRpYt+80camOJ64bDTW
-tYg1Wpksgm6NLs+t5JnVUly9wADdVciAJAzaBdWb4VGjrtVbR27yu3Q0RAUY
-k6zm0brcaDureF1zchNsKDQ30O1ZJWPS1xUpVyeOyHPzY8zqnr6YoFApNkzW
-VTBjh4ukBqIpH7wAfW6hGiRpG9Gy6Nhp8ifo8JfmYLz6r0KQDbhP9Y2vn942
-S0QxR1Pb3nz8o+l7txSaYta4VRPrGbcA7bom8EA3Sgvhqqnzg6H1XR1ew1fN
-+mTmHkXlZTetDRI6MtSS6CFtiJBtgl+w4I9WoDM5ZBoEMe4KS27L+Tti3YQp
-mXNnbdvUpOb3wh9ponRITSyoszfKuAi2UnkVwRY3WBUvGCi0s0NYJiG+xIWT
-jHpaGaNXZtKhijAAYkyPE+T+1COb5rYXZ2FqKwTD67tGULoibotgfY8qrmuR
-ie0unBaxaOLvLP//hv4TLwKs76TfM2SGDM7ichrOtChvjSBwItCVougWwN4b
-i1UlcBuEpQVwG6BbyF+bcEBey5BYgVAAYHUaNTqvQJ4GjBUpI+aTZYFDH8bP
-k44xw5A6IBWwgS8ElBFZ+G22+nYyp4cXZoSmtPfBXtAmZlNuZ2PzCVmZNcel
-LY+0+1yLFakDQESkftR1aCGGFtM7jDKPIvYPyeQ26H6wX/BwJO8b8yKJ7V4A
-P4rjAHaD9MZFu83g5gcPrGtm36UoWd5/CgLR04p4/UdpjuPnuz02DvBAuK4+
-/xt3oUNi+qPgMB0ab5c/cwCMPF1Hnq6jZlezRTQAia4MG/3RBiA/a5tyNLNm
-awcCLzxh2ujyaOyEvNJEVKhcHk3mzp8gjZaF5CfHtSYHzcgD0APPJeNowgPX
-fub2I6o2e1ZxWj7zLwPeMd+G5+RXnKYjwFNWNcMrOJ60AfM3A4zbrrvfNFnY
-+mnhZgsmCYEaSDmpojobhXkO8oFZJf2+A+QiG6Txs9qO6c2lmQWmRjMHNWvr
-+ZAyu7Ct67S769Ttek34IMZNdK5desuhvxf/Jn/7j0YPsYj46Ogy9XSZegjo
-Moj9nVE7ZO8WjTbeZq1zcvssOi1Pr7aZeTaxFRuh97Leyl4Jhi1USCSvvpIR
-NgoIw+LmlpNQi0T7Ez3w9pxyflTDDXectr4Dh9vWTN0XbDxfjHUrzYVFgqiL
-hKYA8GG6mKj1Ctl7Fa/zpau72+dL19Up2fjpIK0vFNnP/nO5v6kga5G6Cxkq
-S5soC1koYgELxQVkwkna43xrO32u4WaBcgXhopCWEm3euFGzBnO3Q8tGWF5b
-rqQnPRpyGd24lFZcSh/6NeFcHbic9ltW792GLf6/U3z+uN4HkuuWPHYsf+BY
-4ahhB+ZRoJDZxvjnusObMqqttmfzTDjBc86ozjeNftZ7O3TNYezi9/6p6V60
-dtIlYWQdjWk2QXnxe70XrOLyvWzqlFUqH5r96PQ6r/eCeZXXeoFnmIAuAKSZ
-LPzn+Gy6QJ/wel6ffIVxmn0WGqfMyrDRw9OHGMUT8NhkGk+jhtjEZrW3cRZ7
-1b/ydrdGCZirJiDgEUrLVz4o7Yzawqm6Zzu7tnKe6dvKtPP7trNuK++K+ezr
-5ZGOfppROvu1s/Gy/RYer4WdW/jZiaWsKWeA53zdUM6dTOBdR6frcoLL7rqk
-9HK6Li5Yuru1yha72xJirLvboqMtKszsbibzKi1z0aZFnfB2rU21z5s7/9MD
-B7b7LZhv+A+IpP9osJr8wu/pEqhvMV1Wo1uvzriiRaXzz6qKvdZ7KfVe67vS
-lvnbrXbN3261cVZR/nN7zmHoVQyBuT2XGHPpfdRtGtQG6DAQdEtxCzPBA6TF
-WPD1UH6WOVZEc5DlbIlm/2UtCg+EJe2KJoRlrQsPhCV0/iK92zV/s/cy9sYi
-vZcce2HbQ6h+HRaIsGB32CF2s5VEqwNgFelqA1hJwDoAlpV33Z3niDy789KS
-trvzciMvJ2/tzh7rxfdTN0es7NSUAbH4vqWjkobBn0W//1j/zzVsHkvrZcHB
-PfK/dXz1s+j45jG58+7vgYVH3fSpWzwahO95nwVoWc10i3OrRkk+RAoowMJG
-xvkCP65SgGJ3dd+NWV09eqthhno8UtCzrbX9YznejJAZx5NJQJgF4ygJb+oQ
-xtEongLtNmv9Rhd5hk+nRoFJcP/jnH4j/TYN7G/4I07H0TUb4H+z2tDHP/oB
-2e00gYVNZatN60rYE7Ez9tOC1Cbkm4j1yg5mgn/5pqI//7F7KtjOmcudTIVD
-ocK0DJKs4JyCLMTwT7w5SKsksec0Tuw5wV/eOanP580J2jlzahl78QnqkN/A
-eumnvdz8498bqIzfnRx/6NocRZpbPUAPAAhXkdR7uxqhRfkYgja+8lHX36jJ
-he0dNPk0eguS27OPDPX+YvvkPT++PWLW6yysxoFXOsl+O9s2DbMkCbLJpGu1
-fP3I5JJXS3bokv3TNH3quKrEd83R/byF7VFr++fXji2Nc5FHxUWWtLkafP1g
-kmegI4MMGLaNQi4vZ1UJ5Ozu5fYoa5JEshIoCn5NihD4M9KstgyxuxUfoyvP
-YDavaI0o31dr/T9H37ec71ougVvfnmvX0TLm+rJXHctdctQpEibSKvsakV32
-qLDc2WC5w8By1v8y5n59SWz6UIYzszQt9pvvErFOhfrx1qOh65NbrIs1w+Yx
-2OrSNU2V1R+M/M8y4y5c8igcY8R5DZMW+ixLnE5s8Ga+Ivjm7YwhhTf5aFds
-it5NNWmUEA4mFrx1p8LJa15DG3d8NY5LibVu4ChgoX4OCiCIruFz2AT5Oe8w
-VgoNADNKCOq43tEvUpQg1fEUeO7qGFe1mGZRlthN25ohLYpSt4R/1BtLDFcH
-pgzckHUdxE7FBKwg9iOTRNoJY9fB69hLxa17cnL/gU9CCfKlLA427A9f4IeU
-qpweO61VebqLXXeJN4vd62mymxa72G23mUaaesuc5Cro4wUnL7L1H79FXcNi
-sL4CsAyG8gVhASNq++sb8Wt0tivE/7goy1mx+/gxZmzFEkcfo5ye/vRhhMdX
-548pwcFjVcMQ+r2Ni3JX/A8sj1hmu/T1T6rDn2W+JSHTh8MAnvqp5kdB4Ub9
-l7VCqR5wvqKyTXjcqv+yXj3WA7BeP7YJjFr0X7p1Yj2QPGVOm8BaCpz+mRfJ
-ys8hF8pOUK5eXalMFk6SczeZucqvqapWmNpOnDyK86hYWUTLzNRwoq6v6c1L
-s8YJPzWh9zG9RrZv2ddbpmTdvKfptZZukgCcfuv1ROz1+jB9vRb72ewmj88v
-StEbrWPBuG0qkSxOsdqxTheLZ3d8U6bdNipZLea8oKJiug4JCgmg7F6SCIKL
-uZOKKL+MxmbQD9E4Lljaq7wqVUHZeYqsykeci+csTrFWCdXQ2KCcOLI3iBv8
-C4xwXDpdTGkDnzTPMHFWiY90ZlVeVHBUh3UyxZew4hEVN1A5Q2AxibBc/MKu
-Q8JJAj5g1RI925cnB7CZuQc+ugbcYCUAbZUXZbs/UnQwVHyk0iu+jc5hDd4j
-hxX0RO8DZpWSCYSo/YFMt6x69JSsoeLTUWTkjEScwtTWDWWJoZU0VUV+nNIw
-BaaQpZxBqgLCCyx1ojIBy+IEcVlEyYRE+wQ0tkgIdaxdNYoKezi7cscjrNjx
-aIP/xfob+Luq3IG/U8EO/YuEIdtx1Q7zm+mvi3Xgn7X6HY9kFjgYc++3R5wc
-4ZGq4vFo8SoeOgGmW8tDDLdFD+mBlTzW+Ves47HuLeNhaHgjFivmsUa66fFj
-wfUj+rueehGggiqgvV0yQheGoL66OISEpUDQg2ZVdQffoZr6E5IZZtWZ8pNT
-AwmOVPo0pJwYvRuYBhyXUjBTxuENZXHQQFFcBIPtYGvAutwjjlEgE735KeyY
-pbYweZR0M8WOuyq9FtU1OaKkDQ0Tg8F8Yka08RkGg2fBcKsLn0N84AgUlduk
-GyOseLQsRo+/h1+/F4e6Uh3++Zhx1UUO7JDvLmzVIPrNZTe++GpyV7zB9LVh
-QomGKOlDIRHGZDUBJ4QK9jHkA7hA9e+9Pdlf33CSRqFs+gCCFii1oTe9cCtv
-it5w8zHWtVzfFYtUC9VQvFVD7XW1qEWB6hyCejWeKnoJrh5hk/KF+sZDSyDR
-vnq+uqYbNui4OiWJggbMApS8I1J20LKbmuNbUfPgXqlpICzOmW5xW6Dn4DEW
-wV2anr66vK3ktAKkb0fP1xrQfILiG+NWgqIMZ2BvUGzEqSSxgcFUFA7nfl0E
-1uStZ/bqkpZ2bjCnVM2dS013r7dTTjb4grKT6Lc5SOuMWafrHOYkCLWX+19W
-iqoWX0KaaurWk6h1cWdrIaUvxp1etlx9W7fu6iZXEt2Gg8H5xe81vqxTdA5f
-DmUSsa+KNb+sQiIKPrk9aZ98o6yPsptPbk1ZTjvyjbJ1ebA5uz1tMX/iN+o+
-aBioHiWFZYQrTGAzyyPKI/uiXXkZ47RDhbUZx3LsnZlv7zTQ0wvVhl/b0mNq
-y66l9xNG1yXs0t3W9FeuQ9it5m9l0a9oz98JLy6h9S2Cd/GCXpFF13uZJfl2
-tqqvh/8l8oK7wZ+o7xurS9JenbdotS7SL6rhumn/jcFvhAls9LCzWKOVcArP
-Wh261NrB+5N/ri2o6TnPbYZ9ewcy+It80e8vEMLJRTwpxT9HN3T5Z+C1W01/
-uQUa1Lf3lyoc5yHVnF8ViYP3wW3wUN17B3jP8d6KdxMGOdN+ZVLtHT1bFcVn
-0Fn0noniZnqWwTaxiLY3BRYtq3HE4RAEbb2bVrdARHW3cOmimsHOwFgITRhk
-uLMyY1HnHvz/rui1Oi66v43OYiQTy9Nsa/MWNIPOPfj/XdFsdVx0fxud+2Kz
-ne1bkAw69+D/d0Wy1XHR/W107o5kRkNF872ML12dhlU3Oau0zlX/+tW+at17
-neVXWBTsVZ5jFtcszzmWYV3YpaFVhdBxlMcYytGmFs8x2rtu6EQLHdvfyJKb
-bQiJ3psAEF/vd5s3ysR4/vSJuNzsD6SVMUArQ4GOCPTIgEbFb2AU1dkU1iyN
-YCWLMpoW/XbG4VxRK0/6BLt3TPlkySmDVXU5RNf34ClMeri1+KQv4vMLfPJE
-UfdsYS1DhzRbnQjHGXJkB41HtyBwGcY55YvvIPL+IlTeS9PoWuxh5Iwi+NPB
-c6A1EBxs2cFzacu+O/1lWyQZRsRT8nEDgkJOJuEo6qDjLcj4bhalHbN8R5PU
-CearQiZMNhBeZkW0gfWcqvFFlccUZ/JzNkIr+/wimorey/2f13Gp5lBqPwkx
-nGu409/ub9fptYW7Em3/IdJrExlUpXR+d3psYWORUBNOxXLyD6/Iq7sdoWNt
-bsGG+1mK/quUajUBBUWPea5WQDNMBZ2ahGFbA2QuA1PsHSeOT2FGWKXE9B5n
-FT7Gia4BC6wzeXIQEB7DzWcbFNz0czidcnw4lb5T/Wz1RAoAMEtYGchYSToi
-juSaP3msFuEKI5wwP3dcWEC47KU4OPkZeoFQCamYzahGns+3FV/4ZsrwD+6c
-dZsjqa3y5H6Z2EQdmbcFi5sQurwhB4OCkhCoJB4jMCGBUUVFDjJVUDjAE2M4
-uXypwcoU0dMjqgjKp31UXxYxKNGLuNwiTY7EGD5TkvoTUrK2R+3HE8cf/jXY
-nD15Uw/IME3m7NpTyiefAr5gsqVIh98jTEsDgNf9ZKA6i2c31vogxRRl6hTB
-XVMUAsAJrPnkYXoLkCbRVn+zv2OT6PmT56j3nyGJWO8/W+8QY3USwS4ZfnES
-qbBp5bg/5UKyeSl+SQFKlmNFWdgPiOx6g9U8zLYgMZ8CMWscd0tyDgcWw31x
-vgJslmCrp3fLVvUT6FfKVpvEVptfL1u9O30LllRwsn8renaSrclK1nmIpy7w
-KfANlTkCtgIuV8T1EnXbjt9DRbzO4ceLGeSC7BkDgU6xIT/KQKJOsir3jP82
-RCsKhnvrtebb2H64oMKZt06v3x3uDz/7QqnlsY0svVBoNbwTh8oyID1N67M/
-5PUAA4mIZq0WT2O4+IJZfeXS3Sv1TRyr73lgl11jvZ8p4BfGAVdo3nXVs+e7
-4oTojGR9hUY0P+GgmwoDVdfaVf3rz4Fab4vivCiDCZy/Oycl+cnbZg5n7cly
-uKbOm4HC9jw/L4jGVmgdPwACC/7XPdGz5rmnR10X06i8yDAoIIPzY2H6tg1m
-niHwS0RBGRkWubRaeRXa1sG3EiBMxtn03pbhVFLTpRqe2DStTGuLaIxWstDl
-3mehUxKFBSZCCeEE+LmoxZuW/RYWbfAQbTpdyBpOSZifR1Tor4jH6IrFHJcj
-crKk8hUMfMsTsM5TcfpRhHiq4gc0eB6ncoeU4hx2KL7AUe/oFool+DyrwQ+c
-SYrcowShatOO4MAXTsUoSvkUiKplQ5xF53Ga8oNs0NtUbV7Tl/e8W+d6lmfn
-sExcbC0jJYPER5+k09jaGSBDZEE/evMHfak6qlsgu0Nvy4feX4Rg42gJgjWI
-0EWxOnVvSzDjlyyrO7h4ADuw5UahXQFbXpFdY8iYUIWmFSh3S5uq9Zx31ezm
-eVixZw9O3zvizdnjebvfQlxc7pDZv6PiHdrnYQA0JoSG7XHHJZbnxLX4xDBc
-fgC4fq0z21p5Zluitw325PBrnVn90nHxmW2jjTzsP/tqF20/XXlu0LWXims4
-aT6hIL+vZYLGKwrTUFlu0O/eIRiplQBBi8FWfBNMXehMZwlmjcu7oxOS8jEW
-gU4iehLeJs4YhUIGUAVjtC5M8J6kew3ZOeTHJ8tqWLB7QKGgk5pnoQYSaqDe
-r49//r2DDVQCMe5+X2j1xi+nLhLyFS4+zh1HE/sNbskfycJVCiW+7sZ0ji/a
-VxKP51xgnbO8PTp+hPcbtJDkJsdEAnhq95Qi1TPROrdv3WaddtUu3RCPJo82
-3JrtVjycmIgfxPD51nAw6A/kc5g/iWPYPbU4aNGbgtWOSYfQDMHCp3Z4Ht/Y
-1OD04O8+fIB/n2Kl1Jita95tj8IUTjB5c2qPeJ9xmrCC0xFcylrm+tkoP6Cn
-YTWERzWUH3kq1dcfBDQvFuzj+z/O8ynFuKMvxLjGjJ3HudbhrJVpraMPcO/2
-06FIp4uwbTpdbzKt7C6Zc5Sllyh+MNOd4lELJ2JODcHPpPseJm0ypwbSZNL6
-88puJv3sj/zu8e2pYlMZy/8PLWDxRcHfgVQlNJs8WnttsYG5dZSM1W9ujFnS
-eKgzh6e/RJj/ZxbFsqCcw+PV0kx+1MHkJsbf5uY9O/a/lW2tNj+II2DXk18X
-4lZs1sYt/hcL3zjBSbTu8ANXt+ngh0OVVov8wO5ViAJrY6didBSAw1JQyiVM
-UCZHk7mDVCYfCjOaZEmSXblRXyARYVoJx6RahewLeTnypL/VuJ7pWGsXd32D
-4yVYS0L45UgHm2ic5Y9tWMKCRfOmULcQKzReojMO10f1xyRiML0wwRSYNzYB
-1Bx4RvWKAu0UUDdbm/0nfP+L7P8b/LRlEaqdQw+nszDO8YwThFfoIDvNZlmS
-nd+YmFtfvigcYdl8USKcYKzZOId/A8qlSLkJA3nFGMQGlVIiEXBKR4CCicQw
-fVRxQQm0kHFhyNoK1woF3GZXOCssc+rx4q8b/+LUjl1T/56ahFYyN5vcInRR
-QMmpaoJOc4c9JrsyY8pnNwMJwe5TWEDqHMv7AtWV4myxHbt5pY9SR2hplAl2
-x4b6xk6WrrUTsTq8pNN6G//CJA+JcsE4Pkc3ynPjG8B/qhQ/XAPba22Ooq7J
-fxAN0GlDMAeSGTfcfEKWnN9AsBM8L4v0jhfpN6sg/cZBeohPCG2kecM4+izN
-fegGmy8cZMYvfxr0h+m0C6OeZMp1eQ+Gu+44i4tIfED+F9ogIWMWwMFRTnWG
-XZQllbyoT8dkeMzXP8+fPqVIUDzhbA5B5ZNzDzO+RVZRGfJh6c7WkWas0nFO
-rbSajn1Aew12SwQaJTf3h2qjT+Iz2GsmgJ5Thsower/5kOYqP7JrTKbW20Ul
-OtP8hfNBNJ3pR6OfPt86bFDeQ/Exza5SOjvAriVUpF2L36r+VUrN+v5Ngreq
-zv0STwskjtQghgL4IWrnJ9ZdR4vHEF+VUMMTZUSdUPlu0kWvccy1F6L+o7p/
-agy4veiA22K/KrPJhF8pYkgzj9UOeqsFNMPbEge6fsriMJ90wnwCK58G/4pR
-dasA31mUFjveccjkBjsNWal5g9c18NNFB34qXoJ5EBzCDkdHNRy3WmbVsWFY
-nKCremzxqH8Da/m4rJDfnL9x9yw4cmtRDM0VHBYJiH9baZQWlix1Ib+cfJmL
-phQYaCjx96D2SSwI4+3wyBC3A9gaokOW8HXCeRinfvVlZkw33mJt0O9PQx1/
-5Kra8ct5mpYGwjv9l/PQWXgRTJeVVsHFSpKc32EoWhsiq141YvOlCkJ5TKWO
-FiU7Nf4cZGcEw7IEwSBPffPWwC6UtOAaYJeV16AFxdUWZKlVIJW5mPG2GJ1N
-oZr5ZKbBl6Qz9bkloes4rkZnG8qC1B6fTRejdaeNbCZC2E/njLgkgaHHLcnL
-WM0hqktMBUUCmEtORbgnPnJ2adAnK6umCZoFi6jQJ0ur0CcrEXw+nu06VAFp
-X5HFlWgxXnYRhv7DKkYHLMb3zciC9ycH6013zs2MrEWeyq7Y6j8Xr4Lh9oZ9
-RMEj6a+Pj37+fQFf5fOnA/0k4zk+tAux8sFoFBXkHoJDHCeFzwW75cNEBzn3
-3vQn0HpdBOK9fw6On6eN1Itv5mJ8y23sJ3LbttbWt4+XoGMrJ8ngizeqiMZD
-E32hq9/g/WiCXnysUZaXAVjrXUE0OAf0alhdEEn+M+ISEnR9wiS/YR+Iqfwg
-Ly6pvRXsyN+OLrIYRH4jI3tbKArfPlB5BKr68d/l5QiNiY8jmpmx6QkFta5l
-iRYYSl2PRuEfovWaDJEMMKISWQVLM/R0sViN84bdk3/+fc1N9f3va+tr7git
-Zyia5r+ESWxVODBJ6HHhca7WOw+LBS0GVUV4dnl6TuvWkZe6Ba4h3XrFW0PV
-E0FGQ692F19DovOKysZDE+yTwyYjH4OM7plBRnfNIPtLMcjovhhEsUQN+Wao
-yt8Th1jFfazlopsuTVErL31Nzra4QD5vZIqjDb1aIZp1KQQGS62wCg5e8CjX
-0oJCWUp9XymO1iw1isF3Sf5xXacNEZWj/uKinvacDGJzM6kut7m/btFv1eir
-D9yd1rcBrl0OvDWcokK/6qFjFOGgbj44BKdOrif8qdh8wv8Cr/D9CMXqIEN5
-JvxViwevAiGGGH0+tvsyCmUe27WWPWiAuxXbpVPgurgfAddtDqx7FPkzkfJo
-w9wr04t+nDirNHUnrVr+PbFfh3byKKVo9lXoI8PN9xcnacagUmJbO1swk6P3
-b0/Eu5P3r4PTV/b7QCwsV83oRUI2sSKkNIzWooBOOUDRQ+m17n+C7NG7F1mn
-2lV52kzjhbSvSxaPFl7h7LXaaUuOx18WdCFIAo4yual9/MdigoC7Iw7UXYkB
-d6sSLrJlTSK1nvzwZ+4BqhM3wu8WByn8WfQwVROcnxqzp3t03+SDJC5K9LGo
-ZyK3IgbW8dYvRDZvR6uCiIUhM7emFjErpWgyE/X0l8zToG2rsCe0l4xybEJw
-pFdXbmX107bWtz3MfjsPfubzIAjvr0LzztNI5K2jUqddiqnm3YM5JBS+bqkn
-RUhFlzp4pZFkHdjcS9Zu+9hvHP/7Wq1IXN0ubotk2DMFh41RjEzsGMY14Bbj
-ai7x61JrfhzGaFNJbtXu6gD40213L57t3pEmgE8IWkPhaCXSt7dDG92OYC7T
-aiq4ivgZmD4REM7Ewxd9sJ54AKAfn/acLfnGujvw7gi9K57uPH+2K17n4TSi
-V6MY0vIB5GecS0WEu4OMvABfyI+dYfaB1fIscQ28dsPO6TvfyHNISouJGtJa
-hUk4KrO8sZb8gsFdRnltP3Su7dvWbLjIGu2p8DqM1Fahud6KBhuYI4Z0VK1O
-OKXxUEttuhZsNnNELwYPywgj/NB+RUFUbHaPMddVMqpYfrhPKlq6kJtB/NDQ
-rn56f9+yqRbkuBXODS5vd/KYj6+c7nN5LLy+Rx6jh7+P+uLPPwgQt176PnKh
-UubjYBoVRXheV95H4XV9KWmAM5SwFNyJbwjoOozeb4M1UVvjJvv1W3fH/e6D
-5lSW2gfN7nP3QbNL6z7w8kTbPqihdjhR96jReMM3z5Ylc4Co5fMtGA2BF5nN
-YRwYLm26IP59b+RPXnsMHXvLXtievDte/MbWtNZoullp7s9V8O1KtntkWs3m
-wRbY8h/CNf7tbtWMuy9dYJbrEp9MVKh0QCTBL38Xy/01nWSN5Ly1cxVl5OcX
-h3Kkb97Sz+ItZercu7f0mzv0mzv0H80d+hVJfY9/sUv0H1qCPjzDh+lvwxt8
-htcIWdRc4xH8Xa44TkVtBbss6iXUQS9q9E8WErM8zlyHoD7eP3vRDfe96goH
-HZOi2pCXFiFOqECXBOAc6nqHJ/sH8+r24MJvbw7gnIUnrPbjlcUW1hB0hAre
-51mZjbKkwQA9Orut1+jyNXCfc1pbOZDKY23cT7TUtzipb3FSX8th8Fuc1Lc4
-qX9EM+ULpILT6qg9FnmeC9G6olzUkajxq/f1GVG1LHV1u1t+PceSuZ3B3Tww
-OmXuCjnomZuaaYsrZyg/8gbnq6cbFPjY9Dc1GNpOZCoXdzi+jPIyLuRuMiCm
-PwzVBpxGYVqofFK5U7fAc9JLN2oFecxX5CynJOGebsEQyaa+MCCsJn8aIoX1
-4P2FbLDPmYeMO6l/bxHvp2HcZbyftSFNihpak479+Nrsp9pCKrh6GdqCPd0X
-CNYOnHbvwOmyO3DBnHpfF9ssKDxvH6KpIdas+7kePj/153r2Wrx6dS5xWbF5
-PvW7x4CryqqwUlZamrfuMWuIe/z5GN2oOJPUNR+6QM9Dv25WdcNa1KTC+YB4
-MFNSxC5qK8t0qlksPqdai23ciNm0wqKceRbuRLvdUiVwYxKBBLPByV2UyLkZ
-2VIjIA1WKf1Un2qLx5Cgdq9M+/rPiSldkH/nEMZaVlesdk22DsI/+Q5/ZKfE
-+0pV1TIONaOsAp0g8HPEB36LtLuvSLulmNLuvUhonZcxbSDfQuu+hdZ9C637
-Flr3LbTuW2jdHYfWeR9Frnhl0zzaWYds9je3ebXnXh42CgD4bhAdY0K23Zlt
-uvZE+1moI3TF8SS3hxc43K5XxLng2KGaUo7h0V7A8RZnf7HK8d+9XzU1GpZe
-KF3YYe4yUcvGIn1bCu9SOLtzietuKmYally5WV1cMAUtLaXmohWMNQEZiQMS
-69HxI1fLvEY1eh1OQSZtSEdYyLdCshJA6yJZQOxTBwyilmZDvjhyvpyPYzdr
-jLIqGaNmwSMBMYAF5DDlvOLoiNgwmcsIrPLgFBcKQkSzlaWKLShwTitgVFga
-zttuFHYRlaVK2e6sKqicTZewtVXDP5Iik1mywmJhesap9gEvwOq3fRp+uxN4
-i5qiwjOjCJhrfs07IpvuGReU+z4dszf2LDKODV4WuRiqu63UsD6DPfSjQuX5
-V63Rr6RXyEiD6BrvrOKSi+0VF1g/DktkVOfozInGbn5qVYtPRPCfKNcGWcAJ
-UXMsZkBiAJZMJeFzRygj2H1hKS9TEKBlqWT5hgtR9WVKKkp1AzbgqF53RrUt
-xjVKmPzmBLqw3BU+Gqhi3ApEbaaMDw6zC7uGKx5IOeN0s3ljpOJ28GJJ8wCI
-2eyqHspvsxGasuk4BOv1BsBV88oBHrK9HhGKuGSET5NRaMvqOiq2lYbfbtSL
-S8BWpl4yi6K9EPWgFVUjpO7QdkrBvKh9CcszzVDayDbu2F1dYO14RVv84h5I
-fvftnIbUdBKDWQqSzr337/btglSl3epuRT99XTclTbObEiuRbx4BBVY+ePy4
-mzZ+arv710vn1iZ3T2GHT13awvSICA42S9HInlNDuiwRtLLvePxRFHE1FlXh
-CDS4S/7GWVfwmM7hu7nr1Uz93ese8hoD1CfYzioOQTWTYBuMSYBlavKJVK52
-G5KD87StI1HvTes6o9TVrreuzv/PWhfZSOoyo2AVY9Y3Bxxzi5qZ9ysOyZ+X
-G5R7VSs0Cq+gc0GT3UM7osIsD+GmTNz+vDPcQjdxZljviFK9FtZgbreG2KNr
-NvwwcKPoW4Shc/M29Hu9eSqJvhRVGHfjqbypjIon7F5WiPqjdssmLWn0om4+
-edIRYedgeHjQPNT5DNoW3yZJ5zbTW/Ilby4m7mOHx2t/rTVl4p/EWl3mLRWK
-uMeDq8qrurgO8662L+VerndXe7vxzMN+76IYql6GraF9VOwIA21+CxsxxAXU
-D/jgfy6/Pvbwp2eB8Ydcow4oD3WJvu4Q/yaH+GFU5XD2K3vr/9He0zYlG8uC
-P52veHTuZ6o8hgqBIidJ/dbqCRa+3q6itZTB2ovGSjbo0/2+SN14S9wo1zby
-yQJ4Laj+fdq+gaaPzTw24D8+p3kmfaf85jkDLMty98Rxq2F2G7bzRmWQdenR
-oIUyGl3r09OIm8w1IGt2prdwaXs1pEZhUjaW0GI5r0IYsowitjtJ4MsHPMa5
-d1jqOyU4t9jVSskZRzVK6U6EHEDmXuxlcHAy+jW4KX/vXa7LOrXyCFE4higa
-QmhRYP/UnAHkYvMk8miEhU/HOuqDm3EUho8e2i7wney99kvLixgf9Tqdbh2H
-de8JgItogc2f2/U3pTVuc7ANuLCv9LisZo0qbbU8JWHqX69CG27KBejs2rDo
-imGcdCCPtZlsfWEqvxait3e43rJlmTw+D/+cmrRqsv5Wq8x5fuHa1hPxXM6Z
-RdChvAk4ILaDZ/bk4d+KTFL+ewlDBtXq46MMSLfuylWlRN2DgndFrx/14Xi1
-f7Ah3h/hfw7ervdrrOXF018Fo72qFP54K0tZS6z722UzrG8bVZFalnIpNyXq
-w3cnxx80YcKiyEZx6DhfVSyaiiIw/U3VVCHPhCC7SKZ3FVND0WpgLFcKpoWb
-vM4sLzcZUew4FNQcQRBrVeloUE1efxVf27NBVzBSFxZO7KilCMyACoiuw2uI
-msTTWOZoc4//PTh+0sJRvAJxr1n/a+Jo+vzg7Yb4i4q6IGj8wHHdcssfptJD
-O6l5u+oCuryoqzIFAlAm5NzHKwmYAngSApoEZzFQs1zqLbDp7XEpLy7EXgLN
-cOjHCdU6zbjmMQsQRXKeUwh7pqDao747MItl68aGfPPytD/sb/oEt3/yHAj1
-ora/30DjxwBxzi7veGeQYzU2NWRPv5nEJ2yD9daZGyg1EtgTwWgeLEIWEK8H
-Y+DhG1GbVrNKo5zZrFhpTirY6EAWPytjev8F4wsen2YUy+sU9mXAXwZCEqbe
-t+E4mdFFnuFN3gimpet/tszH5tAWYV4X1rPisSk+vNKssdTTrKSIAPi1msqY
-LI23sPDu7R/YQaFZ6kjkOglQJI3GgRL8enLoB4PPY7BCrlfB/N1Myow2lRKq
-CAAzH9O9fWKkEpzbb5K6SrSizAS8SXI5dgEK+lS7l+0wvsJcFE6qlPew6vqD
-mPTc5/ucCkMS5i6Vflt4IG5my+iCOWYplh0ucx3iYK0f0sEOUqAf+2882sBu
-wYgEFb8mQbCy1ZLdqG67e7MdlUVnD7Evp6uiV81wajOduunYQUnf82HXhHId
-lt6d2e7m9VtT3au2r5n4wGXi+eXx8GeVEnnOLMk0dwzXFvE3yzD+Q54VyB1z
-T2LwPmSgjbywb7kQoEV3MI7W24ShP8ZFq/edHVmmfYhl2vcvQiwrGOWw1eJR
-wd4ag4PFNKiJLBTQ7xylBfJRwabVRGPC9yk2H8q2rMsak7Tg+iT6bNoi0vGL
-LyTTu+Ygl2cR4Q4zcKT7qmIdB6zLdU2dr0Sw28u4qmRHGAuJdk/DRWS76fb1
-Cff7kuzvbVY+QlY+qLFyQ8TbMBaoS3uvIn4czdCvmJZOLexGVWlV8vMOHQ1z
-ZHmrXLeXBXGnUzHi3kNnzSI27myctEhE+OKzSkRrMs4cvTNbSCKOk9vauzAW
-CUUJoikYFZG+FsForebKghFgLCYYmw0XEoy6W51mHVvs7uTUMmaTZj0bAuK3
-sszROS/QnsQhUe4smQbO9LyV5+dIg+EhKcZBPba1o1PiVHvpLDrgNpIueq/7
-IE4Dcp3WLmFS42pvFldfCn/l48O0JgXfPCC2g/5QpFO7oPQZsAg9P7IeasXa
-xBwzkLAUH1AdYKFl49Si60bTq5dfB/ClfoVDzdeR6RPqSA+sjg6PA/Y9wh9x
-OsojrBxhe1wocCcjx1dAr/CAb7KiDF6/2hdpFI0LGfEVXWNCn2jso68PE6/G
-ssvHL+krUwkkGDgJzLCwqMO3CXjtoG8s0FlsoKD0VYzgUz75tTsBvyZqtLpP
-taS5goZy971eYh/xHVHrUUbUexEDfb6JXidIQy35KfZ16ChnpLb1X1V3NQDW
-FZkNQ9uU83ototVaYPhVHOxJj4bzycO7tc8/KOamivfzLqHY/raB3KMtDlLi
-L4030d0e87l3fU4kH6qLv8gBQNijrC0vYFEvssQrYI2mPgurceC5oZCI7Wzb
-qzxBHwgdJuLz2Il9rLt9Xo5XUnsvNTZdCttiO3XBZilse2sZePJFIKKHot1q
-U9xMz7KE7omQN4wBwh9ZLTHHGTXGJc/x7iejyHCryaxKmCPU130bwGGpXyZW
-0zMWIWP0KIEclKBtI+QCZRUcCvhWhl6TlcU67A68kMucVy5CRsBO44LOo9No
-HDsPmS2EY3yBRysYJomzB+TcYQ/JIZGdhLo8896k5FmSBNlksgr7bFs728jl
-oWebzd0BFg+R0FNYyT3RO4vKkLWgPChRgrcBknFoX5xo8V6Ii+xKHjCBEJIe
-xUWIXojrUeQGH0Mz3EjEMX1xOPlhQHHTGHsFCACRp6F8xdnWCfoMmenlYtMY
-RW2Rnwz+mzoN6a644TlpeUzhXcL+8QsjlXPK/9Da5Ao6v/h9NfPKeZmoHtgX
-TuoO9QBzLO/2bC+sStZClxQymZSdExBJcJXBCk2z8yiNsqoQ705P7CeWPU4K
-eBFeSlESTs3F56jmzAUseSh+MWkzrB4TQ3ZGFxz+EtMK3FBA1ywJR8ALaXRd
-UgABLkSGLwbchaawM2VajqtIJYUE/TYl0z4JZ/a0p9KCclQlLnBOg50nsIMw
-uaDtJLAu8y8wq5xDG8mPFb0kpQhQrp1Rc19H6TnloqsnplOrhtIqTK18OtYS
-Nemmj+64WuH4v0KkMKHjvWI2WmkSjZY9OKouKwiPtT2dKRI0pw8zBI4ScGVN
-+cwr6vw3J/PxBSwNOm34agPgS+PrSAaFk/TevXwFR0k8avF+RcPFVrggRnBV
-MOVmlsPppeTELt5H8CDX8DAcZHAM7ziYL3lMpPOzSuWLCkQ6DPS5W7M4q9/S
-wr9QKWtBmFfST8wZhZ3tU3+K3rGP1KGV35RHItjqD8Yv+SSvn7ZbkkfihCHP
-WtpMqhxDU2WO0wURWDeOCBCANR+COCkso8v8RuclXhWmY2wdsCneyspP4xDU
-wBj0h+lU/CSGz7f6T8Xpz7+r5N4LpGZ4d/g62B4M/vVDMBj2B7viEE+eGFzF
-5t3eeR7Rn4IaecMuqxLMiPvgKwqvMsGM4UdnsfhALW081B3necOLjC0AP1QK
-DgOaxbY5r3WBdFPLqSTRkktOJNLv5YBzS+e5DDkNSjsZkYLo7A+cYysSFp2X
-4RQDBAbp5JT7ZpSydtsij8LatvF6r4gHVmUgl128VwrMIxYS9kGaJVrIRlmj
-pZJPfyVR81vL9UVx32R1aFp8jK7uOeAMCfvX4DeBQ2HirVFSjZlKoZjE1/Cr
-dAu4d09ttzv+C+8yS6KcjCiO8bw/KfbJeXbhBsrSHsRG+vsFXrB3hdfuc6i2
-FSVK3j9MatL+kNqXpqHxLtIwBD+I+jqCS+33nWQRLBBsaqtmN+y08xGPY+Z/
-sF5IK0csvmdS7l/twdJkd1KmO4H99uML+SQKXZq+qdxVXKzLkwvwnO/1Ocu9
-oKzQO895ULtY89SSldxHGrW9yX+C5AbrB4xQ+i28Xq89AqDzMhtGJotu64m5
-tE7MHYfjWYhVueklmvW22hyz3JJkjmO5bJlLa9Du50Ne6v9bIm9rVeuhGDRX
-NZcWcVesgL+NnDUH2ALWBBhpTMlUYJ4wLHaw+eQNGxtYhWZom6WfRJPj2/jX
-L4x11ovVJC+9Q2uRrNzdPOL24PTCtXDcOwD0Od/2To6lqOJ6sAJnlTJbVGh3
-rOpvtZhdNaTC67tCSnLzgkhZSqp5XXL3pKJyp8tQqonTnVNqFZzKrAzvEiNr
-r6tYiPzayoF6VcvxolLUe08m7K6X7/jQD0EKEpN/UvE1dRh3jZV2Jaf3sn+r
-28KORFSnRuOUBrjttTjj1Cip9b5DA9RXg+S/RIXPJqRMjaCfN+oXwpZw8KBn
-ejCmL7qb51E4RtJZjeuPuBYYZD459DTukST3/brpDh8y+VjaSs5XNvIHNk1I
-iw4GxhcwGlvEfZu4aNw/d4SBcAIC7VnTbrxZ2y2yAbBKPKdvURAPu//RLyen
-4vjdqY6gkADr62UgmHXqkkMo+KwVdZL0GNsBK3xmE+Exvedu7QUlFnYKiG/u
-e6PWtd7CDLNsMFGNi9xAm7vnovna9L5nSkMtMM/6E5dbzLPJzIaRluZlrOJU
-EWNYzTvY973hVK52dxPlA9HDOqQ4J5PpdF2cVmxS1HjRlKMLwgJFNDHx4mrD
-279TgYg1K8vqXpJkMhvBUVReZG5cSCPxtz5UzT9cOw+g7eTBiQ4Lg00Lv51l
-VTrmna56m3OWPJDzm9WQnLzrHmnpjnby87tf3h44spKuLhEHdNk5RWu0IOG7
-Jtn3zFRqrAqVepez9k5VsECcwoEvNLKVjQDaUsudqpd+oM8kNIMQCUNPvFmN
-kF4JQauwLMaq9AJWXqhN2am50FpxgebBDGCG9mbv1zxjd/cVq/+0Mj3reKxG
-z/puAWGCV+qByeu81HndSBQxUHfzBpCVIPFMP9VWra1L/FoJ7iLNg+gagMC5
-Kj9vHECdyyx1x8tXvD6ZwknZB3MovAeTGo9jlTiAx2X84XPenKW8VKVDcZ3q
-thgnvTC6iEYf1a6MijKe0j2Y1jve4th4gdR7A/9dX2zZOAPcvBSW3lVz0lXW
-VoUOIuWFAmBGcVdKzyo4v9MbRgXXIhYSRmX8c3D0iguDWJQlXxA5SxqM8SJ0
-zJfQxBH8oDKJJ36JZ6aAcqUo72sWDH3JyYTATufkiZhloNDRwWCVrNXF88Ik
-k+yFQUxW/+bCwX/gf/8bfh4++GNXfAdzCW5gZ1OwiADDIol+WFNMekp5cH7b
-O37DcX/R2sMHRVblo4hCS2D3fgRr54c1lKxrwvomBTR+WIujchIkZAZxPcyf
-Ngeb28FgKxhs93HQNdpu34mTCGxGdNvuywgmvjqUthGS0cLBVGPhOzZQ9uNs
-VJGppEyLUBQgFqYhh+iHJRsTHJlFJWnBNtKJZfElTIGy8zIORcrJ5FFtgJIi
-oLAry2yEIZ0Y30WQwkIcvzrdf3f8Wvzxxz99eL2/s7k9/PQJzbwPr07sL54N
-tgefPvV5FpIHVFciDcGTIZ8F0kEneoIzOLXY0LEcWpeBGR/E6pJPduMp6q4A
-8oTBnVxEwEC9k5Of1w22m3WkNN4OVj+fnr4/WRABd/DTtycERJJhe3sHRrRW
-VGbtxyWn45m8qqS1wA/LPEvoDSWgfry3f6Rwf7aFlCYwsDCX8VhdLXBx3wyD
-FED8jkq5rvxOOgSpihWLck18GZOrpw3ak9PqhRjrbh0ai+pMpa4GMpqKwW2A
-FLuYDDn8qhtT/mAEvZz+q3rrS0l1z6qpKGemkb2GKpsV8fyUjHYduxynlxkp
-Rhw9hxMH/q7GlXFKoXe4iCOEQ46WBLMLPiY63ICRO7VXMTv7r2hUFnon2vuU
-k9lxci7YgjKrFiKj1Kv0qR5nEo4GIyHIJyJ4hsOtdZXj/QOaC0zEgnneZP7S
-jxuBNfmiNFQVtjFpHMZcagXspGPj8Yq+cugCSaWTIdNRlRTtqwHbg17FFPdC
-kKoy5vIuODJzIIltlC0f3u9bTLGhIiuAYcFyCnEfkdAiOASTYlOJdmk2VrmV
-5RSRGMiHG0KecvkPHFb35eUjZx+xDwwRTSZIaBlbp6SdxarxhAkWpzKeDn13
-zFDTEIMDsqpIboBScFqUxlkRaSJJIFgvAZN48yhaPOtcBk79GKa9lM5EXxV3
-5jIULzqce7M8wqTTSkZxn5A8DlJuq73P4kBSt05IlaHKCpstsEhJCfqZ8vZV
-CVqOuHoY1p9NDb2i9DLOMzpeF/Z2KJQiq9EDmC1J8IVeVSqi0MSG/aG7uS2R
-+fT5E9AcdLdwYxIXaVoC81wB0D5r0MO94z2P9nwt7QuTmvKXD4cKg7XDV6ev
-xV+P3ooP0XkMQvNmDYb+EYbe2nn27NOnDYZ6EWJM8JjTkRG76vdvcZSMmcYT
-FYtmobiLGLClAZOCgXdhe+TpLpoFu+TWK3avp8luWuyiMbDbMBdYrjJuuICU
-g39U7jKtD1+dvKEWMAP46Pjx3guJH5zKCsSW5ooShyaJNgkV+uwrrB4+OHVJ
-ipnZ4BRCXdSUbYkmzyZr9Bm9HwUOOka4azAs09BZPZcE2BIw9c/zWKG3EpXe
-wxLE19A1cWknl2qXi7j/FX7M5PGTV3AUAx45zkpo8z7Bp5p4YMGIdWpt0vxh
-a/kkhX1L6qxmUZCYMQgCcRaOPuLvaGHKNyrBWVxIc29fvlqhXY5wnw+eb9Fy
-WOdAUk6TqqwoN7ws/6PuJMZ5OOHRYATGKhr/sEZGuTIq90boIIRdxym+rV0a
-VqAnZa4VnBpuadwbnDYMH+bjx3GORb9HmKsVXQ8fSZp8yGAoljy/xkkp69bp
-/QyEKEkcX8bRFcE/hSm+j7B0FzakulCgEhkhFIRVrk6GU7J1sI9lzoKtn800
-aYV0bukGVyG9zAM20b6pj8AxY75G+H9qHRIe6pABAA==
+H4sIAAAAAAAAA+19aXfbSJLgd73n/5CjejumqgWa1GVbnjpkyXZpx5Lclmqq
+q2f6zYNIUMIYBLgAqKOqPL9lf8v+so0jTyABHpJsd4/1ussSmRkZGRkZV0Zm
+BEHwaGWQDeP0YldMy1Hw7NHKo5UyLpNoV+xn43GWil/3jt+Ig7AMxdntJCrE
+KMvF2/A2ykVPHEfldZZ/KLBXeH6eR1e74m3P6UmdHq0Ms0EajgHqMA9HZRBH
+MNhgEI4nQT4aPO893wzO4yJIwjIqykcr2XmRJRH8vivwu0crxfR8HBdFnKUl
+wNsVh6/OXj9awbEv8mw6AWT3947eiV/gA5iLeIMfwswA3EWW3+6Kohw+Wokn
++a4o82lRbvR6z3sbiHVRhunwP8MkSwHqLWI6iXfFv5fZYF0UWV7m0aiA327H
+/MsAZhalZfE3mvG0vMzy3UcrQgT4HyF4iqdRfhFn4mWUZGUZ8zdZDhQ+zj7E
+If+dZ0jiaBiXWc6fROMwTgBT6tw9584/ptilC8PWRjksAWvxclrYI/w0Da+j
+eMYQMfbsnkPPHy+pvRf+AawRLDLMIonyBScxpL44CejbModXRXkJY7yNxPts
++ls84O/iFNb9Vbf6MY1+kofpReQMFhGQLoxEjX/MqIl3vL0YJizeTDML4utp
+Oc0joII4iwaXaZZkFzHygTVCiN0uplkX2fbHC/yQwePmScs8Pp+WPkb4KczG
+cZiKv15G6UXDKskhfsMml9y+dVXCNI4S8a+xA/DnNL6K8iIub0U2gt2ZDsKi
+jCpr0sWt8WOivuyGg+70Q22AN+F5DiNE8EsSj8+j3OHg/bgYZA7Yiwtu9+MA
+v/KvcprHgww2ZQzM3bAfJDRu2pVNWzjn4DKfXsF/s+FtO2GH2LC2cBVoL2OQ
+VlEGkuPXLEstgK/O3h864M5vb6fpjxGseTePuh/yGqj38SDMh+Lf4iRMytAm
+3dnZvgMqp5bdK27546AsB11mPAfgr9kU8HobRRas03BcTBUHSHC32C6Jom55
+0zLTf4sHJQrwbBL91roSV9Swm2BDex0eraRZPg5LYDhi+MOzn4Oz/3zT3Xn+
+rLuxyyCkAvme/xJibzxJ4lEcDcV4mpTx4DJMU2DiYZQWkbgOr4Dd0ovyEsTG
+VYwyXvWj1pMkukGZHk4ACEh0+L4Q1zE0L2KcsFDgsgmADhPVOU6ByUfhQO1l
+S1rraRPy4n3EYn1IwIWcCzeEzyIkz1WEe0Fs9PrP+AvkzwgwGGUKjNVPEeVp
+77lLkkONFOlREFwKbVBMYVpMQOWIlLXqwmjDaDbSR2E+uASMN3rNGMsuCt/n
+T592+y7Gq2eIF0qXCLXfBAY7B6I3rl3LouGM82gSAXY58IKa+CgGw0Gghg/z
+OIVRQhyguAUhNS5WF6YCzcGmw+voPJ+G+S2Sot9MCt3PEKPXq9DiNUhOEQ5g
++QpRZohzMQDpD4wBUxrHaZgUovOmO4JmayIQ77Jr+KqYRANYXOZ3FNH4AWwH
+JssyE+z17Pn972mCc+s/b5sbd9GbdWenMrP9yzAPBzCLuIBVKVCNTLIEFuQ3
+HnacDWHRY0A9p1VGVoDphCAjCgEmFHbIo0FEegj4OixNk4hWvg3c4kSAGTSs
+cb9ljakXGILwoV+GbdXY/1St3kUeD5mHfzk4chgbtBF+NMqj/zON0sEtNV1i
+Sji6PakTkMAsdNq2sO5mz2JjmVns40fWll5+Go7wPAC2kMKzt9k+D0d4nk4n
+W5s+YURCEvjt8NWrV6Lfe/Ny7/RV8B4EfrMshW15cna8NnM2MCaILjTxhURg
+iZnoftZMNiuKYPVEospyDmRDEV+ktJOA+CAGAS7ITzAvi3gY5bxEC6O/+bxp
+k+y0oo/9Hq0EQSDC86JEwYB/n13GhQBHbkoDDKMRoAmbH5AEM39Ayw+rMmDn
+b4geIzpr4DXBDFKYd4y/4wzJZ4PpFbgVSQmSq0hdUDIkOHUwVC/A6o66AkeO
+WP0gZALqwlkHbHLYzUPYhNmYIJ5P4wT8zNQCXccGfDgbjAhBEaHdkA4BFAj4
+c/hzjHwEf57fIm7TJJLijRBVnjA5AqP4YsorRdiBa1miNpuE53EiZ19MQSWH
+hfjF7LJTsGUGlzCA4ohjzbK/nJ4cF2sI7NHKCDVqgFsS2BB1rwXiQOneI1v3
+dlAqrekd0K0voXazxfvX++Rp4yxBRSfhACHoleGJg+OIDFmGsO5DNsFCAH8N
+PeT4RJg4HSTTIS7REDxD+Bjm1LII7kp2FeON4+EwifCvb9BqygEDYjH8BBiX
+AP7++z8B4k+fb/c+fhQxsqKfhcS04PWkb6i/u1zYbV0uGP/+Phpn8Me7PBtE
+Q/APxX6YJMy+1D/NSq3CWZ5KOotxmMKQRN9JnpUZ7I5CrztS9Ngy7/YdNN7J
+9qJz/Ops/+T49Zqc4s7GVv/jx64QZ2pF1NQISgHbHpgUCVCMAU/Y1iQg9R4w
+lCdqA15XMa7QOELjOS7GbCMDhXgfiYz8cu5R31L0eVeuhMtSsVyqeQSD2rQE
+ZubGlbNXG90jBQgObmEWpnoLI1RXdrDaQzMTV07zC2iX0UiGG15ZUrhz9mpN
+jMBuBUYocBmvIyAy/JtmaXD2ynzViboX3XUxubwttCui+KIiIMgqhM1th9OU
++tJKK2ZXiBDsQGOWuWBsTUtUC0jV0ia/pJGaH4odjAgQEDUIk0DaoACLJLC7
+hHL/eoQUQWoUVL///gMya39nE/bj7787ZhV8govlfrrx8SNrhKp0o3EWlXBy
+/Kfghn38SBBqOPiZFgRVQYIMacNEjnljAwNVhGChRYCRnjwuyk/apK9hSUfT
+nLbQMAJxiYKjiJgRlazkjYsShwKKvJQVcZsC5FvY6MEAGAAIKD3GYjoeoxqX
+3PH777iJL6ICQ6hyik1y3sbUlfUxLjz8txAomPOovO2KQ1D7WlZURL0HX6Mb
+YqkKYCypY3OkQ8oC0JIAE4SXTQvwYCRvr4MAgBVJisxdlkcr7esC026ku49C
+whKmRmvUdwNuW3AW9JC29D4yoh4D5AU4Q5HYA687LmFzT/NIb1haSpTkzza3
+NiQG33wjzshrxJDjLW2D46xkjSIxfB+NUAxnirO3tnb0PqIPtp/hxlKhhA/R
+LTmiBSs8OReCpObD2w0bl9bYCADWGH1Z5IUKUQowYlIQpCyns2lqzYeVr+Q5
+xgDIA+u2evTz6dnqOv8rjk/o9/ev/vzz4ftXB/j76U97b9/qX1Zki9OfTn5+
+e2B+Mz33T46OXh0fcGf4VDgfrawe7f26yrNbPXl3dnhyvPd2tb6cqB6kYYeh
+GOA/tO3CYkVOn8n2cv/d//u//S05x41+/zkJNFrA/tMt+OP6Mkp5tCwF5uU/
+gay3KyB8ozBHKKiJwfzDcDtaDiB0L7PrVAB7Rt0VyQHvcuCQG2xNRyzH6Bcf
+h+NIccBhZQLrFMcjcUELlGZDqQZZZVusnJ3/F6oYrRUnNBRMcFoo445OPzBc
+yd8BjkU2iMNSmXfQRlpLOai3SZYONXtou1hvv0crf6jp8M8fjnTw/vzBLA5e
+c4Tdk17AcoG/o1OiBPWW/bnbHQzXv8DPo5Xfd8U3ZXgeyGkW7Gl9t/pO/Y1E
+8kyE0Vv9iBNAaK/oOAO3IgYH3iVRWERSTkY0lCYNDZ5OySMEymmTo8JxJP3G
+2VXEX4DlyNT6RqtkPlg7YjqBSViiRvBqKuN02aTF7SsNHEfLrzMFCY5Nxq4E
+q/SMlBcUFQBNXtPIoGVtU0aZYqu19VmtqAKW9yMwA7NrRXCClEfTguwvjxm3
+K2cOzIDDE2T12fdiT5zjgjAPshNxqwUgoUtKPCzqsndno7fN4lO6zlKE7Tx/
+bpTC4Ho4DgaXQTEZLDLyfhbmfqdMjuUaLvtkuMjINYwl/a12zBWKw+VQpCDV
+jCElsg0DM0+kg9HFwuNa7HScUaRU7EM7DEm91nGzN3mYTjFKCL07x/uv36wJ
+FeRoJI27ejxMkWRlcB0Py0sYUYM06J69PNhF6wIdRhL7E+20h8CaUiCJDlkh
+0hNZUyNEVaK3QMPpJ3FRcnRUwnUmwTuC+R0+C+Rh/L0DN2G9gEUVipP7HwaN
+iocgT1ZODdjvWXopF4aFDDEIwDk5+3ldujBKy3k8HuMYPO0p9vlenMa47OY7
+CuSBxBhmEcltAS438FMZSeshm0S58rJkIIv0L+iKNFqvovXBZd7qIGxj2W2u
+onSY5YE6LnC9EKPEFW30zlu3gVSsBxmDwO2q9gzNguM0AVoOD8B8BfjJSXiO
+cqcM8zKAiVmjAChSO9RC0Ok98GujGDQm7EWUgoMu0wNA807YmmXzR6lKwtSM
+/YR/j2wj9hlYscQEBIeYS2kjstkYCOJoFsMCSfhosFqEyjOGLO3WyXCZTT4D
+AWDU2qQr85Wg2mfNcGrzA4XN39MMAooqWyqC2FfTlfxDG0VludhEsAaRiFVC
+N2yuNGtMom0VIho8qgPwPhi/cUY6h7tubfQ2uavNB9KPEpZrFVWNJPSoMegJ
+zcfoCpqvNQUlkAnIkTHmyBQe5ijKaDIn4Xhq2KFooIcxdQ6DA8qDCEowaTHt
+6tnTpzvBdIKHA1UNSjj7dyzzqzXzmVzLKlpzLQKRjLvMnsXubRxs8a6H/hIs
+AvHsXZvhwKeLB5faOKbYKLuIHMeh+YL0C6/COCGGTKVhM5CGjToQjHWwFFaz
+EI6nWcj46Ga3j8BUkAAjaOtLjEOOXji8wrQdZdKPv+uvy8mMozCVxxf4DWgc
+A7UK7VawR2t9gHYVB2o9jYM+0sjzxZ/6FJtXAzUyWk0mLsJjimQWj4kF2KxZ
+MipI8+mDBslYm+vCErKBFja/hgrXBuK07PC55U0NDRY9d5I46M00iRovMuDq
+nuv1M1FB3CRNQqOiRgiMzUdFhBK5jBIy5Hz2SsUprn69LgFn6jCmGswXBWwN
+8EMynR1BHrI4z8BXpLhMUBmCIYJX8KGok8psliWJJCqsuihhsLuXJPDFpyZG
+bTctS5MGq2N+qhhM/MQx339qGlmbfFnqIIg6cebYQlEDq+A3n4AOlA3CqUmB
+fRwvnckaMTI5J3bgTGfnLF9GBwDRBMMmq6hZilU8jIqGylzgELtJ8UO/G/W2
+TKMjx7Grs9DDfGj8rzpaKpyiY7Y0ot+npEREKWGz/CJMZd6V7eG1TpzzZ9Ih
+TNpyDzltS64TpUS44As8oWKvlQPeribS6oAT/yVVghioEefongZKTwd46iXx
+58BmEN2g4R+Xc07Ack/DkjO0gVh5lFBwGxrqbFEzPJjT8RhPwADdAcaz8IzL
+Wn6FApHh3uZHI8CwwCxBOU1hHiwlmuZY9Zus/oL7sxiTNh+m2MjzXGwN/BiP
+p2PaMePwhn6XvbTJtm4fcZMxZaw52ZbUvr08FS5bfLVk/NrZYtbK0co8WlEC
+Wq9PjTspg8peKMKSoibULmDxpQJJzREOK0nQignSWZyT1/WRTg6KNJ8NsgEM
+ZZ4ymEkxvAOYXk9CGS8PZWdnh4F88w2lCL4l0Y8d+Lf3fP/i0UrVk6nG2CvO
+H1nMAE8q2miSRwXtOY+LYR+mhBYWOlXqXQiyv/P29N2awNmIC1iklBuC1Nfe
+Dh9egpejMhZ0EF6cSr+rc3J0uiaOomEcin2ZSE63h0TnaP/NGm9yZ5Y/LLfN
+0aEpwOe3iFBc4gnheVQ5PLLawQxpgtBM0Q8nWPCs8wj8mwBoF1HDCRIFE23x
+3yK6oIQQWqkqfeNGtSETNTh5Jy3ji2k2LazuvP8GOln4N06MQ6HZ5JXyyTaN
+SyF5jslUQcIUs4GSzaEH4WlqXFUU33Ta6TYrNKFd68XDYcNoAmqK6KgIq8+O
+aOt8iyevSshQYiybGthqvZl6G4rVmymOMSIGxnDV9QV1ItOpnkBRAiB2Q7hV
+KlvpujpegfbFlI+1a8yrtyjN8r/hR52wJOH4fBiK70R/62lfpGPxJ3Esburo
+jcGXm+YMMB2vKSAVkh3MTbL+QiQ78JKseiLWSjJLz92RZCOk1vPNfq/X7fV6
+4s1Pv81DNGjWTjU0ZIHN74dwJE/05luILhhLUoRZpyODodowFsQL+9Du9Jc3
+63KlwEzpb3S3kSg+1NfW1bWBVlxc8HgmaMHf6W40wxd40I9SHjbI7XrDwrJ2
+qi3s6S+wskewkDAf3+LNWH5Es23N/SKqwjTrDAaJhFjYidIcxQqt/CLLfaIv
+KZ0R4FaPkK7CZGryFLFvXmtjUxydDhuNNS1ijVYmi6Bdo0vXjYKTWoqrSwig
+uwqZk4N5q6B6M7S2q1q9ceQ6v0tfOyrAfGQ1j77AepO57o1OyU2wrtBcx8jf
+NBmSvp6ScnVSaTyHH8bU7ejYPGULsWGypvL5WqIEFRB1+eAF6IuMVCBJ24iW
+RacPk0utM0Dqg/HqvwpBNuA+1YeefnrbLBHFnFBsB7Txj3r42VJoilnjRk2s
+Z9wAtC1S7oFulBbCVVPnOzNruzrDhE9btXPiemPyvJfWBgkdGWpJ9JA2RMgm
+wS9Y8EdL0JliEjWCGI/dktty/o5YN5k6xvWqbJuK1PxW+JMtlA6piAXlfqKM
+i2ArldcRbHGDVfGCgUI7O4tjFOJlVPBk1O3CGAMToxZVhDkAQ8rPl/tTj2ya
+24GMuamtEAxv7htB6Y3fFcHqHlVc1yATm6MYDWLRpKBZIfB1/SfGwq3vZOgv
+ZIYMzuNyHE60KG88RHeSsJWiaBfA3qD9shK4CcLCArgJ0B3kr004IK9lSCxB
+KACwPI1qnZcgTw3GkpQRs8kyh9OHKeSkY8wwpA5IBaxjkrwyIgu/zVbdTsZ7
+eGFGqEt7H+w5bWI25XbWN7bJyqzE7mx5pCPIWqxIHQAiIvWjrrPrMLuWriKU
+eRRxfEi+74LhB/sSCyezvjGXctjuBfCDOA5gN8hoXLRbz+9dWbFOWn3ngmR5
+/ykIREcr4rUfpDmOn+922DhAh3BNff4HdyEnMf1BcKYKjbfLnzkABp6uA0/X
+Qb2r2SIagERXZk7+YAOQnzVNOZpYs7VzYeeeMG106Ro7WZ80EZUtlkejmfMn
+SINFIfnJcaPJQTPyAPTAc8k4GPHAlZ+Z/Yiq9Z7TOC2f+ZcBj1nvwnPyK36p
+IkAvazrBUyietAHzhwHGbdfcb+osbP00cLMFk4RABaScVDE9H4R5DvKBWSX9
+tgXkPBuk9rPcjunMpJkFpkIzBzVr6/mQMruwqeu4vevY7XpD+CDGdXRuXHrL
+ob8V/y5/+1uth5hHfLR0GXu6jD0EdBnE/s6oHbJ3i1obb7PGObl95p2Wp1fT
+zDyb2EoP0HtZb2WvBMMWKiuQV1/JCBsFhGFxc4Mn1CDR/kR3nD1ezg9quP6O
+09bncLhtzdR9+bazxVi70pxbJIiqSKgLAB+m84lar5B9UPE6W7q6u322dF2e
+krWfFtL6snH97D+T++sKspKsOpehsrCJMpeFIuawUFxAJqOiOdW1stNnGm4W
+KFcQzgtpIdHmTZ00azBzOzRshMW15VJ60qMhF9GNC2nFhfShXxPO1IGLab9F
+9d5d2OJ/nOLzp7auSK5b0O1Y3OFYwtWwc9MoV8ZsY/xzzeFNmdhV2bN5Jpz8
+MWdU55taP+vKGYbmMH3vW//UdC9aOxmSMLKOxjSboLz8rdoLVnHxXjZ1ymkq
+71r94PS6qPaCeZU3eoEn+AZbAEgzWfjP4fl4jj7hzaw++RLj1PvMNU6ZlWGt
+h6cPMYon56/ONJ5GNbGJzSrXwyz2qn7l7W6NEjBXjUDAI5SGr3xQmhm1gVN1
+z2Z2beQ807eRaWf3bWbdRt4Vs9nXyyMt/TSjtPZrZuNF+809XgM7N/Czk05Y
+Uc4Az/m6ppxbmcC7jk7XxQSX3XVB6eV0nV+wtHdrlC12twXEWHu3eUebV5jZ
+3czjo7TMRZMWdTK8tTbVMW/u/E8rDmz3WzDf8B8QSX+rsZr8wh/pEqhv8cWo
+WrdOlXFFg0rnn2UVe6X3Quq90nepLfPHnXbNH3faOMso/5k9ZzD0MobAzJ4L
+jLnwPmo3DSoDtBgIuqW4g5ngAdJgLPh6qDjLDCuiPshitkS9/6IWhQfCgnZF
+HcKi1oUHwgI6f57ezZq/3nsRe2Oe3guOPbftIVS/FgtEWLBb7BC72VKi1QGw
+jHS1ASwlYB0Ai8q79s4zRJ7deWFJ2955sZEXk7d2Z4/14vupmiPWA830CGDx
+bUNHJQ2D70W3+0T/zzVsnkjrZc7BPfK/cXz1M+/45j61c/VtxcKjavpULR4N
+wnfDzQK0qGa6g9+qUZpEALK8DSjBwkbG+QI/nqYAxe7qXp2yunr0Vs0M9USk
+oGdTa/vHCrwZITOMR6OAMAuGURLeViEMo0E8BtptVPoNLvMMr04NAvPG+w8z
++g2GgSQO2N/wB1GIDfA/rDaacB5Af8ykso2k/SA9EbuCrA/JydjGEv/yoak/
+v3c0OYUpTMsgyQp+Do+FD/6JEf90miQ2vsPExhf+8uKrPlf4GpgLIqxTbwPr
+xp2ONrfxKCrFk9Pj921MWqS51QPkMYBwBXq1tyuZG5SAIVDtKx+1/I3qozVT
+Tf/U1huI8Gc7xO358bGlIft5OB0G3s0u++1s2aTIkiTIRqM2ovv6kQUjT2rs
+TCD7p25JVHFVT6nVR/ezCLZHJeifXzO2NM5lHhWXWdLkufv6wSTPQeUEGfBd
+E4VclsymJZCzvZfbo6xscMlCIHf5ciZC4M9IUdlb2+5WfIiuPYPZvKIVjLyx
+q9XpDPXZ4C41nKk23mbWkZhFrN9FTw4WOzOoUiRMpJHzJSK7qOW9mKm9mG29
+mDG9iPVcXRKbPvRmllmaBnPIdyZXpULVW/Qozurk5utizbDuVVpd2qap3okH
+m/mTzLgNlzwKh5jAXcGkgT6LEqcVGzzonhJ8cxXFkML7nGVbqofeTRVplBAO
+JrW6caeCIzOroY07XsLGpcTqKWBZW6hfgAIIohv4HDZBfsE7jJVCDcCEnph0
+ItkYZihKkOroVF24OsZVLaZZlCV206ZmSIui1C3hH3VlEbO/gSkDNwNc54TT
+8/RWTviReZbYyQrXueDYS6WBe155/h1vWBLkK1luqt/tv8AP6fFruju0Os3T
+Xey6S7xZ7N6Mk9202MVuu/WHiam3fOVa5VC84OdwbP3HVztXsbyor6Qog6EX
+aLAkDrX95Y34JTrfFeJfLstyUuw+eYJvgGLRnA9RTjdpujDCk+uLJ/RewBNV
+FQ/6vY2Lclf8CxbcK7Nd+vpH1eF7+YKPkA9SwwCeipzmR0HhRt2XldKbHnC+
+MqV1eNyq+7Jaj9QDsFqRtA6MWnRfupVHPZA8hTPrwBpKZn7Pi2Q9dyEXyn7y
+Wl1iUg9DOM9mu89jqxcbVR0EUy2InyPiZ1utdynLzFQFoq6v6QpJvWoG39yg
+6yad2vvRsq+38MWauZ7SaSwGJAE4/daqT3tXK4509VrsZ5PbPL64LEVnsIYl
+yLao6K44w/q5+gFSdJfxipaOgqjnT/EJCSpTpStboJAAyu4liSC4+BpPEeVX
+0dAM+j4CF5ylvXqmZFrQey9FNs0H/LrLeZxi9QuqyrBOj7HL3iBu8C8wwnHp
+dHmedbwhPMGnmEq88zKZ5sUUPGhYJ1POB2vo0HP56gkOWEwiLJdTsCtb8J37
+91gHQ8/25ekBbGbugXeYATdYCUBbPTOy1R0oOhgqPlYP9r2NLmAN3iGHFXTj
+7T2+UyTfyKH2B/IBX9Wjo2QNlTOOIiNnJOKU9bVmKEsMraSpKhvjFBsp8FFS
+ejBJvan/AotnqLdl5XP3cVlEyYhE+wg0tkgIdayGNIgKezi7FsRjrAHxeJ3/
+xYoO+LuqBYG/UwkI/YuEIdtxHQjzm+mvyz/gn5WKEI/lu2Iw5t6vj/mtgceq
+LsTj+etC6CcV3eoQor8lOkgPrA2xxr9iZYg1b2EIQ8NbMV95iFXSTU+eCK5I
+0N31VCAAFTQF2ttFCHSpAeqryw1IWAoE3Q9WdVzwWqepaCCZYTI9V2FnaiDB
+kUofh/TEROcWpgHuUgpmyjC8pUcRNFAUF0FvO9josy73iGMUyERvvlk6ZKkt
+zLNEuplix131ghRVyjiiNxBqJgaD+ciMaOPTD3rPgv5mGz6HeF8QKCq3STtG
+WENnUYyefAu/fisOde0z/PMJ46qfzbczqNuwVYPoK4zt+OIlxF3xBh9EDRN6
+t4feUFD13PHtl4DfVwr2MYMCuED177w93V9bd95gQtn0HgQtUGpdb3rh1nIU
+nf7GE6yUuLYr5qk/qaF461Da62pRi/K+OaPzejhW9BJcj8Am5Qv1jYeWQKJ9
+dRt0VTes0XF5ShIFDZg5KHlPpGyhZTs1h3ei5sGDUtNAmJ8z3XKpQM/eEyyr
+ujA9fZVeG8lp5RvfjZ6vNaDZBMUru40ERRnOwN6g2IhTSWIDg6koHM79sgis
+yVt9KKtNWtpPbTnFT+5darp7vZlyssFnlJ1Ev41eWmXMKl1nMCdBqFyE/7xS
+VLX4HNJUU7f6JlkbdzaW5vls3Olly+W3deOurnMl0a3f611c/lbhyypFZ/Bl
+X77J9UWx5udVSETB7buTdvsrZX2U3di+M2X5FY+vlK3Kg43J3WmLzxF+pe5K
+zUD1KCksTDvF92AmeUTPsr5oVl7GOG1RYU3GsRx7Z+LbOzX09EI14de09PhS
+ZNvS+wmjK9216W5r+ktXtmtX83ey6Je05++FFxfQ+hbB23hBr8i8673Iknz1
+rarr4b/YO+du8L9795XVJWmvLxq0Whvp59Vw7bT/yuC3wuQnethZrNJKOKVM
+rQ5tau3g3em/VhbU9JwVNsO+nQOZ/EWx6HeXCOH0Mh6V4l+jWzr8M/CaraY/
+3wEN6tv58zQc5iFVMV8WiYN3wV3wUN07B3jO8c7KdxMGOdN+aVLtHT1bFsVn
+0Fl0nonidnyewTaxiLY3BhYtp8OI0yEI2lo7re6AiOpu4dJGNYOdgTEXmjBI
+f2dpxqLOHfj/fdFreVx0fxud+UgmFqfZ5sYdaAadO/D/+6LZ8rjo/jY6D8Vm
+O1t3IBl07sD/74tky+Oi+9vo3B/JjIaKZkcZX7o6Des48iPN+un316/2VevO
+6yy/xjJTr/IcH0XN8pxzGdaEXWxY1ZwcRnmMqRxNavECs72rhk40l9v+RhZx
+bEJIdN4EgPhat928USbG86fb4mqj25NWRg+tDAU6ItADAxoVv4FRTM/HsGZp
+BCtZlNG46DYzDj+9tPSkT7F7y5RPF5wyWFVXfQx9957CpPub80/6Mr64xBtE
+lHXPFtYidEiz5YlwnCFHttB4cAcCl2Gc0/PrLUTen4fKe2ka3Yg9zJxRBH/a
+ew60BoKDLdt7Lm3Zk7Oft0SSYUY8veVtQFDKySgcRC10vAMZTyZR2jLLE5qk
+fq99Wsj3hw2El1kRrWN5pOnwcprHlGfyUzZAK/viMhqLzsv9n9ZwqWZQaj8J
+MZ2rv9Pd6m5V6bWJuxJt/z7SawMZVL2QfHJ2bGFjkVATTuVy8g+vyKv7HaFl
+be7AhvtZivGrlEofAQVFh3muUpIxTAV5TcKwrQEyk4Ep947fYU9hRlj0w/Qe
+ZlO8jBPdABZYufD0ICA8+hvP1im56adwPOb8cCqmpvrZ6okUAGCWsDKQuZLk
+Ig7kmm8/UYtwjRlO+Nx1XFhAuJCiODj9CXqBUAmpNsygQp5PtxVf+GbK8A/u
+nXXrI6mtsv2wTGyyjszdgvlNCF3Bj5NBQUkIVBJPEJiQwKhGHyeZKiic4Ik5
+nFwQ02BlatLpEVUG5dMuqi+LGPRuirjaJE2OxOg/U5L6I1KyskftyxPH7/8a
+bEy231QTMkyTGbv2jJ5nTwFfMNlSpMNvEb7yAoDX/GSgGuLnt9b6IMUUZaoU
+wV1TFALACSyh5GF6C5Am0WZ3o7tjk+j59nPU+8+QRKz3n621iLEqiWCX9D87
+iVTatArcn3Fp0rwUP6cAJcuxRinsB0R2rcZqHmabk5hPgZgVjrsjOfs9i+E+
+O18BNguw1dP7ZauqB/qFstUGsdXGl8tWJ2dvwZIKTvfvRM9WstVZyfKHeOoC
+rwLfUtUgYCvgckVcL1G37Pw9VMRrnH48n0EuyJ4xEMiLDflSBhJ1lE1zz/hv
+Q7SiYLi3Xmu+ie37cyqcWev0+uRwv//JF0otj21k6YVCq+FEHCrLgPQ0rc9+
+n9cDDCQimrVaPI3+/Atm9ZVL96DUN3msvuuBbXaNdX+mgF8YB1yhWcdVz57v
+ilOiM5L1FRrRfIWDTioMVF26VvWvXgdqPC2K86IMRuB/t05K8pO3zQzO2pPV
+ZU3ZNAOF7Xm+XhANrdQ6vgAEFvwve6JjzXNPj7omxlF5mWFSQAb+Y2H6Ng1m
+riHwTUSskBXdzHNotfQqNK2DbyVAmAyz8YMtw5mkpks19Ng0rUxri2iMVjLX
+4d4noVMShQW+TxKCB/ipqMWbluMWFm3QiTadLmVJpCTMLyKqm1fEQwzF4pOR
+AwqypPIWDHzLE7D8qTj9IEL0qvgCDfrjVD2QXgyHHYo3cNQ9urlyCT7NavAF
+Z5IiDyhBqHizIzjwhlMxiFL2AlG1rIvz6CJOZbF50NtUW17Tl/e8WzZ6kmcX
+sExcuywjJYPEx5ik09jaGSBDZH08uvMHfanYqFtvukVvy4ven4Vgw2gBgtWI
+0EaxKnXvSjATlyyn93DwAHZgw4lCswK2oiK7xpAxqQp1K1DuliZV6/F31exm
+RVixZwe87x3x5vzJrN1vIS6udsjs31H5Ds3zMABqE0LD9rjlEMvjcc0/MUyX
+7wGuX+rMNpee2abobIE92f9SZ1Y9dJx/ZltoI/e7z77YRdtPl54bdO2k4gY8
+zW1K8vtSJmiiojAN9coNxt1bBCO1EiBoMdmKT4KpC/l0lmDWuJwcnZKUj7Gm
+chLRlfAmccYoFDKBKhiidWGS9yTdK8jOID9eWVbDgt0DCgWD1DwLNZBQA3V+
+efLTby1soB4Q4+4PhVZn+HLsIiFv4eLl3GE0su/glvyRrAOlUOLjbnwd8UXz
+SqJ7zvXK+ZW3x8eP8XyDFpLC5PiQAHrtnsqeeiZa53at06yztlKg6+Lx6PG6
+WwLdyodrLlFfyYOuV6u30/P4xKYCpwN/d+ED/PsMC4/GbF3zbnscpuDB5PWp
+PeZ9xs+EFfwcwZUsDa6vjfIFehpWQ3hcQfmxp/B79UJA/WDBdt//ca5PKcYd
+fCbGNWbsLM61nLNGprVcH+Derad9kY7nYdt0vFZnWtldMucgS69Q/OBLd4pH
+LZyIOTUEP5Pue5i0zpwaSJ1Jq9cr25n0k1/ye8C7p4pNZS7/P7SAxRsFfwdS
+ldCs82jltsU6vq2jZKy+c2PMktpFnRk8/TnS/D+xKJb12Rweny7M5EctTG5y
+/G1u3rNz/xvZ1mrznTgCdj39ZS5uxWZN3OK/sfCVE5x3yx1+4GIxLfxwqJ7V
+ojiwexSiwNrYqRwdBeCwFPTkEj5QJkeTbwepl3wozWiUJUl27WZ9gUSEaSWc
+k2rVhS/k4ch2d7N2PNOy1i7u+gTHS7CG99UXIx1somGWP7FhCQsWzZtS3UIs
+eHiFwThcH9UfHxGD6YUJPoF5axNAzYFnVH2gv5kC6mRro7vN57/I/r/CT9Mr
+QhU/9HA8CeMcfZwgvMYA2Vk2yZLs4tbk3Prei8IRFn0vSoQjzDUb5vBvQG8p
+0tuEgTxiDGKDSimRCPhJR4CCD4nh81HFJT2ghYwLQ1ZWuPLu/l12hbPC8k09
+Xvw1E18c27lr6t8z86CVfJtNbhE6KKDHqSqCTnOHPSaHMmN6z24CEoLDp7CA
+1DmW5wWqK+XZYjsO88oYpc7Q0igT7JYN9ZWdLF1rP8Tq8JJ+1tvEF0Z5SJQL
+hvEFhlGem9gA/jNN8cNVsL1WZyjqivwH0QCd1gVzIJlx/Y1tsuT8BoL9wPOi
+SO94kX6zDNJvHKT7eIXQRpo3jKPP0tyHbrDxwkFm+PLHXrefjtsw6kimXJPn
+YLjrjrO4iMR75H+hDRIyZgEcuHKqM+yiLJnKg/p0SIbHbP3z/OlTygRFD2ej
+Dyqfgnv44ltk1WihGJbubLk0Q/Uc59h6VtOxD2ivwW6JQKPk5vxQbfRRfA57
+zSTQ85OhMo3ebz6kuXof2TUmU+vuohKdaf7C+SAaT/Sl0Y+fbh3W6d1D8SHN
+rlPyHWDXEirSrsVvVf9pSs26/k2Cp6rO+RJPCySO1CCGAvghaudt66yjIWKI
+t0qo4akyok6pGjbpotc45uoLUf1R3T/WBtyad8AtsT8ts9GIbyliSjOP1Qx6
+swE0w9sUB7pkyfwwt1thbsPKp8FfMatuGeA789JixzsOmdxgpyEr1U/w2gZ+
+Ou/AT8VLMA+CQ9jhGKgGd6thVi0bhsUJhqqHFo/6N7CWj4sK+Y3ZG3fPgiO3
+FuXQXIOzSED820qjNLdkqQr5xeTLTDSlwEBDib8HtU9iQZhoh0eGuB3A1hAt
+soSPEy7COPWrLzNjOvEWq71udxzq/CNX1Q5fztK0NBCe6b+chc7ci2C6LLUK
+LlaS5HwPQ9HaEFn1qhCbD1UQyhOqQDQv2anxpyA7IxiWJQgG6fXNWgO7dtKc
+a4Bdll6DBhSXW5CFVoFU5nzG23x0NoVqZpOZBl+QztTnjoSu4rgcnW0oc1J7
+eD6ej9atNrKZCGE/njHiggSGHnckL2M1g6guMRUUCWAmORXhtn3kbNOg20ur
+phGaBfOo0O2FVej2UgSfjWezDlVAmldkfiVaDBddhL7fWcXsgPn4vp5Z8O70
+YK0ezrmdkLXIU9kVm93n4lXQ31q3XRR0SX95cvTTb3PEKp8/7ekrGc/xol2I
+lQ8Gg6ig8BA4cfwofC44LB8mOsm586Y7gtZrIhDv/HNw4jxNpJ5/MxfDO25j
+P5GbtrW2vn28BB0bOUkmX7xRRTQemewLXf0Gz0cTjOJjjbK8DMBab0uiwTlg
+VMPqgkjynxGXkKDjEyb5LcdATOUHeXBJ7a1kR/52cJnFIPJrL7I3paLw6QOV
+R6CqH/8sD0doTLwcUX8Zm65QUOvKK9ECU6mr2Sj8Q7RelSmSAWZUIqtgaYaO
+rr2qcV63e/LPf6y6T33/x+raqjtCow9F0/y3MImtCgfmEXpceJyrdc/DYkGL
+QVURnl2entO6ceSFToErSDce8VZQ9WSQ0dDLncVXkGg9orLx0AT76LDJwMcg
+gwdmkMF9M8j+QgwyeCgGUSxRQb6eqvL3xCFWcR9rueikS1PUepe+ImcbQiCf
+NjPF0YZerRBN2hQCg6VWWAUHD3hUaGlOoSylvq8UR+MrNYrBd0n+cV2ndRGV
+g+78op72nExic19SXWxzf9mi36rRVx24/VnfGrhmOfDWcIpK/aqmjlGGgzr5
+4BScKrm2+VOxsc3/Aq/w+Qjl6iBDeSb8RYsHrwIhhhh8Orb7PAplFts1lj2o
+gbsT26Vj4Lq4GwHXbfSscxT5M5LyaN2cK9ONfpw4qzR1Jq1a/j2xX4t28iil
+aPJF6CPDzQ+XJ2nGoFJimzubMJOjd29Pxcnpu9fB2Sv7fiAWlptO6EZCNrIy
+pDSMxqKATjlA0UHptea/guzRu5dZq9pV77SZxnNpX5csHi28hO+1nLclx+Mv
+CzoQJAFHL7mpffz7fIKAuyMO1F2JAXerEi6yZUUiNXp++DPTgWrFjfC7gyOF
+P/M6UxXB+bE2ezpH900+SOKixBiLuiZyJ2JgHW99Q2TjbrQqiFiYMnNnahGz
+0hNNZqKe/pJ5arRtFPaE9oJZjnUIjvRqe1tZ/TSt9V2d2a/+4Cf2B0F4fxGa
+d5ZGomgdlTptU0yV6B7MIaH0dUs9KUIqulTBK40k68DmXrK228d+4/g/VitF
+4qp2cVMmw54pOGyMYmRixzCuALcYV3OJX5da8+M0RptKcqu2VwfAn3a7e/7X
+7h1pAviEoDUUjtZD+vZ2aKLbEcxlPB0LriJ+DqZPBIQz+fBFF6wnHgDox96e
+syXfWGcH3h2hd8XTnefPdsXrPBxHdGsUU1reg/yMc6mIcHeQkRfgDfmhM8w+
+sFqeJa6B12zYOX1nG3kOSWkxUUNaqzAKB2WW19aSbzC4yyiP7fvOsX3TmvXn
+WaM9lV6HmdoqNddb0WAd34ghHVWpE07PeKilNl0LNps5oxeTh2WGEX5o36Ig
+Kta7x/jWVTKYsvxwr1Q0dKEwg/iupl399P62YVPNyXFL+A0ub7fymI+vnO4z
+eSy8eUAeo4u/j7vi++8EiFsvfR+7UOnl42AcFUV4UVXeR+FNdSlpgHOUsJTc
+iXcI6DiM7m+DNVFZ4zr7dRt3x8Pug/pUFtoH9e4z90G9S+M+8PJE0z6ooHY4
+Uueo0XDdN8+GJXOAqOXzLRgNgQeZ9WEcGC5t2iD+fW/kj157DAN7ix7Ynp4c
+z39ia1prNN1XaR4uVPD1SLZ9ZFrNumMLbPkPERr/erZqxt2XITArdIlXJqao
+dEAkwS9/F8v9JXmyRnLeObiKMvLTi0M50tdo6SeJljJ1Hjxa+jUc+jUc+o8W
+Dv2CpL4nvtgm+g8tQR+e48X0t+EtXsOrpSxqrvEI/rZQHD9FbSW7zBsl1Ekv
+avSPFhKTPM7cgKB275+9aIf7TnUFR8c8UW3IS4sQJ1SgSwJwnLrO4en+way6
+PbjwWxs98LPQw2p2ryy2sIYgFyp4l2dlNsiSGgN0yHdbq9DlS+A+x1tbOpHK
+Y208TLbU1zypr3lSX4oz+DVP6mue1D+imfIZnoLT6qg5F3lWCNE6opw3kKjx
+q/b1GVGVV+qqdrf8eoYlczeDu+4wOmXuCjnoufs00yZXzlBx5HV+r55OUOBj
+09/UYGjyyNRb3OHwKsrLuJC7yYAYf9dXG3AchWmh3pPKnboFHk8vXa8U5DFf
+UbCcHgn3dAv6SDb1hQFhNflTHymsB+/OZYN9ynfIuJP69w75fhrGfeb7WRvS
+PFFDa9KyH1+b/VRZSAVXL0NTsqd7A8HageP2HThedAfO+abel8U2cwrPu6do
+aogV635mhM9P/ZmRvYaoXpVLXFas+6f+8BhwVTktrCcrLc1bjZjVxD3+fIhu
+VZ5J6poPbaBnoV81q9phzWtS4XxAPJgpKWIXlZVlOlUsFl9QrcE2ruVsWmlR
+zjwLd6LtYakSuDGJQILZ4OQuSuTcjGypEJAGmyr9VJ1qQ8SQoLavTPP6z8gp
+nZN/ZxDGWlZXrLZNtgrCP/mWeGSrxPtCVdUiATWjrAL9QOCnyA/8mmn3UJl2
+CzGl3Xue1DovY9pAvqbWfU2t+5pa9zW17mtq3dfUuntOrfNeilzyyKbu2llO
+Nsebm6LaMw8PawUAfCeIjjEh2+5MNlx7otkXakldcSLJzekFDrfrFXEOOHao
+ppRjeDQXcLyD7y+Wcf/d81VTo2HhhdKFHWYuE7WsLdLXpfAuhbM7FzjupmKm
+YcmVm9XBBVPQ0lJqLlrBWBOQmTggsR4fP3a1zGtUozfhGGTSugyEhXwqJCsB
+NC6SBcT2OmAQtTTr8saR8+VsHNtZY5BNkyFqFnQJiAEsIIcpvyuOgYh183IZ
+gVURnOJSQYhotrJUsQUF/LQCRoWl4XfbjcIuorJUT7Y7qwoqZ8MlbGXV8I+k
+yOQrWWExNz3jVMeA52D1u14Nv5sH3qCmqPDMIALmml3zjsime8YFvX2fDjka
+ex6ZwAYvi1wM1d1WalifwR76caHe+VetMa6kV8hIg+gGz6zikovtFZdYPw5L
+ZEwvMJgTDd33qVUtPhHBf6JcG2QBP4iaYzEDEgOwZOoRPneEMoLdF5byMAUB
+WpZKlq+7EFVfpqSiVDtgA47qdWdU22JYoYR535xAF1a4wkcDVYxbgajMlPHB
+YXZh13DFAylnnG42bwxU3g4eLGkeADGbXVdT+W02QlM2HYZgvd4CuOmscoCH
+bK9HhCIuGeFTZxTasrqOim2l4bfr1eISsJWpl3xF0V6IatKKqhFSDWg7pWBe
+VL6E5RlnKG1kG3fsti6wdryiDXFxDyR/+HZGQ2o6isEsBUnnnvu3x3ZBqtJu
+dbein75umJKm2U6Jpcg3i4ACKx88edJOGz+13f3rpXNjk/unsMOnLm1hekQE
+B5uFaGTPqSZdFkha2Xci/iiKuBqLqnAEGtwlf83XFTym43zXd72aqb97NUJe
+YYDqBJtZxSGoZhJsgzkJsEx1PpHK1W5DcnCWtnUk6oNpXWeUqtr11tX5n6x1
+kY2kLjMKVjFmdXOAm1tUzLxfcEj+vFynt1e1QqP0CvIL6uwe2hkVZnkIN2Xi
+dmf5cHOdxJlhvSNK9VpYg7ndamKPjtnww8DNom8Qhs7JW98f9eapJPpQVGHc
+jqeKpjIqnrR7WSHq98opm7SkMYq6sb3dkmHnYHh4UHfqfAZtQ2yTpHOT6S35
+kjcXE/eJw+OVv1brMvFPYrUq8xZKRdzjwVXlVV1ch3lX25dyL1e7q71du+Zh
+33dRDFUtw1bTPip3hIHWv4WNGOIC6gt88D+XX594+NOzwPhDoVEHlIe6RF93
+iH+XQ3w3mObg+5Wdtb8197RNydqy4E/rLR799jNVHkOFQJmTpH4r9QQLX29X
+0VrKYPVFbSVr9Gm/X6ROvCVu9NY28skceM2p/n3avoamj808NuA/Pqd5Jn2v
+/ObxARZluQfiuOUwuwvbebMyyLr0aNBCGY2u9elpxE1mGpAVO9NbuLS5GlKt
+MCkbS2ixXExDGLKMIrY7SeDLCzwmuHdY6jMl8FvsaqUUjKMapXQmQgEgcy72
+Mjg4HfwS3Ja/da7WZJ1a6UIUjiGKhhBaFNg/NT6AXGyeRB4NsPDpUGd9cDPO
+wvDRQ9sFPs/ea7803IjxUa816NbirHs9AC6iBTZ/btfflNa4zcE24MI+0uOy
+mhWqNNXylISpfr0MbbgpF6Cza8NiKIZx0ok81may9YWp/FqIzt7hWsOWZfL4
+IvwzatKqyfpbLTPn2YVrGz3imZwziaBDeRtwQmwLz+xJ59/KTFLxewlDJtVq
+91EmpFtn5apSou5Bybui04264F7tH6yLd0f4n4O3a90Ka3nx9FfBaK4qhT/e
+ylLWEuv+dtkM69taVaSGpVwoTIn68OT0+L0mTFgU2SAOneCrykVTWQSmv6ma
+KqRPCLKLZHpbMTUUrQbGYqVgGrjJG8zycpMRxU5AQc0RBLFWlY4G1eT1V/G1
+Ixt0BCN1YeHkjlqKwAyogOg6vIaoSTyO5RttrvvfAfeTFo7yFYh7zfrfEEfT
+5wdv18WfVdYFQeMLjmtWWP4wlRHaUSXaVRXQ5WVVlSkQgDIh515eScAUQE8I
+aBKcx0DNcqG7wKa3J6Q8vxB7CTTDoZ8kVOs045rHLEAUyXlOIeyZgmqP+s7A
+LJatGhvyzsvTbr+74RPc/slzItSLyv5+A42fAMQZu7zlnkGO1djUkB19ZxKv
+sPXWGmduoFRIYE8Es3mwCFlAvB4MgYdvRWVa9SqNcmaTYqk5qWSjA1n8rIzp
+/heML3h8mlEsj1M4lgF/GQhJmHrvhuNkBpd5hid5A5iWrv/ZMB+bQxuEeVVY
+T4onpvjwUrPGUk+TkjIC4NfpWOZkabyFhXdn/8BOCs1SRyJXSYAiaTAMlODX
+k8M4GHxOEngZzE8mUmY0qZRQZQCY+ZjuzRMjhJzTb5K6SrSizAS5R5LLsQtQ
+0Kc6vGyn8RXmoHA0TXkPq67fiVHHvb7PT2EMq4ZAI9c3MUFzRNGvuJvzB3G3
+72t6Hbj08j2zSiabY9A0bItJhnkB0oYkN/2BtsdD7A0beWGffiBAi0igNNea
+Nok/90GL/Z0dWb67j+W79y9DLDcX5cCK8aBgL97gYK0wSigLBYxHRmmBi16w
+yh1pTDjObjONbMsyrjZJC65vp0/GDVsdv/hMe71tDnJ55tn00NDZ9ctudxyw
+ut81de7Tyvdw//0KhXc2YY+QsAcVwt6fdBhGEwxVpKVTXrdWqFZVEbxH32WG
+GGgUCTYNEXcytBH3Dvp/86jNyTBp2EzwxSfdTKJhN3lnNtdmOnh7VxWKIHA/
+SRD1PaWIVNtTnrrG97cxFtEamnw2BEPJpXePvhCOShUHxh204BtJpued3KIj
+DYaHpANAdRPNPrqNU+3CWtRAhpDxK69tHacBxRUqEcrUxKHqlYcXwl85wHjn
+v+CwHGLb6/ZFOrarrZ4Do1BuvnWLIdZ6dshAwlK8R8GGVUiNx0exeNOrk98E
+8KVOUafmaxilSKgj3T44OjwO2DEPsab2II/wWXXbHaFT7Yy8woCuqADfZEUZ
+vH61L9IoGhYyHQI8fnAso6GPvj5MvLLXrq28oCOpblczcNr6YWFRh0NtGJPT
+4TyMpBgoKEcUI/jEaH7jTsAvU2utHlLAaq6goaxFMwvsI/0MoSqLrd+DjVIl
+Rk24+qnVIGlt5vBvyPu1S94r6lI94uVtEOCpP9eul7UHH2aGTZ2kCBQuf5YD
+gGjAnVlegky5zBLvdjRy/TycDgNPsMdTo9pTpbrRU3o5XEpIvtTYtIl3izdU
+rNIS73bmu4EnL1cgeigIrDbF7fg8SyjkhrFeo674I6slPhdDjXHJcwyjZZRk
+ZzWZTBPmCPV11wZwWOpLHtPxOV+iG6ITBjtHgrZV1iXa5qDCOcBFifllsQas
+jLHNzEkYFjKZaBwXZDSPo2Hs3AmzEI7xMgOtYJgkzqsAcu7A8HJIZCeh4pDe
+oFSeJUmQjUbLsM+WtQ2NH9L3bLOZO8DiITKGFVZyT3TOozJkmSkNRHorp4dk
+7NsxKH1oVIjL7Foa1kAISY/iMsQDj5tB5OZxQTPcSMQxXXE4+q4ny39HN4AA
+EHkcygsxTZ2gT5+ZXi42jVFUFnm7979UQFR3xQ3P77/GdFIu7B+/MFLPd/jv
+rJlnFy4uf1tOGTuXPNRdxcK5Ba3usgxlmNQOXKh775QDJd/lsJ9XQhJcZ7BC
+4+wiSqNsWoiTs1P7tkqH31e6DK+kKAnHJoY8qMQ/AEseii+f2Ayrx8TTz8El
+nyTGtAK3dDY+ScIB8EIa3ZR0FoMLkWHypbvQdIKvDJHhNFLva4EyGpMhmIQT
+e9pjqXEdvYYLnNNgFwnsIHynydbj1rnIJT7Q49BG8uOULuVQMg0/Q16J+ETp
+BT3rU33jR60aSqswtZ4msJaoTjd9tQlXKxz+V4gUJnS80XqjlUbRYFE3Q3VZ
+Qnis7ulHt0Bzeu+qAXCUgEtrymdeUecPNs7GF7A06DThqw2Az42vIxkUTjJq
+8fIVOB5omPN+RcPFVrggRnBV8PWyLAdbt+Q78t77hCDX0HUKMnDaWty4BZ0K
+8rbUq4ioQKR7qb00zeKsfksL/0K9/gfCfCqDWfw4o7N9qrf6WvaRcnH4el4k
+gs1ub/iS/T59S9CSPBInzB7T0mY0zTHLRz4XNycCa8ZtBQFY8TjFaWEZXbZj
+EalVYTrGljtGR9fWVX+HoAYG+MfgHv8o+s83u0/F2U+/qXdS57jlenL4Otjq
+9f76Puj1u71dcYi+Cp5Ts3m3d5FH9KegRt4MlmkJZsRD8BWdVJu8kPCDs1js
+gEkbD3XHRV6LnmELwA+VgsOAZrFtzmtcIN3UCkFItOSSE4n01QPg3NLJPCYn
+03nXQUF09gfOsREJi86LcIoBAoO0cspDM0pZiTJLf1XbNt5YB/HAsgzksos3
+lMo8YiFhe70s0UI2ymotlXz6C4maXxvCtsVDk9WhafEhun7gs3sk7F+CXwUO
+hW+YDJLpkKkUykLMMtHHjbk3RbX9Z0RllkQ5GVGcLvNwUuyjk8Hq5hzRHsRG
++vs5LgO2ZSrtc9ablXBD0SK8H958J81347V2xcQwBOeWfxl5OvZVGbII5sjb
+sVWzm8HTmg/tmPnvrctmKnCHqeEqWKhz0jTZnddnnRxJO49VZpdnqX8q95Vi
+5PLkHDznu8jHci8opxjL5SflZqbxSlnJfaRR2xn9J0husH7ACKXfwpu1Sj4l
++ctsGJkHCRs95tLymFuc40mIBU4pqd+6pmbcLLe6S2lXhCkb5tKY//TpkJf6
+/47I21rVyrmH5qp8xTzhiiXwt5Gz5gBbwJoAI42vWxT45Aq+G72x/YaNDXzQ
+v2+bpR9FneOb+NcvjPUF4uUkL6X0N0hW7m7uw3lweuFaOG6gHmPOdz3BYSmq
+uB6swMlUmS0qSy5WpUwazK4KUuHNfSEluXlOpCwlVT/TuH9SUeW4RShVx+ne
+KbUMTmVWhveJkbXX1fl5fmM9J3dduS6vXvv1eiYcrg8rRcPxHTWqY6OccddY
+aVZyei/7t7ot7EhEtWo0vh2K216LM75lnlqpshqgTram+CUqfDYh5S1TfVNE
+X7ayhIMHPdODMX3R3jyPwiGSzmpczYefY5DZ5NDTeECSPHSi+D3mhPtY2nrn
+qKw9xVQ3IS06GBifwWhsEPdN4qKWvNWSNMB3OXVkTYfxCJjvVogBYN8PmfdW
+iG9REA+7/9HPp2fi+ORMn7hLgNX1MhDMOrXJIRR81oo67x0Y2wGLpWUj4TG9
+Z27tOSUWdgqIbx56o1a13twMs2jqSYWL3LSM++ei2dr0oWdKQ80xT56d7X4u
+Pc86MxtGWpiXsSDGlBjDat7Cvu8Mp3LhoNso74kOFdmGv82jcWvibMomRYUX
+TWWfICxQRBMTz682vP1bFYhYtR6s20uSTF7sPIrKy8zNC6m9oaqdqtnOtXOX
+zH6HMdFpRLBp4bfzbJoOeaer3sbPkg45X/8JKci75pGW7minP538/PbAkZV0
+dIk4YMjOef9fCxI+a5J9z03Rq2mhXjHkBxDHKlkgTsHhC41sZSOAttRiXvXC
+dx2ZhGYQIiHqeFb+pnWFkF4JQauwKMbqFWt8xLoyZef56sbHq2kezABmaO9D
+yJpn7O6+ur8fl6ZnFY/l6OkpTopH6oF5InMhf91IFNFTZ/MGkPXW1Lm+9aZa
+W4f4lWqmRZoH0Q0AAb8qv6g5oM5hljrj5SNen0zh9217Myi8B5MaDmN1B5PH
+Zfzhc96cpTxUJae4SnVbjJNeGFxGgw9qV0ZFGY/pHEzrHW+dUTxA6ryB/67N
+t2z8mM6s18C8q+a8/FVZFXJEyksFwIzirpSeVXBxryeMCq5FLCSMejzJwdEr
+LgxiUZZ8RuQsaTDEg9AhH0ITR/AdpCQe+SWemQLKlaJ8qFkw9AUnEwI7XVAk
+YpKBQscAg1X9T9chCpNMshcmMVn96wsH/4H//Tf8PFr5fVd8A3MJbmFnU7KI
+AMMiib5bVUx6Rk8K/Lp3/Ibz/qLVRytFNs0HEaWWwO79ANbOd6soWVeF9U0K
+aHy3GkflKEjIDOLSYj9u9Da2gt5m0Nvq4qCrtN2+EacR2IwYtt2XGUx8dCht
+IySjhYN52J7P2EDZD7PBlEwlZVqEogCxMA45oTss2ZjgzCyq7ge2kX6jD29P
+FCg7r+JQpPwuL6oNUFIEdCKLEReU30WQwkIcvzrbPzl+LX7//Z/ev97f2djq
+f/yIZt77V6f2F896W72PH7s8C8kDqiuRhuDJlM8C6aDfzAAfnFqs61wOrcvA
+jA9idcgnu/EUdVcAecrgTi8jYKDO6elPawbbjSpSGm8Hq5/Ozt6dzomAO/jZ
+21MCIsmwtbUDI1orKh9AxiUn90weVdJa4IdlniV00QtQP97bP1K4P9tEShMY
+WJireKiOFrhOYoZJCiB+B6VcV75aGIJUxeIPuSa+zMnV0wbtyS8UhfhGoOU0
+FtNz9QookNEUX2wCpNjFPDbAFyHx9QQglqS66m1aX0mqe1ZNZTkzjew1VA+D
+EM+PyWjXuctxepWRYsTRc/A48Hc1rsxTCr3DRZwhHHK2JJhd8DHR4RaM3LG9
+itn5f0WDstA70d6n/C4Qv3MCW1A+UILIKPUqY6rHmYSjwUgI8koB+nC4ta5z
+PH9Ac4GJWDDPm0dU9KUuYE0+KA1VsVJ8fwdzLrUCdl624fGKrgroAkllkCHT
+WZWU7asB24Nex5T3QpCmZcwv5ePIzIEktlG2vH+3bzHFusqsAIYFyynEfURC
+i+AQTMpNJdql2VA9UymniMRAPqSq0Egh/gOH1X15+SjYR+wDQ0SjERJa5tYp
+aWexajxigsWpzKfD2B0z1DjE5IBsWiS3QCnwFqVxVkSaSBIIPj2N76HyKFo8
+6+u/zlP8THspnYm+Ku/MZShedPB7szzC9zuVjOI+IUUcpNxWe5/FgaRulZDq
+sQ8rbbbA995L0M/0BNI0QcsRVw/T+rOxoVeUXsV5Ru51YW+HQimyCj2A2ZIE
+73NNS0UUmli/23c3tyUynz7fBs1BZwu35g0ITUtgnmsA2mUNerh3vOfRnq+l
+fWFe+fr5/aHCYPXw1dlr8Zejt+J9dBGD0LxdhaF/gKE3d549+/hxnaFehpgT
+POSXXYhd9W2pOEqGTOORykWzUNxFDNjSgEnBwLuwPfJ0F82CXQrrFbs342Q3
+LXbRGNitmQssVxk3XEB6znhQ7jKtD1+dvqEWMAP46PjJ3guJH3hlBWJLc0WJ
+Q5NEm4RqpnUVVo9WzlyS4iM34IVQFzVlW6JJ32SVPqPbhsBBxwh3FYZlGjqr
+55IAWwKm/nkeK/SWotI7WIL4BromLu3kUu1yPdy/wI+ZPH7yClwx4JHjrIQ2
+7xK82IcOC2asU2vzYhK2lldSOLakfDWLgsSMQRCI83DwAX9HC1PeUQnO40Ka
+e/vy1grtcoT7vPd8k5bD8gNJOY2m5ZSe2ZWVFNSZxDAPRzwajMBYRcPvVsko
+V0bl3gADhLDr+LVUa5eGU9CT8nkCnBpuadwb/AILXkjGj+Mc66cO8Nk7DD18
+IGnyPoOhWPL8EielLAGk9zMQoiRxfBVH1wT/DKb4LsIqKNiQSmyASmSEUBBO
+c+UZjsnWwT6WOQu2fjbRpBUyuKUbXMPeBGsF2ETHpj4Axwz5GOH/AwsA1JmH
+iAEA
 
 -->
 

--- a/ietf-layer0-types.folded.tree
+++ b/ietf-layer0-types.folded.tree
@@ -197,22 +197,26 @@ module: ietf-layer0-types
     +--ro line-coding-bitrate?                identityref
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               decimal-2
-    +--ro max-chromatic-dispersion?           decimal64
-    +--ro cd-penalty* []
+    +--ro max-chromatic-dispersion?           decimal-2
+    +--ro cd-penalty* [cd-index]
+    |  +--ro cd-index?        decimal-2
     |  +--ro cd-value         union
     |  +--ro penalty-value    union
-    +--ro max-polarization-mode-dispersion?   decimal64
-    +--ro pmd-penalty* []
+    +--ro max-polarization-mode-dispersion?   decimal-2
+    +--ro pmd-penalty* [pmd-index]
+    |  +--ro pmd-index?       decimal-2
     |  +--ro pmd-value        union
     |  +--ro penalty-value    union
     +--ro max-polarization-dependant-loss     power-loss-or-null
-    +--ro pdl-penalty* []
+    +--ro pdl-penalty* [pdl-index]
+    |  +--ro pdl-index?       decimal-2
     |  +--ro pdl-value        power-loss-or-null
     |  +--ro penalty-value    union
     +--ro available-modulation-type?          identityref
     +--ro min-OSNR?                           snr
     +--ro rx-ref-channel-power?               power-dbm
-    +--ro rx-channel-power-penalty* []
+    +--ro rx-channel-power-penalty* [rx-channel-power-index]
+    |  +--ro rx-channel-power-index?   decimal-2
     |  +--ro rx-channel-power-value    power-dbm-or-null
     |  +--ro penalty-value             union
     +--ro min-Q-factor?                       decimal-2
@@ -225,7 +229,7 @@ module: ietf-layer0-types
     +--ro in-band-osnr?                       snr
     +--ro out-of-band-osnr?                   snr
     +--ro tx-polarization-power-difference?   power-ratio
-    +--ro polarization-skew?                  decimal64
+    +--ro polarization-skew?                  decimal-2
   grouping common-standard-organizational-mode:
     +--ro line-coding-bitrate*   identityref
   grouping transmitter-tuning-range:

--- a/ietf-layer0-types.folded.tree
+++ b/ietf-layer0-types.folded.tree
@@ -198,26 +198,22 @@ module: ietf-layer0-types
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               decimal-2
     +--ro max-chromatic-dispersion?           decimal-2
-    +--ro cd-penalty* [cd-index]
-    |  +--ro cd-index?        decimal-2
-    |  +--ro cd-value         union
+    +--ro cd-penalty* [cd-value]
+    |  +--ro cd-value         decimal-2
     |  +--ro penalty-value    union
     +--ro max-polarization-mode-dispersion?   decimal-2
-    +--ro pmd-penalty* [pmd-index]
-    |  +--ro pmd-index?       decimal-2
-    |  +--ro pmd-value        union
+    +--ro pmd-penalty* [pmd-value]
+    |  +--ro pmd-value        decimal-2
     |  +--ro penalty-value    union
     +--ro max-polarization-dependant-loss     power-loss-or-null
-    +--ro pdl-penalty* [pdl-index]
-    |  +--ro pdl-index?       decimal-2
-    |  +--ro pdl-value        power-loss-or-null
+    +--ro pdl-penalty* [pdl-value]
+    |  +--ro pdl-value        power-loss
     |  +--ro penalty-value    union
     +--ro available-modulation-type?          identityref
     +--ro min-OSNR?                           snr
     +--ro rx-ref-channel-power?               power-dbm
-    +--ro rx-channel-power-penalty* [rx-channel-power-index]
-    |  +--ro rx-channel-power-index?   decimal-2
-    |  +--ro rx-channel-power-value    power-dbm-or-null
+    +--ro rx-channel-power-penalty* [rx-channel-power-value]
+    |  +--ro rx-channel-power-value    power-dbm
     |  +--ro penalty-value             union
     +--ro min-Q-factor?                       decimal-2
     +--ro available-baud-rate?                decimal64

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -197,22 +197,26 @@ module: ietf-layer0-types
     +--ro line-coding-bitrate?                identityref
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               decimal-2
-    +--ro max-chromatic-dispersion?           decimal64
-    +--ro cd-penalty* []
+    +--ro max-chromatic-dispersion?           decimal-2
+    +--ro cd-penalty* [cd-index]
+    |  +--ro cd-index?        decimal-2
     |  +--ro cd-value         union
     |  +--ro penalty-value    union
-    +--ro max-polarization-mode-dispersion?   decimal64
-    +--ro pmd-penalty* []
+    +--ro max-polarization-mode-dispersion?   decimal-2
+    +--ro pmd-penalty* [pmd-index]
+    |  +--ro pmd-index?       decimal-2
     |  +--ro pmd-value        union
     |  +--ro penalty-value    union
     +--ro max-polarization-dependant-loss     power-loss-or-null
-    +--ro pdl-penalty* []
+    +--ro pdl-penalty* [pdl-index]
+    |  +--ro pdl-index?       decimal-2
     |  +--ro pdl-value        power-loss-or-null
     |  +--ro penalty-value    union
     +--ro available-modulation-type?          identityref
     +--ro min-OSNR?                           snr
     +--ro rx-ref-channel-power?               power-dbm
-    +--ro rx-channel-power-penalty* []
+    +--ro rx-channel-power-penalty* [rx-channel-power-index]
+    |  +--ro rx-channel-power-index?   decimal-2
     |  +--ro rx-channel-power-value    power-dbm-or-null
     |  +--ro penalty-value             union
     +--ro min-Q-factor?                       decimal-2
@@ -225,7 +229,7 @@ module: ietf-layer0-types
     +--ro in-band-osnr?                       snr
     +--ro out-of-band-osnr?                   snr
     +--ro tx-polarization-power-difference?   power-ratio
-    +--ro polarization-skew?                  decimal64
+    +--ro polarization-skew?                  decimal-2
   grouping common-standard-organizational-mode:
     +--ro line-coding-bitrate*   identityref
   grouping transmitter-tuning-range:

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -198,26 +198,22 @@ module: ietf-layer0-types
     +--ro bitrate?                            uint16
     +--ro max-diff-group-delay?               decimal-2
     +--ro max-chromatic-dispersion?           decimal-2
-    +--ro cd-penalty* [cd-index]
-    |  +--ro cd-index?        decimal-2
-    |  +--ro cd-value         union
+    +--ro cd-penalty* [cd-value]
+    |  +--ro cd-value         decimal-2
     |  +--ro penalty-value    union
     +--ro max-polarization-mode-dispersion?   decimal-2
-    +--ro pmd-penalty* [pmd-index]
-    |  +--ro pmd-index?       decimal-2
-    |  +--ro pmd-value        union
+    +--ro pmd-penalty* [pmd-value]
+    |  +--ro pmd-value        decimal-2
     |  +--ro penalty-value    union
     +--ro max-polarization-dependant-loss     power-loss-or-null
-    +--ro pdl-penalty* [pdl-index]
-    |  +--ro pdl-index?       decimal-2
-    |  +--ro pdl-value        power-loss-or-null
+    +--ro pdl-penalty* [pdl-value]
+    |  +--ro pdl-value        power-loss
     |  +--ro penalty-value    union
     +--ro available-modulation-type?          identityref
     +--ro min-OSNR?                           snr
     +--ro rx-ref-channel-power?               power-dbm
-    +--ro rx-channel-power-penalty* [rx-channel-power-index]
-    |  +--ro rx-channel-power-index?   decimal-2
-    |  +--ro rx-channel-power-value    power-dbm-or-null
+    +--ro rx-channel-power-penalty* [rx-channel-power-value]
+    |  +--ro rx-channel-power-value    power-dbm
     |  +--ro penalty-value             union
     +--ro min-Q-factor?                       decimal-2
     +--ro available-baud-rate?                decimal64

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -739,9 +739,7 @@ module ietf-layer0-types {
   }    
 
   typedef snr {
-    type decimal64 {
-      fraction-digits 2;
-    }
+    type decimal-2;
     units "dB@0.1nm";
     description
       "(Optical) Signal to Noise Ratio measured over 0.1 nm
@@ -1685,8 +1683,7 @@ module ietf-layer0-types {
 
     leaf penalty-value {
       type union {
-        type decimal64 {
-          fraction-digits 2;
+        type decimal-2 {
           range "0..max";
         }
         type empty;
@@ -1739,8 +1736,7 @@ module ietf-layer0-types {
         lane";
     }
     leaf max-chromatic-dispersion {
-      type decimal64 {
-        fraction-digits 2;
+      type decimal-2 {
         range "0..max";
       }
       units "ps/nm";
@@ -1750,6 +1746,7 @@ module ietf-layer0-types {
         on the receiver";
     }
     list cd-penalty {
+      key cd-index;
       config false;
       description
         "Optional penalty associated with a given accumulated
@@ -1757,10 +1754,19 @@ module ietf-layer0-types {
 
         This list of pair cd and penalty values can be used to
         sample the function penalty = f(CD).";
+      leaf cd-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the cd-penalty list.
+              
+          It may be equal to the cd-value attribute, when the
+          cd-value attribute is present.";
+      }
       leaf cd-value {
         type union {
-          type decimal64 {
-            fraction-digits 2;
+          type decimal-2 {
             range "0..max";
           }
           type empty;
@@ -1775,8 +1781,7 @@ module ietf-layer0-types {
       uses penalty-value;
     }
     leaf max-polarization-mode-dispersion {
-      type decimal64 {
-        fraction-digits 2;
+      type decimal-2 {
         range "0..max";
       }
       units "ps";
@@ -1790,6 +1795,7 @@ module ietf-layer0-types {
         compensate for polarization mode dispersion";
     }
     list pmd-penalty {
+      key pmd-index;
       config false;
       description
         "Optional penalty associated with a given accumulated
@@ -1797,10 +1803,19 @@ module ietf-layer0-types {
 
         This list of pair pmd and penalty can be used to
         sample the function penalty = f(PMD).";
+      leaf pmd-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the pmd-penalty list.
+              
+          It may be equal to the pmd-value attribute, when the
+          pmd-value attribute is present.";
+      }
       leaf pmd-value {
         type union {
-          type decimal64 {
-            fraction-digits 2;
+          type decimal-2 {
             range "0..max";
           }
           type empty;
@@ -1823,6 +1838,7 @@ module ietf-layer0-types {
         dependent loss (PDL) on the receiver";
     }
     list pdl-penalty {
+      key pdl-index;
       config false;
       description
         "Optional penalty associated with a given accumulated 
@@ -1830,6 +1846,16 @@ module ietf-layer0-types {
 
         This list of pair pdl and penalty values can be used to
         sample the function PDL = f(penalty).";
+      leaf pdl-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the pdl-penalty list.
+              
+          It may be equal to the pdl-value attribute, when the
+          pdl-value attribute is present.";
+      }
       leaf pdl-value {
         type power-loss-or-null;
         config false;
@@ -1867,12 +1893,24 @@ module ietf-layer0-types {
         and min-OSNR";
     }
     list rx-channel-power-penalty {
+      key rx-channel-power-index;
       config false;
       description
         "Optional penalty associated with a received power
           lower than rx-ref-channel-power.
           This list of pair power and penalty can be used to
           sample the function penalty = f(rx-channel-power).";
+      leaf rx-channel-power-index {
+        type decimal-2 {
+          range "0..max";
+        }
+        description
+          "The identifier of one entry of the
+          rx-channel-power-penalty list.
+              
+          It may be equal to the rx-channel-power-value attribute,
+          when the rx-channel-power-value attribute is present.";
+      }
       leaf rx-channel-power-value {
         type power-dbm-or-null;
         units "dBm";
@@ -2003,9 +2041,7 @@ module ietf-layer0-types {
         "OIF-400ZR-01.0: Implementation Agreement 400ZR";
     }
     leaf polarization-skew {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type decimal-2;
       units "ps";
       config false;
       description

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -51,7 +51,7 @@ module ietf-layer0-types {
 
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-03-04 {
+  revision 2024-04-30 {
     description
       "To be updated";
     reference
@@ -598,22 +598,6 @@ module ietf-layer0-types {
         "all elements must use power (dBm)";
     }
 
-  identity operational-mode {
-    description
-      "Base identity to be used when defining organization/vendor 
-      specific modes.
-      
-      The format of the derived identities has to be defined by the 
-      organization which is responsible for defining the 
-      corresponding optical interface specification.";
-    reference
-      "Section 2.5.2 of RFC YYYY: A YANG Data Model for Optical
-      Impairment-aware Topology.";
-  }
-// RFC Ed.: replace YYYY with actual RFC number and remove
-// this note after draft-ietf-ccamp-optical-impairment-topology-yang
-// is published as an RFC
-
 /*
  * Typedefs
  */
@@ -721,13 +705,11 @@ module ietf-layer0-types {
 // is published as an RFC
 
   typedef operational-mode {
-    type identityref {
-      base operational-mode;
-    }
+    type string;
     description
       "Identifies an organization (e.g., vendor) specific mode.
       
-      The format of these identities has to be defined by the 
+      The format of the string has to be defined by the 
       organization which is responsible for defining the 
       corresponding optical interface specification.";
     reference

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -746,6 +746,10 @@ module ietf-layer0-types {
     description
       "(Optical) Signal to Noise Ratio measured over 0.1 nm
       resolution bandwidth";
+    reference
+      "ITU-T G.977.1 (02/2021): Transverse compatible dense
+      wavelength division multiplexing applications for repeatered
+      optical fibre submarine cable systems";
   }
 
   typedef snr-or-null {
@@ -905,6 +909,9 @@ module ietf-layer0-types {
       "The power spectral density (PSD).
       
       Typical value : 3.9 E-14, resolution 0.1nW/MHz.";
+    reference
+      "ITU-T G.9700 (07/2019): Fast access to subscriber terminals
+      (G.fast) - Power spectral density specification";
   }
 
   typedef psd-or-null {
@@ -1777,6 +1784,10 @@ module ietf-layer0-types {
       description
         "Maximum acceptable accumulated polarization mode
          dispersion (PMD) on the receiver";
+      reference
+        "ITU-T G.666 (02/2011): Characteristics of polarization
+        mode dispersion compensators and of receivers that
+        compensate for polarization mode dispersion";
     }
     list pmd-penalty {
       config false;

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -51,7 +51,7 @@ module ietf-layer0-types {
 
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-04-30 {
+  revision 2024-05-21 {
     description
       "To be updated";
     reference
@@ -1746,37 +1746,21 @@ module ietf-layer0-types {
         on the receiver";
     }
     list cd-penalty {
-      key cd-index;
+      key cd-value;
       config false;
       description
         "Optional penalty associated with a given accumulated
         chromatic dispersion (CD) value.
 
-        This list of pair cd and penalty values can be used to
+        This list of pair CD and penalty values can be used to
         sample the function penalty = f(CD).";
-      leaf cd-index {
-        type decimal-2 {
-          range "0..max";
-        }
-        description
-          "The identifier of one entry of the cd-penalty list.
-              
-          It may be equal to the cd-value attribute, when the
-          cd-value attribute is present.";
-      }
       leaf cd-value {
-        type union {
-          type decimal-2 {
-            range "0..max";
-          }
-          type empty;
-        }
+        type decimal-2;
         units "ps/nm";
         config false;
         mandatory true;
         description
-          "The Chromatic Dispersion (CD), when the value is known 
-          or an empty value when the value is not known.";
+          "The Chromatic Dispersion (CD).";
       }
       uses penalty-value;
     }
@@ -1795,37 +1779,23 @@ module ietf-layer0-types {
         compensate for polarization mode dispersion";
     }
     list pmd-penalty {
-      key pmd-index;
+      key pmd-value;
       config false;
       description
         "Optional penalty associated with a given accumulated
         polarization mode dispersion (PMD) value.
 
-        This list of pair pmd and penalty can be used to
+        This list of pair PMD and penalty can be used to
         sample the function penalty = f(PMD).";
-      leaf pmd-index {
+      leaf pmd-value {
         type decimal-2 {
           range "0..max";
-        }
-        description
-          "The identifier of one entry of the pmd-penalty list.
-              
-          It may be equal to the pmd-value attribute, when the
-          pmd-value attribute is present.";
-      }
-      leaf pmd-value {
-        type union {
-          type decimal-2 {
-            range "0..max";
-          }
-          type empty;
         }
         units "ps";
         config false;
         mandatory true;
         description
-          "The Polarization Mode Dispersion (PMD), when the value 
-          is known or an empty value when the value is not known.";
+          "The Polarization Mode Dispersion (PMD).";
       }
       uses penalty-value;
     }
@@ -1838,31 +1808,21 @@ module ietf-layer0-types {
         dependent loss (PDL) on the receiver";
     }
     list pdl-penalty {
-      key pdl-index;
+      key pdl-value;
       config false;
       description
         "Optional penalty associated with a given accumulated 
         polarization dependent loss (PDL) value.
 
-        This list of pair pdl and penalty values can be used to
+        This list of pair PDL and penalty values can be used to
         sample the function PDL = f(penalty).";
-      leaf pdl-index {
-        type decimal-2 {
-          range "0..max";
-        }
-        description
-          "The identifier of one entry of the pdl-penalty list.
-              
-          It may be equal to the pdl-value attribute, when the
-          pdl-value attribute is present.";
-      }
       leaf pdl-value {
-        type power-loss-or-null;
+        type power-loss;
         config false;
         mandatory true;
         description
           "Maximum acceptable accumulated polarization dependent
-          loss.";
+          loss (PDL).";
       }
       uses penalty-value;
     }
@@ -1893,32 +1853,21 @@ module ietf-layer0-types {
         and min-OSNR";
     }
     list rx-channel-power-penalty {
-      key rx-channel-power-index;
+      key rx-channel-power-value;
       config false;
       description
         "Optional penalty associated with a received power
-          lower than rx-ref-channel-power.
-          This list of pair power and penalty can be used to
-          sample the function penalty = f(rx-channel-power).";
-      leaf rx-channel-power-index {
-        type decimal-2 {
-          range "0..max";
-        }
-        description
-          "The identifier of one entry of the
-          rx-channel-power-penalty list.
-              
-          It may be equal to the rx-channel-power-value attribute,
-          when the rx-channel-power-value attribute is present.";
-      }
+        lower than rx-ref-channel-power.
+
+        This list of pair power and penalty can be used to
+        sample the function penalty = f(rx-channel-power).";
       leaf rx-channel-power-value {
-        type power-dbm-or-null;
+        type power-dbm;
         units "dBm";
         config false;
         mandatory true;
         description
-          "The Received Power, when the value is known or an empty 
-          value when the value is not known.";
+          "The Received Power.";
       }
       uses penalty-value;
     }


### PR DESCRIPTION
Changed operational model to be a string: fix https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/172

Added references: fix #6 

Added keys to lists: see https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/167

Updated types to consistently use the decimal-2 data type.

Aligned title and abstract with RFC8776 and L1-Types: fix #99 

Addressed comments from Adrian: see #98 

---

Co-Authored-By: sergio belotti <sergio.belotti@nokia.com>