### PR TITLE
Fix pyang compilation errors

### DIFF
--- a/draft-ietf-ccamp-rfc9093-bis.txt
+++ b/draft-ietf-ccamp-rfc9093-bis.txt
@@ -6,13 +6,13 @@ CCAMP Working Group                                      S. Belotti, Ed.
 Internet-Draft                                                     Nokia
 Obsoletes: 9093 (if approved)                               I. Busi, Ed.
 Intended status: Standards Track                                  Huawei
-Expires: 5 February 2026                                  D. Beller, Ed.
+Expires: 7 February 2026                                  D. Beller, Ed.
                                                                    Nokia
                                                             E. Le Rouzic
                                                                   Orange
                                                                   A. Guo
                                                   Futurewei Technologies
-                                                           4 August 2025
+                                                           6 August 2025
 
 
           Common YANG Data Types for Layer 0 Optical Networks
@@ -47,13 +47,13 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 5 February 2026.
+   This Internet-Draft will expire on 7 February 2026.
 
 
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 1]
+Belotti, et al.          Expires 7 February 2026                [Page 1]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -85,15 +85,15 @@ Table of Contents
      2.4.  WDM Label and Label Range . . . . . . . . . . . . . . . .   9
    3.  YANG Module for Layer 0 Types . . . . . . . . . . . . . . . .  11
    4.  Security Considerations . . . . . . . . . . . . . . . . . . .  61
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  61
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  62
    6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  62
      6.1.  Normative References  . . . . . . . . . . . . . . . . . .  62
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .  65
-   Appendix A.  The Complete Schema Trees  . . . . . . . . . . . . .  67
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .  66
+   Appendix A.  The Complete Schema Trees  . . . . . . . . . . . . .  68
    Appendix B.  Changes from RFC 9093  . . . . . . . . . . . . . . .  73
    Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  77
    Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  77
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  78
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  79
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 2]
+Belotti, et al.          Expires 7 February 2026                [Page 2]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -165,7 +165,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 3]
+Belotti, et al.          Expires 7 February 2026                [Page 3]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -221,7 +221,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 4]
+Belotti, et al.          Expires 7 February 2026                [Page 4]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -277,7 +277,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 5]
+Belotti, et al.          Expires 7 February 2026                [Page 5]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -333,7 +333,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 6]
+Belotti, et al.          Expires 7 February 2026                [Page 6]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -389,7 +389,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 7]
+Belotti, et al.          Expires 7 February 2026                [Page 7]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -445,7 +445,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 8]
+Belotti, et al.          Expires 7 February 2026                [Page 8]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -501,7 +501,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026                [Page 9]
+Belotti, et al.          Expires 7 February 2026                [Page 9]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -557,7 +557,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 10]
+Belotti, et al.          Expires 7 February 2026               [Page 10]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -613,7 +613,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 11]
+Belotti, et al.          Expires 7 February 2026               [Page 11]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -669,7 +669,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 12]
+Belotti, et al.          Expires 7 February 2026               [Page 12]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -679,7 +679,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
         described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
         they appear in all capitals, as shown here.";
 
-     revision 2025-08-04 {
+     revision 2025-08-06 {
        description
          "This revision adds the following new identities:
           - cwdm-ch-spc-type;
@@ -725,7 +725,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 13]
+Belotti, et al.          Expires 7 February 2026               [Page 13]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -781,7 +781,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 14]
+Belotti, et al.          Expires 7 February 2026               [Page 14]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -837,7 +837,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 15]
+Belotti, et al.          Expires 7 February 2026               [Page 15]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -893,7 +893,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 16]
+Belotti, et al.          Expires 7 February 2026               [Page 16]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -949,7 +949,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 17]
+Belotti, et al.          Expires 7 February 2026               [Page 17]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1005,7 +1005,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 18]
+Belotti, et al.          Expires 7 February 2026               [Page 18]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1061,7 +1061,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 19]
+Belotti, et al.          Expires 7 February 2026               [Page 19]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1117,7 +1117,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 20]
+Belotti, et al.          Expires 7 February 2026               [Page 20]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1173,7 +1173,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 21]
+Belotti, et al.          Expires 7 February 2026               [Page 21]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1229,7 +1229,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 22]
+Belotti, et al.          Expires 7 February 2026               [Page 22]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1285,7 +1285,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 23]
+Belotti, et al.          Expires 7 February 2026               [Page 23]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1341,7 +1341,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 24]
+Belotti, et al.          Expires 7 February 2026               [Page 24]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1397,7 +1397,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 25]
+Belotti, et al.          Expires 7 February 2026               [Page 25]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1453,7 +1453,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 26]
+Belotti, et al.          Expires 7 February 2026               [Page 26]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1509,7 +1509,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 27]
+Belotti, et al.          Expires 7 February 2026               [Page 27]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1565,7 +1565,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 28]
+Belotti, et al.          Expires 7 February 2026               [Page 28]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1621,7 +1621,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 29]
+Belotti, et al.          Expires 7 February 2026               [Page 29]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1677,7 +1677,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 30]
+Belotti, et al.          Expires 7 February 2026               [Page 30]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1733,7 +1733,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 31]
+Belotti, et al.          Expires 7 February 2026               [Page 31]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1789,7 +1789,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 32]
+Belotti, et al.          Expires 7 February 2026               [Page 32]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1845,7 +1845,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 33]
+Belotti, et al.          Expires 7 February 2026               [Page 33]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1901,7 +1901,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 34]
+Belotti, et al.          Expires 7 February 2026               [Page 34]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1957,7 +1957,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 35]
+Belotti, et al.          Expires 7 February 2026               [Page 35]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -1986,7 +1986,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
            type identityref {
              base flexi-slot-width-granularity;
            }
-           default "flexi-swg-12p5ghz";
+           default "l0-types:flexi-swg-12p5ghz";
            description
              "Minimum space between slot widths.";
            reference
@@ -2013,7 +2013,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 36]
+Belotti, et al.          Expires 7 February 2026               [Page 36]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -2069,7 +2069,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 37]
+Belotti, et al.          Expires 7 February 2026               [Page 37]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -2097,7 +2097,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
          type identityref {
            base flexi-ch-spc-type;
          }
-         default "flexi-ch-spc-6p25ghz";
+         default "l0-types:flexi-ch-spc-6p25ghz";
          status obsolete;
          description
            "Label-step is the nominal central frequency granularity
@@ -2110,7 +2110,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
          type identityref {
            base flexi-ncfg-type;
          }
-         default "flexi-ncfg-6p25ghz";
+         default "l0-types:flexi-ncfg-6p25ghz";
          description
            "Label-step is the nominal central frequency granularity
             (GHz), e.g., 6.25 GHz.";
@@ -2125,7 +2125,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 38]
+Belotti, et al.          Expires 7 February 2026               [Page 38]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -2181,7 +2181,7 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 39]
+Belotti, et al.          Expires 7 February 2026               [Page 39]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
@@ -2214,90 +2214,94 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
      grouping wdm-label-range-info {
        description
-         "WDM label range related information.
+         "Label range information for WDM.
 
           This grouping SHOULD be used together with the
           wdm-label-start-end and wdm-label-step groupings to provide
           WDM technology-specific label information to the models which
           use the label-restriction-info grouping defined in the module
           ietf-te-types.";
-       uses l0-label-range-info;
-       container flexi-grid {
-         when 'derived-from-or-self(../grid-type, '
-            + '"l0-types:flexi-grid-dwdm")' {
-           description
-             "Applicable only when the grid type is flexi-grid-dwdm.";
-         }
+       container wdm-label-range {
          description
-           "flexi-grid definition.";
-         leaf slot-width-granularity {
-           type identityref {
-             base flexi-slot-width-granularity;
+           "Label range information for WDM.";
+         uses l0-label-range-info;
+         container flexi-grid {
+           when 'derived-from-or-self(../grid-type, '
+              + '"l0-types:flexi-grid-dwdm")' {
+             description
+               "Applicable only when the grid type is flexi-grid-dwdm.";
            }
+           description
+             "flexi-grid definition.";
+           leaf slot-width-granularity {
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 40]
+Belotti, et al.          Expires 7 February 2026               [Page 40]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
 
-           default "flexi-swg-12p5ghz";
-           description
-             "Minimum space between slot widths.";
-           reference
-             "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                        Grid Dense Wavelength Division Multiplexing
-                        (DWDM) Networks";
-         }
-         leaf min-slot-width-factor {
-           type uint16 {
-             range "1..max";
+             type identityref {
+               base flexi-slot-width-granularity;
+             }
+             default "l0-types:flexi-swg-12p5ghz";
+             description
+               "Minimum space between slot widths.";
+             reference
+               "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                         Grid Dense Wavelength Division Multiplexing
+                         (DWDM) Networks";
            }
-           description
-             "A multiplier of the slot width granularity, indicating
-              the minimum slot width supported by an optical port.
+           leaf min-slot-width-factor {
+             type uint16 {
+               range "1..max";
+             }
+             description
+               "A multiplier of the slot width granularity, indicating
+                the minimum slot width supported by an optical port.
 
-              Minimum slot width is calculated by:
-                Minimum slot width (GHz) =
-                  min-slot-width-factor * slot-width-granularity.";
-           reference
-             "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                        Grid Dense Wavelength Division Multiplexing
-                        (DWDM) Networks";
-         }
-         leaf max-slot-width-factor {
-           type uint16 {
-             range "1..max";
+                Minimum slot width is calculated by:
+                   Minimum slot width (GHz) =
+                     min-slot-width-factor * slot-width-granularity.";
+             reference
+               "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                         Grid Dense Wavelength Division Multiplexing
+                         (DWDM) Networks";
            }
-           must '. >= ../min-slot-width-factor' {
-             error-message
-               "Maximum slot width must be greater than or equal to
-                minimum slot width.";
-           }
-           description
-             "A multiplier of the slot width granularity, indicating
-              the maximum slot width supported by an optical port.
+           leaf max-slot-width-factor {
+             type uint16 {
+               range "1..max";
+             }
+             must '. >= ../min-slot-width-factor' {
+               error-message
+                 "Maximum slot width must be greater than or equal to
+                  minimum slot width.";
+             }
+             description
+               "A multiplier of the slot width granularity, indicating
+                the maximum slot width supported by an optical port.
 
-              Maximum slot width is calculated by:
-                Maximum slot width (GHz) =
-                  max-slot-width-factor * slot-width-granularity
+                Maximum slot width is calculated by:
+                   Maximum slot width (GHz) =
+                     max-slot-width-factor * slot-width-granularity
 
-              If specified, maximum slot width must be greater than or
-              equal to minimum slot width.  If not specified, maximum
-              slot width is equal to minimum slot width.";
-           reference
-             "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                        Grid Dense Wavelength Division Multiplexing
-                        (DWDM) Networks";
+                If specified, maximum slot width must be greater than or
+                equal to minimum slot width.  If not specified, maximum
+                slot width is equal to minimum slot width.";
+             reference
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 41]
+Belotti, et al.          Expires 7 February 2026               [Page 41]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
 
+               "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                         Grid Dense Wavelength Division Multiplexing
+                         (DWDM) Networks";
+           }
          }
        }
      }
@@ -2320,47 +2324,55 @@ Internet-Draft            L0 Common YANG Types               August 2025
                     Label Switching Routers
           RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
                     Switch Capable (LSC) Label Switching Routers";
-       leaf dwdm-n {
-         when 'derived-from-or-self(../../../grid-type, '
-            + '"l0-types:wson-grid-dwdm")' {
-           description
-             "Valid only when grid type is a fixed DWDM grid.";
-         }
-         type dwdm-n;
+       container wdm-label {
          description
-           "The given value 'N' is used to determine the
-            nominal central frequency on a DWDM fixed grid.";
-         reference
-           "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                      (LSC) Label Switching Routers";
-       }
-       leaf cwdm-n {
-         when 'derived-from-or-self(../../../grid-type, '
-            + '"l0-types:wson-grid-cwdm")' {
+           "Label start or label end for WDM.
+
+            The format of the label depends on the type of WDM grid
+            specified in the 'grid-type' leaf defined in the
+            wdm-label-range-info grouping.";
+         leaf dwdm-n {
+           when 'derived-from-or-self(../../../../wdm-label-range'
+              + '/grid-type, "l0-types:wson-grid-dwdm")' {
+             description
+               "Valid only when grid type is a fixed DWDM grid.";
+           }
+           type dwdm-n;
            description
-             "Valid only when grid type is a CWDM grid.";
+             "The given value 'N' is used to determine the
+              nominal central frequency on a DWDM fixed grid.";
+           reference
+             "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                       (LSC) Label Switching Routers";
          }
-         type cwdm-n;
-         description
-           "The given value 'N' is used to determine the nominal
-            central wavelength on a CWDM fixed grid.";
-         reference
-           "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+         leaf cwdm-n {
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 42]
+Belotti, et al.          Expires 7 February 2026               [Page 42]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
 
-                      (LSC) Label Switching Routers";
-       }
-       uses flexi-grid-label-start-end {
-         when 'derived-from-or-self(../../grid-type, '
-            + '"l0-types:flexi-grid-dwdm")' {
+           when 'derived-from-or-self(../../../../wdm-label-range'
+              + '/grid-type, "l0-types:wson-grid-cwdm")' {
+             description
+               "Valid only when grid type is a CWDM grid.";
+           }
+           type cwdm-n;
            description
-             "Valid only when grid type is a flexible DWDM grid.";
+             "The given value 'N' is used to determine the nominal
+              central wavelength on a CWDM fixed grid.";
+           reference
+             "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                       (LSC) Label Switching Routers";
+         }
+         uses flexi-grid-label-start-end {
+           when 'derived-from-or-self(../../../wdm-label-range'
+              + '/grid-type, "l0-types:flexi-grid-dwdm")' {
+             description
+               "Valid only when grid type is a flexible DWDM grid.";
+           }
          }
        }
      }
@@ -2386,117 +2398,137 @@ Internet-Draft            L0 Common YANG Types               August 2025
           RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-Grid
                     Dense Wavelength Division Multiplexing (DWDM)
                     Networks";
-       leaf wson-dwdm-channel-spacing {
-         when 'derived-from-or-self(../../grid-type, '
-            + '"l0-types:wson-grid-dwdm")' {
-           description
-             "Valid only when grid type is a fixed DWDM grid.";
-         }
-         type identityref {
-           base dwdm-ch-spc-type;
-         }
+       container wdm-label-step {
          description
-           "The channel spacing (GHz) of a fixed DWDM grid, e.g.,
-            100 GHz, 50 GHz, 25 GHz, or 12.5 GHz.";
-         reference
-           "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                      (LSC) Label Switching Routers";
-       }
+           "Label step for WDM.
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 43]
+
+Belotti, et al.          Expires 7 February 2026               [Page 43]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
 
-       leaf wson-cwdm-channel-spacing {
-         when 'derived-from-or-self(../../grid-type, '
-            + '"l0-types:wson-grid-cwdm")' {
+            The format of the label depends on the type of WDM grid
+            specified in the 'grid-type' leaf defined in the
+            wdm-label-range-info grouping.";
+         leaf wson-dwdm-channel-spacing {
+           when 'derived-from-or-self(../../../wdm-label-range'
+              + '/grid-type, "l0-types:wson-grid-dwdm")' {
+             description
+               "Valid only when grid type is a fixed DWDM grid.";
+           }
+           type identityref {
+             base dwdm-ch-spc-type;
+           }
            description
-             "Valid only when grid type is a CWDM grid.";
+             "The channel spacing (GHz) of a fixed DWDM grid, e.g.,
+              100 GHz, 50 GHz, 25 GHz, or 12.5 GHz.";
+           reference
+             "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                       (LSC) Label Switching Routers";
          }
-         type identityref {
-           base cwdm-ch-spc-type;
-         }
-         description
-           "The channel spacing (nm) of a fixed CWDM grid, e.g., 20nm
-            (which is the only standardized value).";
-         reference
-           "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                      (LSC) Label Switching Routers";
-       }
-       container flexi-grid-cfg {
-         when 'derived-from-or-self(../../grid-type, '
-            + '"l0-types:flexi-grid-dwdm")' {
+         leaf wson-cwdm-channel-spacing {
+           when 'derived-from-or-self(../../../wdm-label-range'
+              + '/grid-type, "l0-types:wson-grid-cwdm")' {
+             description
+               "Valid only when grid type is a CWDM grid.";
+           }
+           type identityref {
+             base cwdm-ch-spc-type;
+           }
            description
-             "Valid only when grid type is a flexible DWDM grid.";
+             "The channel spacing (nm) of a fixed CWDM grid, e.g., 20nm
+              (which is the only standardized value).";
+           reference
+             "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                       (LSC) Label Switching Routers";
          }
-         description
-           "The Central Frequency Granularity (CFG) of a flexible DWDM
-            grid (flexi-grid), defined as a multiplier of the Nominal
-            central frequency granularity (NCFG).";
-         uses flexi-grid-label-step;
+         container flexi-grid-cfg {
+           when 'derived-from-or-self(../../../wdm-label-range'
+              + '/grid-type, "l0-types:flexi-grid-dwdm")' {
+             description
+               "Valid only when grid type is a flexible DWDM grid.";
+           }
+           description
+             "The Central Frequency Granularity (CFG) of a flexible DWDM
+              grid (flexi-grid), defined as a multiplier of the Nominal
+              central frequency granularity (NCFG).";
+           uses flexi-grid-label-step;
+         }
        }
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 44]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
      }
 
      grouping wdm-label-hop {
        description
          "Generic label-hop information for DWDM and CWDM labels.";
-       choice grid-type {
+       container wdm-label {
          description
-           "Label for DWDM or CWDM grid.";
-         reference
-           "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
-                      Label Switching Routers";
-         case fixed-dwdm {
-           choice fixed-single-or-multi-channel {
-             description
-               "Single channel or multichannel.";
-             case single {
-               leaf dwdm-n {
-                 type dwdm-n;
-                 description
-                   "The given value 'N' is used to determine the
+           "Label hop for WDM.";
+         choice grid-type {
+           description
+             "Label for DWDM or CWDM grid.";
+           reference
+             "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                        (LSC) Label Switching Routers";
+           case fixed-dwdm {
+             choice fixed-single-or-multi-channel {
+               description
+                 "Single channel or multichannel.";
+               case single {
+                 leaf dwdm-n {
+                   type dwdm-n;
+                   description
+                     "The given value 'N' is used to determine the
+                      nominal central frequency.";
+                 }
+               }
+               case multi {
+                 leaf-list subcarrier-dwdm-n {
+                   type dwdm-n;
+                   min-elements 2;
+                   description
+                     "The given values 'N' are used to determine the
+                      nominal central frequency for each subcarrier
+                      channel.";
+                   reference
+                     "ITU-T G.694.1 (10/2020): Spectral grids for WDM
+                                 applications: DWDM frequency grid";
+                 }
+               }
+             }
+           }
+           case cwdm {
+             leaf cwdm-n {
+               type cwdm-n;
+               description
+                 "The given value 'N' is used to determine the nominal
+                  central wavelength.";
+               reference
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 44]
+Belotti, et al.          Expires 7 February 2026               [Page 45]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
 
-                    nominal central frequency.";
-               }
-             }
-             case multi {
-               leaf-list subcarrier-dwdm-n {
-                 type dwdm-n;
-                 min-elements 2;
-                 description
-                   "The given values 'N' are used to determine the
-                    nominal central frequency for each subcarrier
-                    channel.";
-                 reference
-                   "ITU-T G.694.1 (10/2020): Spectral grids for WDM
-                                applications: DWDM frequency grid";
-               }
+                 "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                           (LSC) Label Switching Routers";
              }
            }
-         }
-         case cwdm {
-           leaf cwdm-n {
-             type cwdm-n;
-             description
-               "The given value 'N' is used to determine the nominal
-                central wavelength.";
-             reference
-               "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                          (LSC) Label Switching Routers";
+           case flexi-grid {
+             uses flexi-grid-label-hop;
            }
-         }
-         case flexi-grid {
-           uses flexi-grid-label-hop;
          }
        }
      }
@@ -2514,14 +2546,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          "RFC ZZZZ: A YANG Data Model for Optical Impairment-aware
                     Topology.";
        container supported-modes {
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 45]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          presence
            "When present, it indicates that the modes supported by a
             transceiver are reported.";
@@ -2546,6 +2570,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
              description
                "Indicates whether the transceiver's mode is a standard
                 mode, an organizational mode or an explicit mode.";
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 46]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
              case G.698.2 {
                uses standard-mode;
                uses common-standard-organizational-mode;
@@ -2570,14 +2602,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
                      "Container for all the standard and organizational
                       modes supported by the transceiver's explicit
                       mode.";
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 46]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
                    leaf-list supported-application-code {
                      type leafref {
                        path "../../../../supported-mode/mode-id";
@@ -2602,6 +2626,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
                         + 'organizational-mode' {
                        description
                          "The pointer is only for organizational modes
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 47]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
                           supported by transceiver.";
                      }
                      description
@@ -2626,14 +2658,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
                     transport network, Clause 5.3";
        leaf standard-mode {
          type standard-mode;
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 47]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          description
            "Identifies an ITU-T G.698.2 standard application code.
 
@@ -2658,6 +2682,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
        leaf organization-identifier {
          type organization-identifier;
          description
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 48]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
            "The identifier of the organization that defines the
             organizational-mode.";
        }
@@ -2682,14 +2714,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
             impairment at the receiver, when the value is known or an
             empty value when the value is not known.";
        }
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 48]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
      }
 
      grouping explicit-mode {
@@ -2714,6 +2738,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
            "ITU-T G.698.2 v3.0 (11/2018): Amplified multichannel dense
                         wavelength division multiplexing applications
                         with single channel optical interfaces Optical
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 49]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
                         transport network, Clause 7.1.2";
        }
        leaf bitrate {
@@ -2738,14 +2770,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          }
          units "ps/nm";
          config false;
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 49]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          description
            "Maximum acceptable accumulated chromatic dispersion (CD) on
             the receiver at Rx-power reference point
@@ -2770,6 +2794,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
                       Impairment-aware Topology, Section 2.6.4";
          leaf cd-value {
            type decimal-2;
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 50]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
            units "ps/nm";
            description
              "The Chromatic Dispersion (CD).";
@@ -2794,14 +2826,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
                       Topology, Section 2.4.6";
        }
        list pmd-penalty {
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 50]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          key "pmd-value";
          config false;
          description
@@ -2826,6 +2850,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
        }
        leaf max-polarization-dependent-loss {
          type power-loss-or-null;
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 51]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
          config false;
          mandatory true;
          description
@@ -2850,14 +2882,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          reference
            "RFC ZZZZ: A YANG Data Model for Optical Impairment-aware
                       Topology, Section 2.4.6";
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 51]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          leaf pdl-value {
            type power-loss;
            description
@@ -2882,6 +2906,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
          description
            "Minimum OSNR measured over 0.1 nm resolution bandwidth:
             if received OSNR at Rx-power reference point
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 52]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
             (rx-ref-channel-power) is lower than MIN-OSNR, an increased
             level of bit-errors post-FEC needs to be expected.";
        }
@@ -2906,14 +2938,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
            units "dBm";
            description
              "The Received Power.";
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 52]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          }
          uses penalty-value;
        }
@@ -2938,6 +2962,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
            "Baud-rate the specific transceiver in
             the list can support.
             Baud-rate is the unit for symbol rate or modulation rate
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 53]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
             in symbols per second or pulses per second.
             It is the number of distinct symbol changes (signal events)
             made to the transmission medium per second in a digitally
@@ -2962,14 +2994,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          description
            "This attribute specifies the minimum nominal difference
             between the carrier frequencies of two homogeneous OTSis
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 53]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
             (which have the same optical characteristics but the central
             frequencies) such that if they are placed next to each other
             the interference due to spectrum overlap between them can be
@@ -2994,6 +3018,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
          }
          config false;
          description
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 54]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
            "FEC-code-rate";
        }
        leaf fec-threshold {
@@ -3018,14 +3050,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
             The in-band OSNR is referenced to an optical bandwidth of
             0.1nm @ 193.7 THz or 12.5 GHz.";
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 54]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          reference
            "OIF-400ZR-01.0: Implementation Agreement 400ZR";
        }
@@ -3050,6 +3074,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
          description
            "The transmitter polarization dependent power difference
             defined as the power difference between X and Y
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 55]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
             polarizations.";
          reference
            "OIF-400ZR-01.0: Implementation Agreement 400ZR";
@@ -3074,14 +3106,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          type identityref {
            base line-coding;
          }
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 55]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          config false;
          description
            "The list of the bit rate/line coding of the optical
@@ -3106,6 +3130,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
            "This parameter indicates the minimum frequency for the
             transceiver tuning range.";
        }
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 56]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
        leaf max-central-frequency {
          type frequency-thz;
          description
@@ -3130,14 +3162,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          uses transceiver-tuning-range;
        }
        leaf tx-channel-power-min {
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 56]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          type power-dbm;
          config false;
          description
@@ -3162,6 +3186,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
            "The maximum input power of this interface";
        }
        leaf rx-total-power-max {
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 57]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
          type power-dbm;
          config false;
          description
@@ -3186,14 +3218,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
        leaf line-coding-bitrate {
          type identityref {
            base line-coding;
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 57]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          }
          description
            "Bit rate/line coding of the optical tributary signal.
@@ -3218,6 +3242,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
      }
 
      grouping common-transceiver-readonly-param {
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 58]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
        description
          "The common read-only parameters of an optical transceiver,
           that supplement the configured mode.";
@@ -3242,14 +3274,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
          "Parameters for Layer0 (WSON or Flexi-Grid) Tunnels.";
        leaf wavelength-assignment {
          type identityref {
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 58]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
            base wavelength-assignment;
          }
          description
@@ -3274,6 +3298,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
        leaf upper-frequency {
          type frequency-thz;
          must '. > ../lower-frequency' {
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 59]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
            error-message
              "The upper frequency must be greater than the lower
               frequency.";
@@ -3298,14 +3330,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
        }
        container frequency-range {
          description
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 59]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
            "The frequency range for which these optical
             impairments apply.";
          uses frequency-range;
@@ -3330,6 +3354,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
      grouping path-properties {
        description
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 60]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
          "Common attribute for reporting the Layer 0 computed path
           properties.";
        leaf estimated-gsnr {
@@ -3354,14 +3386,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
             path.";
        }
      }
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 60]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    }
    <CODE ENDS>
 
@@ -3383,6 +3407,16 @@ Internet-Draft            L0 Common YANG Types               August 2025
    provides the means to restrict access for particular NETCONF or
    RESTCONF users to a preconfigured subset of all available NETCONF or
    RESTCONF protocol operations and content.
+
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 61]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    The YANG module defines a set of identities, types, and groupings.
    These nodes are intended to be reused by other YANG modules.  The
@@ -3408,16 +3442,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
    Module Names" registry [RFC6020] within the "YANG Parameters"
    registry group.
 
-
-
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 61]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
          Name: ietf-layer0-types
          Maintained by IANA? N
          Namespace: urn:ietf:params:xml:ns:yang:ietf-layer0-types
@@ -3435,6 +3459,20 @@ Internet-Draft            L0 Common YANG Types               August 2025
               ietf-ccamp-optical-impairment-topology-yang-19, 7 July
               2025, <https://datatracker.ietf.org/doc/html/draft-ietf-
               ccamp-optical-impairment-topology-yang-19>.
+
+
+
+
+
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 62]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    [I-D.ietf-teas-rfc8776-update]
               Busi, I., Guo, A., Liu, X., Saad, T., and I. Bryskin,
@@ -3466,14 +3504,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
    [ITU-T_G.698.2]
               International Telecommunication Union, "Amplified
               multichannel dense wavelength division multiplexing
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 62]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
               applications with single channel optical interfaces",
               ITU-T Recommendation G.698.2 , November 2018,
               <https://www.itu.int/rec/T-REC-G.698.2>.
@@ -3487,6 +3517,18 @@ Internet-Draft            L0 Common YANG Types               August 2025
               International Telecommunication Union, "OTU4 long-reach
               interface", ITU-T Recommendation G.709.2, Corrigendum 1 ,
               September 2020, <https://www.itu.int/rec/T-REC-G.709.2>.
+
+
+
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 63]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    [ITU-T_G.709.3]
               International Telecommunication Union, "Flexible OTN B100G
@@ -3518,18 +3560,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
               ITU-T Recommendation G.975.1, Corrigendum 2 , July 2013,
               <https://www.itu.int/rec/T-REC-G.975.1>.
 
-
-
-
-
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 63]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    [ITU-T_G.977.1]
               International Telecommunication Union, "Transverse
               compatible dense wavelength division multiplexing
@@ -3547,6 +3577,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/rfc/rfc2119>.
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 64]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    [RFC3471]  Berger, L., Ed., "Generalized Multi-Protocol Label
               Switching (GMPLS) Signaling Functional Description",
@@ -3575,17 +3613,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
               DOI 10.17487/RFC7689, November 2015,
               <https://www.rfc-editor.org/rfc/rfc7689>.
 
-
-
-
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 64]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    [RFC7699]  Farrel, A., King, D., Li, Y., and F. Zhang, "Generalized
               Labels for the Flexi-Grid in Lambda Switch Capable (LSC)
               Label Switching Routers", RFC 7699, DOI 10.17487/RFC7699,
@@ -3603,6 +3630,17 @@ Internet-Draft            L0 Common YANG Types               August 2025
               Access Control Model", STD 91, RFC 8341,
               DOI 10.17487/RFC8341, March 2018,
               <https://www.rfc-editor.org/rfc/rfc8341>.
+
+
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 65]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    [RFC8342]  Bjorklund, M., Schoenwaelder, J., Shafer, P., Watsen, K.,
               and R. Wilton, "Network Management Datastore Architecture
@@ -3634,14 +3672,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
    [I-D.ietf-netmod-rfc8407bis]
               Bierman, A., Boucadair, M., and Q. Wu, "Guidelines for
               Authors and Reviewers of Documents Containing YANG Data
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 65]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
               Models", Work in Progress, Internet-Draft, draft-ietf-
               netmod-rfc8407bis-28, 5 June 2025,
               <https://datatracker.ietf.org/doc/html/draft-ietf-netmod-
@@ -3656,6 +3686,17 @@ Internet-Draft            L0 Common YANG Types               August 2025
               International Telecommunication Union, "Architecture of
               optical transport networks", ITU-T Supplement G.872,
               Amendment 1 , January 2021.
+
+
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 66]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    [ITU-T_G.Sup39]
               International Telecommunication Union, "Optical system
@@ -3686,18 +3727,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
               <https://www.rfc-editor.org/rfc/rfc6241>.
 
-
-
-
-
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 66]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    [RFC7446]  Lee, Y., Ed., Bernstein, G., Ed., Li, D., and W. Imajuku,
               "Routing and Wavelength Assignment Information Model for
               Wavelength Switched Optical Networks", RFC 7446,
@@ -3716,6 +3745,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
               Wavelength Division Multiplexing (DWDM) Networks",
               RFC 7698, DOI 10.17487/RFC7698, November 2015,
               <https://www.rfc-editor.org/rfc/rfc7698>.
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 67]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
@@ -3746,14 +3783,6 @@ Appendix A.  The Complete Schema Trees
    data type of every leaf node is shown near the right end of the
    corresponding line.
 
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 67]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    module: ietf-layer0-types
 
      grouping l0-label-range-info:
@@ -3773,6 +3802,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
              +-- wson-cwdm-channel-spacing?   identityref
      grouping wson-label-hop:
        +-- (grid-type)?
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 68]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
           +--:(dwdm)
           |  +-- (single-or-super-channel)?
           |     +--:(single)
@@ -3802,14 +3839,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
           +--:(single)
           |  +-- flexi-n?              flexi-n
           |  +-- flexi-m?              flexi-m
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 68]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
           o--:(super)
           |  o-- subcarrier-flexi-n* [flexi-n]
           |     +-- flexi-n?   flexi-n
@@ -3820,55 +3849,59 @@ Internet-Draft            L0 Common YANG Types               August 2025
                    +-- flexi-n?   flexi-n
                    +-- flexi-m?   flexi-m
      grouping wdm-label-range-info:
-       +-- grid-type?    identityref
-       +-- priority?     uint8
-       +-- flexi-grid
-          +-- slot-width-granularity?   identityref
-          +-- min-slot-width-factor?    uint16
-          +-- max-slot-width-factor?    uint16
+       +-- wdm-label-range
+          +-- grid-type?    identityref
+          +-- priority?     uint8
+          +-- flexi-grid
+             +-- slot-width-granularity?   identityref
+             +-- min-slot-width-factor?    uint16
+             +-- max-slot-width-factor?    uint16
      grouping wdm-label-start-end:
-       +-- dwdm-n?    dwdm-n
-       +-- cwdm-n?    cwdm-n
-       +-- flexi-n?   flexi-n
-     grouping wdm-label-step:
-       +-- wson-dwdm-channel-spacing?   identityref
-       +-- wson-cwdm-channel-spacing?   identityref
-       +-- flexi-grid-cfg
-          o-- flexi-grid-channel-spacing?   identityref
-          +-- flexi-ncfg?                   identityref
-          +-- flexi-n-step?                 uint8
-     grouping wdm-label-hop:
-       +-- (grid-type)?
-          +--:(fixed-dwdm)
-          |  +-- (fixed-single-or-multi-channel)?
-          |     +--:(single)
-          |     |  +-- dwdm-n?               dwdm-n
-          |     +--:(multi)
-          |        +-- subcarrier-dwdm-n*    dwdm-n
-          +--:(cwdm)
-          |  +-- cwdm-n?                     cwdm-n
-          +--:(flexi-grid)
-             +-- (single-or-super-channel)?
-                +--:(single)
-                |  +-- flexi-n?              flexi-n
-                |  +-- flexi-m?              flexi-m
-                o--:(super)
-                |  o-- subcarrier-flexi-n* [flexi-n]
-                |     +-- flexi-n?   flexi-n
-                |     +-- flexi-m?   flexi-m
-                +--:(multi)
-                   +-- frequency-slots
+       +-- wdm-label
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 69]
+Belotti, et al.          Expires 7 February 2026               [Page 69]
 
 Internet-Draft            L0 Common YANG Types               August 2025
 
 
-                      +-- frequency-slot* [flexi-n]
-                         +-- flexi-n?   flexi-n
-                         +-- flexi-m?   flexi-m
+          +-- dwdm-n?    dwdm-n
+          +-- cwdm-n?    cwdm-n
+          +-- flexi-n?   flexi-n
+     grouping wdm-label-step:
+       +-- wdm-label-step
+          +-- wson-dwdm-channel-spacing?   identityref
+          +-- wson-cwdm-channel-spacing?   identityref
+          +-- flexi-grid-cfg
+             o-- flexi-grid-channel-spacing?   identityref
+             +-- flexi-ncfg?                   identityref
+             +-- flexi-n-step?                 uint8
+     grouping wdm-label-hop:
+       +-- wdm-label
+          +-- (grid-type)?
+             +--:(fixed-dwdm)
+             |  +-- (fixed-single-or-multi-channel)?
+             |     +--:(single)
+             |     |  +-- dwdm-n?               dwdm-n
+             |     +--:(multi)
+             |        +-- subcarrier-dwdm-n*    dwdm-n
+             +--:(cwdm)
+             |  +-- cwdm-n?                     cwdm-n
+             +--:(flexi-grid)
+                +-- (single-or-super-channel)?
+                   +--:(single)
+                   |  +-- flexi-n?              flexi-n
+                   |  +-- flexi-m?              flexi-m
+                   o--:(super)
+                   |  o-- subcarrier-flexi-n* [flexi-n]
+                   |     +-- flexi-n?   flexi-n
+                   |     +-- flexi-m?   flexi-m
+                   +--:(multi)
+                      +-- frequency-slots
+                         +-- frequency-slot* [flexi-n]
+                            +-- flexi-n?   flexi-n
+                            +-- flexi-m?   flexi-m
      grouping transceiver-capabilities:
        +--ro supported-modes!
           +--ro supported-mode* [mode-id]
@@ -3881,6 +3914,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
                 |  |  +--ro min-central-frequency?
                 |  |  |       frequency-thz
                 |  |  +--ro max-central-frequency?
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 70]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
                 |  |  |       frequency-thz
                 |  |  +--ro transceiver-tunability-granularity?
                 |  |          frequency-ghz
@@ -3914,14 +3955,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
                       |  |       frequency-thz
                       |  +--ro max-central-frequency?
                       |  |       frequency-thz
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 70]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
                       |  +--ro transceiver-tunability-granularity?
                       |          frequency-ghz
                       +--ro tx-channel-power-min?       power-dbm
@@ -3937,6 +3970,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
      grouping standard-mode:
        +-- standard-mode?   standard-mode
      grouping organizational-mode:
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 71]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
        +-- operational-mode?          operational-mode
        +-- organization-identifier?   organization-identifier
      grouping penalty-value:
@@ -3970,14 +4011,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
        +--ro available-fec-type?                 identityref
        +--ro fec-code-rate?                      decimal64
        +--ro fec-threshold?                      decimal64
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 71]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
        +--ro in-band-osnr?                       snr
        +--ro out-of-band-osnr?                   snr
        +--ro tx-polarization-power-difference?   power-ratio
@@ -3993,6 +4026,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
        |  +--ro min-central-frequency?                frequency-thz
        |  +--ro max-central-frequency?                frequency-thz
        |  +--ro transceiver-tunability-granularity?   frequency-ghz
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 72]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
        +--ro tx-channel-power-min?       power-dbm
        +--ro tx-channel-power-max?       power-dbm
        +--ro rx-channel-power-min?       power-dbm
@@ -4026,14 +4067,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
        +--ro estimated-eol-gsnr?      snr
        +--ro estimated-lowest-gsnr?   snr
 
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 72]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
                                   Figure 2
 
 Appendix B.  Changes from RFC 9093
@@ -4048,6 +4081,14 @@ Appendix B.  Changes from RFC 9093
    *  cwdm-ch-spc-type;
 
    *  flexi-ncfg-type;
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 73]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    *  flexi-ncfg-6p25gh;
 
@@ -4083,13 +4124,6 @@ Appendix B.  Changes from RFC 9093
 
    *  no-fec;
 
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 73]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    *  sc-fec;
 
    *  o-fec;
@@ -4103,6 +4137,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
    *  nrz-otu1;
 
    *  nrz-10g;
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 74]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    *  nrz-otu2;
 
@@ -4139,13 +4181,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
    *  organization-identifier
 
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 74]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    *  operational-mode
 
    *  frequency-thz
@@ -4159,6 +4194,13 @@ Internet-Draft            L0 Common YANG Types               August 2025
    *  decimal-2
 
    *  decimal-2-or-null
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 75]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    *  power-gain
 
@@ -4195,13 +4237,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
 
    *  wdm-label-range-info
 
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 75]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    *  transceiver-capabilities
 
    *  standard-mode
@@ -4215,6 +4250,13 @@ Internet-Draft            L0 Common YANG Types               August 2025
    *  common-standard-organizational-mode
 
    *  transceiver-tuning-range
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 76]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
 
    *  common-all-mode
 
@@ -4247,17 +4289,6 @@ Internet-Draft            L0 Common YANG Types               August 2025
    The default value of the min-slot-width-factor data node within
    flexi-grid-label-range-info grouping has been removed (bug fixing).
 
-
-
-
-
-
-
-Belotti, et al.          Expires 5 February 2026               [Page 76]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
 Acknowledgments
 
    The authors and the working group give their sincere thanks to Robert
@@ -4275,6 +4306,14 @@ Contributors
 
    Daniel King
    University of Lancaster
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 77]
+
+Internet-Draft            L0 Common YANG Types               August 2025
+
+
    Email: d.king@lancaster.ac.uk
 
 
@@ -4308,12 +4347,6 @@ Contributors
    Email: younglee.tx@gmail.com
 
 
-
-Belotti, et al.          Expires 5 February 2026               [Page 77]
-
-Internet-Draft            L0 Common YANG Types               August 2025
-
-
    Victor Lopez
    Nokia
    Email: victor.lopez@nokia.com
@@ -4327,6 +4360,14 @@ Internet-Draft            L0 Common YANG Types               August 2025
    Gert Grammel
    Juniper
    Email: ggrammel@juniper.net
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 78]
+
+Internet-Draft            L0 Common YANG Types               August 2025
 
 
 Authors' Addresses
@@ -4365,4 +4406,19 @@ Authors' Addresses
 
 
 
-Belotti, et al.          Expires 5 February 2026               [Page 78]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Belotti, et al.          Expires 7 February 2026               [Page 79]

--- a/draft-ietf-ccamp-rfc9093-bis.xml
+++ b/draft-ietf-ccamp-rfc9093-bis.xml
@@ -48,7 +48,7 @@
       </address>
     </author>
 
-    <date year="2025" month="August" day="04"/>
+    <date year="2025" month="August" day="06"/>
 
     
     <workgroup>CCAMP Working Group</workgroup>
@@ -557,7 +557,7 @@ module ietf-layer0-types {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision 2025-08-04 {
+  revision 2025-08-06 {
     description
       "This revision adds the following new identities:
        - cwdm-ch-spc-type;
@@ -1682,7 +1682,7 @@ module ietf-layer0-types {
         type identityref {
           base flexi-slot-width-granularity;
         }
-        default "flexi-swg-12p5ghz";
+        default "l0-types:flexi-swg-12p5ghz";
         description
           "Minimum space between slot widths.";
         reference
@@ -1777,7 +1777,7 @@ module ietf-layer0-types {
       type identityref {
         base flexi-ch-spc-type;
       }
-      default "flexi-ch-spc-6p25ghz";
+      default "l0-types:flexi-ch-spc-6p25ghz";
       status obsolete;
       description
         "Label-step is the nominal central frequency granularity
@@ -1790,7 +1790,7 @@ module ietf-layer0-types {
       type identityref {
         base flexi-ncfg-type;
       }
-      default "flexi-ncfg-6p25ghz";
+      default "l0-types:flexi-ncfg-6p25ghz";
       description
         "Label-step is the nominal central frequency granularity
          (GHz), e.g., 6.25 GHz.";
@@ -1878,74 +1878,78 @@ module ietf-layer0-types {
 
   grouping wdm-label-range-info {
     description
-      "WDM label range related information.
+      "Label range information for WDM.
 
        This grouping SHOULD be used together with the
        wdm-label-start-end and wdm-label-step groupings to provide
        WDM technology-specific label information to the models which
        use the label-restriction-info grouping defined in the module
        ietf-te-types.";
-    uses l0-label-range-info;
-    container flexi-grid {
-      when 'derived-from-or-self(../grid-type, '
-         + '"l0-types:flexi-grid-dwdm")' {
-        description
-          "Applicable only when the grid type is flexi-grid-dwdm.";
-      }
+    container wdm-label-range {
       description
-        "flexi-grid definition.";
-      leaf slot-width-granularity {
-        type identityref {
-          base flexi-slot-width-granularity;
-        }
-        default "flexi-swg-12p5ghz";
-        description
-          "Minimum space between slot widths.";
-        reference
-          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                     Grid Dense Wavelength Division Multiplexing
-                     (DWDM) Networks";
-      }
-      leaf min-slot-width-factor {
-        type uint16 {
-          range "1..max";
+        "Label range information for WDM.";
+      uses l0-label-range-info;
+      container flexi-grid {
+        when 'derived-from-or-self(../grid-type, '
+           + '"l0-types:flexi-grid-dwdm")' {
+          description
+            "Applicable only when the grid type is flexi-grid-dwdm.";
         }
         description
-          "A multiplier of the slot width granularity, indicating
-           the minimum slot width supported by an optical port.
-
-           Minimum slot width is calculated by:
-             Minimum slot width (GHz) =
-               min-slot-width-factor * slot-width-granularity.";
-        reference
-          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                     Grid Dense Wavelength Division Multiplexing
-                     (DWDM) Networks";
-      }
-      leaf max-slot-width-factor {
-        type uint16 {
-          range "1..max";
+          "flexi-grid definition.";
+        leaf slot-width-granularity {
+          type identityref {
+            base flexi-slot-width-granularity;
+          }
+          default "l0-types:flexi-swg-12p5ghz";
+          description
+            "Minimum space between slot widths.";
+          reference
+            "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                      Grid Dense Wavelength Division Multiplexing
+                      (DWDM) Networks";
         }
-        must '. >= ../min-slot-width-factor' {
-          error-message
-            "Maximum slot width must be greater than or equal to
-             minimum slot width.";
+        leaf min-slot-width-factor {
+          type uint16 {
+            range "1..max";
+          }
+          description
+            "A multiplier of the slot width granularity, indicating
+             the minimum slot width supported by an optical port.
+
+             Minimum slot width is calculated by:
+                Minimum slot width (GHz) =
+                  min-slot-width-factor * slot-width-granularity.";
+          reference
+            "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                      Grid Dense Wavelength Division Multiplexing
+                      (DWDM) Networks";
         }
-        description
-          "A multiplier of the slot width granularity, indicating
-           the maximum slot width supported by an optical port.
+        leaf max-slot-width-factor {
+          type uint16 {
+            range "1..max";
+          }
+          must '. >= ../min-slot-width-factor' {
+            error-message
+              "Maximum slot width must be greater than or equal to
+               minimum slot width.";
+          }
+          description
+            "A multiplier of the slot width granularity, indicating
+             the maximum slot width supported by an optical port.
 
-           Maximum slot width is calculated by:
-             Maximum slot width (GHz) =
-               max-slot-width-factor * slot-width-granularity
+             Maximum slot width is calculated by:
+                Maximum slot width (GHz) =
+                  max-slot-width-factor * slot-width-granularity
 
-           If specified, maximum slot width must be greater than or
-           equal to minimum slot width.  If not specified, maximum
-           slot width is equal to minimum slot width.";
-        reference
-          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                     Grid Dense Wavelength Division Multiplexing
-                     (DWDM) Networks";
+             If specified, maximum slot width must be greater than or
+             equal to minimum slot width.  If not specified, maximum
+             slot width is equal to minimum slot width.";
+          reference
+            "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                      Grid Dense Wavelength Division Multiplexing
+                      (DWDM) Networks";
+        }
       }
     }
   }
@@ -1968,39 +1972,47 @@ module ietf-layer0-types {
                  Label Switching Routers
        RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
                  Switch Capable (LSC) Label Switching Routers";
-    leaf dwdm-n {
-      when 'derived-from-or-self(../../../grid-type, '
-         + '"l0-types:wson-grid-dwdm")' {
-        description
-          "Valid only when grid type is a fixed DWDM grid.";
-      }
-      type dwdm-n;
+    container wdm-label {
       description
-        "The given value 'N' is used to determine the
-         nominal central frequency on a DWDM fixed grid.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    leaf cwdm-n {
-      when 'derived-from-or-self(../../../grid-type, '
-         + '"l0-types:wson-grid-cwdm")' {
+        "Label start or label end for WDM.
+
+         The format of the label depends on the type of WDM grid
+         specified in the 'grid-type' leaf defined in the
+         wdm-label-range-info grouping.";
+      leaf dwdm-n {
+        when 'derived-from-or-self(../../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-dwdm")' {
+          description
+            "Valid only when grid type is a fixed DWDM grid.";
+        }
+        type dwdm-n;
         description
-          "Valid only when grid type is a CWDM grid.";
+          "The given value 'N' is used to determine the
+           nominal central frequency on a DWDM fixed grid.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
       }
-      type cwdm-n;
-      description
-        "The given value 'N' is used to determine the nominal
-         central wavelength on a CWDM fixed grid.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    uses flexi-grid-label-start-end {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:flexi-grid-dwdm")' {
+      leaf cwdm-n {
+        when 'derived-from-or-self(../../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-cwdm")' {
+          description
+            "Valid only when grid type is a CWDM grid.";
+        }
+        type cwdm-n;
         description
-          "Valid only when grid type is a flexible DWDM grid.";
+          "The given value 'N' is used to determine the nominal
+           central wavelength on a CWDM fixed grid.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
+      }
+      uses flexi-grid-label-start-end {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:flexi-grid-dwdm")' {
+          description
+            "Valid only when grid type is a flexible DWDM grid.";
+        }
       }
     }
   }
@@ -2026,101 +2038,113 @@ module ietf-layer0-types {
        RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-Grid
                  Dense Wavelength Division Multiplexing (DWDM)
                  Networks";
-    leaf wson-dwdm-channel-spacing {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:wson-grid-dwdm")' {
-        description
-          "Valid only when grid type is a fixed DWDM grid.";
-      }
-      type identityref {
-        base dwdm-ch-spc-type;
-      }
+    container wdm-label-step {
       description
-        "The channel spacing (GHz) of a fixed DWDM grid, e.g.,
-         100 GHz, 50 GHz, 25 GHz, or 12.5 GHz.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    leaf wson-cwdm-channel-spacing {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:wson-grid-cwdm")' {
+        "Label step for WDM.
+
+         The format of the label depends on the type of WDM grid
+         specified in the 'grid-type' leaf defined in the
+         wdm-label-range-info grouping.";
+      leaf wson-dwdm-channel-spacing {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-dwdm")' {
+          description
+            "Valid only when grid type is a fixed DWDM grid.";
+        }
+        type identityref {
+          base dwdm-ch-spc-type;
+        }
         description
-          "Valid only when grid type is a CWDM grid.";
+          "The channel spacing (GHz) of a fixed DWDM grid, e.g.,
+           100 GHz, 50 GHz, 25 GHz, or 12.5 GHz.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
       }
-      type identityref {
-        base cwdm-ch-spc-type;
-      }
-      description
-        "The channel spacing (nm) of a fixed CWDM grid, e.g., 20nm
-         (which is the only standardized value).";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    container flexi-grid-cfg {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:flexi-grid-dwdm")' {
+      leaf wson-cwdm-channel-spacing {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-cwdm")' {
+          description
+            "Valid only when grid type is a CWDM grid.";
+        }
+        type identityref {
+          base cwdm-ch-spc-type;
+        }
         description
-          "Valid only when grid type is a flexible DWDM grid.";
+          "The channel spacing (nm) of a fixed CWDM grid, e.g., 20nm
+           (which is the only standardized value).";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
       }
-      description
-        "The Central Frequency Granularity (CFG) of a flexible DWDM
-         grid (flexi-grid), defined as a multiplier of the Nominal
-         central frequency granularity (NCFG).";
-      uses flexi-grid-label-step;
+      container flexi-grid-cfg {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:flexi-grid-dwdm")' {
+          description
+            "Valid only when grid type is a flexible DWDM grid.";
+        }
+        description
+          "The Central Frequency Granularity (CFG) of a flexible DWDM
+           grid (flexi-grid), defined as a multiplier of the Nominal
+           central frequency granularity (NCFG).";
+        uses flexi-grid-label-step;
+      }
     }
   }
 
   grouping wdm-label-hop {
     description
       "Generic label-hop information for DWDM and CWDM labels.";
-    choice grid-type {
+    container wdm-label {
       description
-        "Label for DWDM or CWDM grid.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
-                   Label Switching Routers";
-      case fixed-dwdm {
-        choice fixed-single-or-multi-channel {
-          description
-            "Single channel or multichannel.";
-          case single {
-            leaf dwdm-n {
-              type dwdm-n;
-              description
-                "The given value 'N' is used to determine the
-                 nominal central frequency.";
+        "Label hop for WDM.";
+      choice grid-type {
+        description
+          "Label for DWDM or CWDM grid.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                     (LSC) Label Switching Routers";
+        case fixed-dwdm {
+          choice fixed-single-or-multi-channel {
+            description
+              "Single channel or multichannel.";
+            case single {
+              leaf dwdm-n {
+                type dwdm-n;
+                description
+                  "The given value 'N' is used to determine the
+                   nominal central frequency.";
+              }
             }
-          }
-          case multi {
-            leaf-list subcarrier-dwdm-n {
-              type dwdm-n;
-              min-elements 2;
-              description
-                "The given values 'N' are used to determine the
-                 nominal central frequency for each subcarrier
-                 channel.";
-              reference
-                "ITU-T G.694.1 (10/2020): Spectral grids for WDM
-                             applications: DWDM frequency grid";
+            case multi {
+              leaf-list subcarrier-dwdm-n {
+                type dwdm-n;
+                min-elements 2;
+                description
+                  "The given values 'N' are used to determine the
+                   nominal central frequency for each subcarrier
+                   channel.";
+                reference
+                  "ITU-T G.694.1 (10/2020): Spectral grids for WDM
+                              applications: DWDM frequency grid";
+              }
             }
           }
         }
-      }
-      case cwdm {
-        leaf cwdm-n {
-          type cwdm-n;
-          description
-            "The given value 'N' is used to determine the nominal
-             central wavelength.";
-          reference
-            "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                       (LSC) Label Switching Routers";
+        case cwdm {
+          leaf cwdm-n {
+            type cwdm-n;
+            description
+              "The given value 'N' is used to determine the nominal
+               central wavelength.";
+            reference
+              "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                        (LSC) Label Switching Routers";
+          }
         }
-      }
-      case flexi-grid {
-        uses flexi-grid-label-hop;
+        case flexi-grid {
+          uses flexi-grid-label-hop;
+        }
       }
     }
   }
@@ -3630,7 +3654,7 @@ within the "YANG Parameters" registry group.</t>
 </references>
 
 
-<?line 2948?>
+<?line 2972?>
 
 <section anchor="yang-tree"><name>The Complete Schema Trees</name>
 
@@ -3695,47 +3719,51 @@ module: ietf-layer0-types
                 +-- flexi-n?   flexi-n
                 +-- flexi-m?   flexi-m
   grouping wdm-label-range-info:
-    +-- grid-type?    identityref
-    +-- priority?     uint8
-    +-- flexi-grid
-       +-- slot-width-granularity?   identityref
-       +-- min-slot-width-factor?    uint16
-       +-- max-slot-width-factor?    uint16
+    +-- wdm-label-range
+       +-- grid-type?    identityref
+       +-- priority?     uint8
+       +-- flexi-grid
+          +-- slot-width-granularity?   identityref
+          +-- min-slot-width-factor?    uint16
+          +-- max-slot-width-factor?    uint16
   grouping wdm-label-start-end:
-    +-- dwdm-n?    dwdm-n
-    +-- cwdm-n?    cwdm-n
-    +-- flexi-n?   flexi-n
+    +-- wdm-label
+       +-- dwdm-n?    dwdm-n
+       +-- cwdm-n?    cwdm-n
+       +-- flexi-n?   flexi-n
   grouping wdm-label-step:
-    +-- wson-dwdm-channel-spacing?   identityref
-    +-- wson-cwdm-channel-spacing?   identityref
-    +-- flexi-grid-cfg
-       o-- flexi-grid-channel-spacing?   identityref
-       +-- flexi-ncfg?                   identityref
-       +-- flexi-n-step?                 uint8
+    +-- wdm-label-step
+       +-- wson-dwdm-channel-spacing?   identityref
+       +-- wson-cwdm-channel-spacing?   identityref
+       +-- flexi-grid-cfg
+          o-- flexi-grid-channel-spacing?   identityref
+          +-- flexi-ncfg?                   identityref
+          +-- flexi-n-step?                 uint8
   grouping wdm-label-hop:
-    +-- (grid-type)?
-       +--:(fixed-dwdm)
-       |  +-- (fixed-single-or-multi-channel)?
-       |     +--:(single)
-       |     |  +-- dwdm-n?               dwdm-n
-       |     +--:(multi)
-       |        +-- subcarrier-dwdm-n*    dwdm-n
-       +--:(cwdm)
-       |  +-- cwdm-n?                     cwdm-n
-       +--:(flexi-grid)
-          +-- (single-or-super-channel)?
-             +--:(single)
-             |  +-- flexi-n?              flexi-n
-             |  +-- flexi-m?              flexi-m
-             o--:(super)
-             |  o-- subcarrier-flexi-n* [flexi-n]
-             |     +-- flexi-n?   flexi-n
-             |     +-- flexi-m?   flexi-m
-             +--:(multi)
-                +-- frequency-slots
-                   +-- frequency-slot* [flexi-n]
-                      +-- flexi-n?   flexi-n
-                      +-- flexi-m?   flexi-m
+    +-- wdm-label
+       +-- (grid-type)?
+          +--:(fixed-dwdm)
+          |  +-- (fixed-single-or-multi-channel)?
+          |     +--:(single)
+          |     |  +-- dwdm-n?               dwdm-n
+          |     +--:(multi)
+          |        +-- subcarrier-dwdm-n*    dwdm-n
+          +--:(cwdm)
+          |  +-- cwdm-n?                     cwdm-n
+          +--:(flexi-grid)
+             +-- (single-or-super-channel)?
+                +--:(single)
+                |  +-- flexi-n?              flexi-n
+                |  +-- flexi-m?              flexi-m
+                o--:(super)
+                |  o-- subcarrier-flexi-n* [flexi-n]
+                |     +-- flexi-n?   flexi-n
+                |     +-- flexi-m?   flexi-m
+                +--:(multi)
+                   +-- frequency-slots
+                      +-- frequency-slot* [flexi-n]
+                         +-- flexi-n?   flexi-n
+                         +-- flexi-m?   flexi-m
   grouping transceiver-capabilities:
     +--ro supported-modes!
        +--ro supported-mode* [mode-id]
@@ -4073,473 +4101,482 @@ during the model and document development.</t>
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+29/3bbyJEo/D+foldzviNpItCkLMmyZiceWbI9umvJjqXZ
-SbJfzh6IBEmsSYABQEvyxPdZ7rPcJ7tV1b8bDRCgKNuZmCcZiyC6u7q6uqq6
-un4EQdAZpMM4GR+xRTEKDjudIi6m0RE7SWezNGF/Ob54xU7DImRXd/MoZ6M0
-Y6/DuyhjPfZmXsSDcMououImzd7nnU54fZ1FH47Y657Vnpp2hukgCWfQ9TAL
-R0UQRzDeYBDO5kE2GjztPX0cXMd5MA2LKC866XWeTiP484jhT518cT2L8zxO
-kwI6O2JnL65ednDUcZYu5gDuyfH5W/YrPIC5sFf4sDOArsZpdnfE8mLYiefZ
-ESuyRV7s9npPe7udTl6EyfC/w2maQId3AOE8PmL/VaSDHZanWZFFoxz+upvx
-PwYwoSgp8r/BNBfFJM2OOowF8H/G+LQuo2wcp+x5NE2LIqYf0gzwepG+j0P6
-mqWI2WgYF2lGD6JZGE8BPGrZveYtf0qwQRfGcwY4KwBW9nyRG53/vAhvori2
-9xibda+h2U8TetvT9SmsBqwpwD6NsjagD6khgg4NKyF/kRcT6P51xN6li4/x
-gH6KE1jcF13nKY37JguTcWSOE1EPXRiEXv0ppTc8Qx3HMEn2apHq3l4uikUW
-wcTZVTSYJOk0Hcew2kbvITYaL9IuEuVPY3xIXcPeSIosvl4U5eX+OUxncZiw
-v06iZOxdENH5R3xhwt+uWYEwiaMp+4/Y7OyXJP4QZXlc3LF0BPsuGYR5EdkL
-0EWK/2kqf+uGg+7ivdP5q/A6g94j+GMaz66jzE+fosuxeLs7Vm9Xr2ySxYMU
-NlwMRFzXKX+xK16s7O90ki0+wH/T4V0dTof4mrtadk/PY+A+UQrc4C9pmujO
-Xly9OzO7ur67WyQ/RbDM3Szqvs+cbt4Bi8uG7D/jaTgtQt3NydXVidlNRu91
-P/D3fhoUxaBLRGZ29pd0AfC8jiLdz2U4yxdizUVXd/jWNIq6xW3l7P4zHhTI
-itN59LEG6x/ote4UX6vE+bsU1zhl52Hy0WZdJ3E+SK1Zzvg7Pw3wF09fr6An
-oIYQeOVU9/O/Fkk8t+l2POYv/fQ//LduEhWdTpLCCAUQPe62s6tfgqv/ftU9
-ODg4oqZCNP2RvjB2MgmzcAA0H+cgiHLcIvN0GmbxR+gCZM8sHUbAoPI5biH4
-DtDOoyQPASM5A9aPDbJoENEeY8UkLPQrEUm6uu42CAotCtRkzxIAKaE2IByv
-YCOh6IBZDng/sKkFPQ5hHGBP0XW2CLM7ttvr9+k57pAoj5NResSRwN5FXPwM
-eReEE46SMBtHxRGbFMU8P3r06ObmphsXi26cFI9gbo+ugncvTgL5vsLo071u
-38LpxuU8GhQZADzO4iGX87+enrNwPp8KwIFbn+KjURb9fRElgzt6dW1oeAOU
-CnQIWNjtNcYCzqMdHkQLExO7K2DiBB/dhB9gWsm4mKwXFadAlDOOi97jNrjY
-bY2LXQsXhw4u5E47nsHcR3E0ZLPFFPbaJEwSEFZD2CqRiYVh/CHO5VwYf3k+
-jW5RJzPxx25ieBvmA2yOyd5Srk6KtjHibBQOhKBeA1Yv0g8Sq/3D5lg9bI3V
-QwurT3pPLZyeqYkRaYFaI2cO2mmY5HNQPVnCVep1TR34b9RqYwHQrSbN3zem
-7BDSm6tf9hgo2uMgi8LBRK/uumZ4Gc0Lubqtptnd3YGzSpbFY3i+mLF27IQ6
-cGb+2Jr5SyT/ayDzN1cX7Hm/13vlxcNDUPnubhs8PN6BbQ7P8JCzAhYeG1h4
-uv/UES9vqiiczSd3Of00pVPl+hHyvxbTu1ZbnqBvNX/ZQs3/yb5NA2l2g0pk
-lGWw4wdAbSBhcDBkAHiyBSUDNmh+Bwr8bG0T1wK113hDAOTtZk7vG/N21r12
-5pN4PGHXcRFkqG+RbvFgyJBU0Fic0lxs1tBODlAHFnKeuDrXFe4GVD4jUjxh
-aGQUlVK1Rp4iOrNoHsFcM5DSUqCM4ussMpA6CHEAgdqHUGB3GyuwhI6WCH3i
-ILTXs/H5Ek7ALBwA8wB1PsV55wM4vcMegAnNYphNzrZedUfw2jYL2Nv0Bn7K
-pbqHeMeTNj4AZYdPdm1IkgT4tDmCxLZtjh9q8Obs5X/v9Xp/fWdrHaDBRcja
-effH4yyir4xerZqk4tt8tpxlI/HBvl7MjNmdhxlIM6/oBXgCGiTo9bu9SkAq
-p5rGIxwMz5qPbuYBWmTg9UeL+TQNh/kju/v/BupfDKLhbnc+HHU6CIHnQHnY
-e2ITzqsoAYgHbLRIBmJFcUJxAaSxgB0EB0VTT5tFwziUEmx9FBImy3bR5WIu
-sMdoFq7IVhN84pxpjp3ZVGqc6+MKrafzZLdqOvDeY1uJ3pCEyXkZ7N08Hid0
-qAeeCawOxgIyBWLJ42GUcS75ICf2gyZzowl0OkEQsPA6L9Bq0elcTeKcDdPB
-gl4aRiMAO2chAD2dCikJKzXgdvQhmuDR9J3vMJhRAniAAXc6OGMygcN0c9Ce
-iE7J6E4t0GYxRUxMw2S8CMdRl11NIi5vsFvq0e5kB0DJYMMM4aCfzqi/60U8
-LYI4MTpeCkoIhIbKXDKEnoAZX8PXGVIafL2+Q8AW00hYXQhKxWvk9QIs3ige
-L/ji0dLmwDSiziCch9fxlI8KTB4YT5izX7W8vITT5WAC47gXFGzr18s3F/k2
-dtYZoRwN8NwO522UuEYPp1LinpsSdwtVlG21U7ruEqo7C/bu5QldW+BMQSxP
-wwG2V0vDJ89itDcBI4R1H/ITMTKVG2ghRifkxMlguhgiZQyHsSDRmnVg1jJ0
-OdHN4uFwGnU63yGpZzA6kVcHSdeeQix+bkKIkk6wl6Wk0sWRIkVavAMLVOwG
-iYZvZUU02KlJrFLvQUUGtR5F4aBMjUb8EuGFwQK2rl5ssxEoRsD5ciSUm2g6
-xX+TNAmuXuiftqLuuLujziPYjzyjOJRIGgNQkXkXJhmqJA7AJPZA0OVic4Ne
-tiiQH3F5YuBdYEdODYkbLf7YgxyAT17oJtAVbXV76QSdeHYCdlS5GX777RnQ
-60H/4PGnT/DFshHCE1wk++nup0879NjdQjhM210khn9y8PTw0yfsoARB10On
-sBdy2iuIFo7emGvCQDXOPiM6wy70/uRj4g6F7hlqMyD6M7qjGkawIafIWCJO
-fHI3Yg/EgOgWUKoE1n5OoOM7YLSgpAwjQJ0w7+SL2QylBSeJ335Dg9c4yvG6
-k2ZXxUVMKG1OEuNyw39zhts+i4q7LjsrOvMs/RATq7D5iAdWzXhiwWdgKM7D
-M8QAYhL3q97tc+wuXeSgxgpy3oHdDksxzVN7PTr169HtVOK7jBvGd4Yj0crU
-j1sUVD013oU2oJ2HCQg+egsvsvMiBS5jKURye9IC/hsg4vDx3i4N/9137AXd
-eca4c1I4pm5dEVvKoln6gYsyZPb8pe1O54/8LQGF/umIE3Au+GmcC/Ym+5ln
-MVJLyuaLa3msK5GGWDRYC6CDaJJOgZ2yD+F0IQUpML2h6pheEoJlhIef+CN8
-Fa/DywhgEc+IG5mjckgTnAanXGgHDYBrCjrCcxUIm4VYYBwYGTcOHg0B6LfT
-KMw5N7ujBiMQJOkNEq6AirbQEcgm9mf4sCD4I70X5oL1I96SBZmxuI0UADoL
-TrHBX+CztAGsIrxO94NBAcCgh8HhkycHwWKOGhwwGujpr/Bp1RN3VhCcPgBt
-JowznElQpHO8VL4LcPNj5wIDYrYWGyEVUmKSOzuUNuomDUcGsV5Au29T7lta
-TXzHWDGjS46nHbbIpcLB8Y+HILZ1F4VZAJK0mATD8G5bL9UMdfUprNYovtXb
-tYCjWW5wNfwOnOhmEoPKNQE+D3QWJWyMh6dQ6HVzfJOEA72QpzPUCUgRgb10
-RcdwwhW9A3uFq+adzlkiRD3ojLdFSULu8MlAe7bBLYW9DcDbiG7uaLN15pO0
-SEFnF5ZEcW3Dv0hJLhRkz+GuU3kkYltvri62UWWw+IRh8kV5qB/AQQYedGy5
-CYc1lKUgN+bzNOe7FCHBs0aR8aMMCWu8/yeYlYiB0XcE0nGbAT3g69M7Pv2M
-9wU985n22dbr/jaxjhK+ZuEdZ9fAHxYIBFJ4Smy4fPVQGL4SUjkaAPRRFlwD
-zQD3z8JhnMovyNKBPkBDQYonZObyt6gYdLfNOUg9iLgJdOrRiIj1v8MZ4vSE
-krC3d6A0Enqwf4gqip7G++iOJp3z+QkxgV1pQsLmkpgkMWIPIDjRWoQbxxE3
-ORuECSCNNN10kRiS4snT/Z4Q4hGNDrgDUbhx/svl1cYO/5ddvKG/37340y9n
-716c4t+XPx+/fq3+6Ig3Ln9+88vrU/2Xbnny5vz8xcUpbwxPmfWos3F+/JcN
-PrWNN2+vzt5cHL/eKEtJoh9+FsMjL4h03LZh3hFz5yh7fvL2//6f/p6Y4W6/
-/5QUQxKM/Sd7xAKihI+WJkCI/Cvg9K4DTB+YDPaCAgOOauh9BNId6DOfpDcJ
-g1UCDeDfn03RHhkcPPtjhzjDWyBm4D3QjpzNLvCu/SKcweEUkX6WuNwAvQ1o
-h9AqJelQHCc4GRiaQnr9P6ity9PFnMaBeWoOSW5gaKTmv6EoSAcxMTTJbbE1
-Ga9hiyRDRSHqQCsVm84/5ET45x+WzuX9/IMTeZQMImhdRJzfi5+EADOelVr/
-//8Fy4JC8W/QfNorNzfFiGdwEHcogzu/HbHvivA6EAjKuaXlx4238jti14MD
-PreNT3i4lGcV7ip4zmd9wg12ebXBw8TRiK4J6LhnnXx2ypPp8g6l8p1rloYH
-m9IBBYWBcXQHmjtTh2a+fTdKQ2w46nLuqDMEeRYtcjqOcppQnYJ+A+uBg1Nn
-R50jdsyQI1ov3qlbYAKTzjOuqMGdd7Db21e879/4iekpcZ7BzXAWDCZBPh80
-G+gkDTO/vaNjn9RO6KQm7ucD5Oy0Z+pBBIiGbSGixVkyTqc8Dl/eZDAatxjG
-oImLlC4F2Am8hzcAL5VnyysQhwv0/YHWWxcnL19tM+ABlTNXayHV/4nQr4k9
-kspNQGBPit+QOm6pEvLIDbR80N3df/XzRzXJfJoWwU08BNVtrGFrPeNL6Ib9
-it3YU7z8FWaI09upnd9R/fSgl2az6+925eyiZSSCliWuOciLGfbyxQnbkleL
-L+hq8URdLfJ5WBaxTBmeYEQUPIHweW4zqNEhP98K8XENh3FUfx+RROMd2yZ2
-9B/F8z+eMPAKyoZHX/QF/BCC3HEtkBkbPI+kJW8WFZN0mFet8yEpszaExANJ
-T68EC5QK3hm3GsQjEmkF000lG69So8lEjmcnpQYHN3maBNN8wEf1E3gDsy8I
-ktn1MAz47+wEzcfArcn8Fby+PNnWTgdaB2fKynxXhalD2vEaXL3NlgFNPiHB
-K9yQFbDpN1aG8PAxGvQAwrMCtxxgAnAEp3pOHXwDZyQ3QbeNE/gCqhpoISDP
-+Irlk3gOqmJxg4c8BLsCVgLQB9ZOGajHe0/60npIyyfWgB7Yk9atUeVA6oWV
-vnNXwBCIYsLsmNuuk5wz84gfHTfLdLVJjTerVnDTFehiW3CgQmX/Nt9QdnCj
-V+zKRUW9dYKrJzrqYo3qiTbogXoCB69M3HoFqC0bNKve41oV7G8+yxEe3PHW
-LEykX6w4G36IkmGabWu2RP6yRPJ4tuRutibR8jPHHPsos4VLwa52uyAJkZ2u
-YobJk6x2SlkE2m5OByOYhmAb2+yS+DR0FyRpjGYcnCcwzjBfkHMFzqPX7bNk
-hqSZTskQBlwxGZKAruZx5MGAgM3zYVPAhJeCcko9FV4KW28vT7frhur1cCSg
-o1fqhmV9ZKRubYCK+HYKr1F1AzlXBEAIOLsrsb8Z/cYoYIPdVCuOmiuM+XV8
-Ry6oOMrJEwO3nKnxHvG/I/NYfgjnctxHdEKQwNIJNNd8R1Gq0RnBoDrUDgRo
-F70kCzX/kWYjTA+zlPgC2bG7zELIJJ1/JlTASKXpi1sTOf9O/fx5D23nS4cc
-452ALsE1cSvkk8wx4ZbnOxMnxvgd56KPH+qqjx2EZLcvFG+yATA7bmbH7cOb
-7u32HnO91iaU2LQfRaVj5PUdXcbCi4QKQ2xIlHbmYRbOMDQqb4xHax9F86U4
-5HPFV/MKBHWWS5qmwJmi0b/VDSQtpXJ+nlBU3hFUzlbY8B17w7srqUnes0rV
-G98kRKFuS5ogVZdby7hhn6YJEir8ALgick3EuXIgzpUyYiKOGlPDEaoxllVO
-y8THIHtQIiqdZ2cFQEjxG37A4C5pNpn92JdGWhB28moHfwHxqDt1O7tj3Phn
-PMDTKteFPC8HfcSh54c/9AkoOZCP6gx+2obeJJpa05uPq9bQ2DrZamnuLdhr
-BW5Moiajr//I0FDQrc45GjC30gw4n3so9oYGKw9f84I4SGfXikz0VTfuvCom
-pYUa9WDSaB6hqCjE0canSzmWTPfnnQ65us7p8sZxQ2GgdichyDwV3kYKHrtO
-6U74NhoGTu9oHnnfQmYpvImduRLGmLNHWmAJW3rxAz98JZhpsG+XIqisHTVH
-kR7fjyn9+1eCsFoGsRRV2NrCVIOdFlUQEf7yRZFiHJ0D0+/Rix7LBuc9dNNV
-Lt0A4w1yNOxsoODLN7aF8wbvg1+MandnbrdUIQp0ekcp+OskEvdyruLM9YHo
-FhX4uCDbgvI4ykBe4t0gqE/hYowHd4BDeD9OoxD0gRFdaCeqPbckFNFsjv4S
-hgtEhgYM9ue3IR66SXGBxZ4DT8ylnRQtXCUIw0HBvR0QVDLav7gN0S2dLhRB
-mLsItFCvu+KXwlwrxFVW02H2dDq10+G3kuS4pQ4c8kbM9B0kefestRVE3pY7
-DemKJh4FdE4Rr3ZFSowwG7rmIDVnacJUl6ZEQH4bBEVCUremvahsa/JRMHdH
-SNDBybBScdSJzUgOJ1bXOXohcDuUz8DdGncAuUXDy3fdNM7JdyUsuNkfUEPm
-VO3wMY1nsXYflDGvGga86UyAtHLuE2HsYot+1jM99z6H7wyG2DXckXiEzGLG
-0sEAJs0dfYCg31xdxoy7iingyC1FrA7uAkHQNivQh2PYP4MQNhD5QvPtBDAP
-Fhxl+o5eHQqC63AxpIAxcehJp9MgHY2UwQQ4F2zXLIth28qbRL0aDkstFnhZ
-whlwI5uFuR68MRfNkv0oJ1wBSjwDtCFos/CW/haN1Klnx3RJxqOJPg+JV43r
-PrzspbvxANgXodIrCPQxVdGluFI3yJJewnWcTs1ZbeZ8R8NQwEjDaXEX0P3e
-ctIXrxvXgTJcTf0kroCky/7JBJg0bNwBO9VJGrZO0Kz51ky8cI40Y77y9rzO
-9HlwcMB9b61OTkkwoEn1dZrnW29PX2+TdRTtOa9JccBl4n+9I23rt+9M8dzp
-lA/kNffynDq5AxopcNKim3uOyrl2P0RRYcCk7rRQxuFVy9tthuvIxrBYCX8R
-FAp1bOciA/emkN3qQp9J68HWm/PLbXZOIUwnIvSeTMRs6/zklfBzs6bZXugI
-f6gcdrmBgy0O5HJUuO43fJ4495tYaA4SXyl3NMKdI5GBvqqY9iWEkeCgH5Bb
-GrQGtgPdYVaPkG5ESVizrbgbddEyUP0KB3uYRpzViT0OTe7Y43d8EJRQabbd
-FWRGV8Cc88EbdsCKTRfokodbBf7Bvrn7M3rnhk7fmCUq6pgXI0+QP6+gELhq
-JkJqj4W7/9g158SVUl7ECYhrtyIeL9JFbjTnh5eBytbykXMeFINVBiruHkrj
-0p0Kt+66XcLKpwMpXEMPwItEm63gFe4c5hCcoFX7KOExZ0nNUqwrLqHy2CFX
-5jMttik7CNf/8Z2dasztSlZRjW1k0rwz3q/MlyGl25brAETxTdgM+3UxbMQV
-K7smavaLQl5q2nvfMbDjsQqkkfsj74V0A9K5eTxyiOobkASwqhhvYgFN/xs+
-IvRuStfJ7EfW33tCl2l/YAn7vjw9dfEGYyazbd4FKO1cu99MNkukacAV5nR3
-PgZAtuZpHuMt8g6cdsYh/wvg7G07q3faePX6rVbv1Lt6rrNU7eoZesMXXr0R
-LtzTx/1er9vr9dirnz82WT947bMtoEi8sZ41JD1YsaNWS4QHPLlGO+Q8M5RM
-xOjRUPPIHWtHEA2IAuEt5QV9e0dmsqqFxe4e3dCM/oWvmb9/y/tip4LGePSW
-6ZjNHcZMosut19GlWCj8XOzw6JQwF/fOuU1tl78Cuc2AutDFrExRNSR5AY3I
-7W5VOhTANqJD7lAyq+zoUMjJRPU1zihnA5400K2CwXqhz1jK+pVyydlgO3x6
-ODIip2RBKEVqcEwbRi16bSrc1vjxWV9iiHgh4eQxIgOO+45JXMrNUQAkQxG0
-Tsu16yVaoIoq0gJcJuICPU1GT+VRwUBxJY8MVyeuGNdhzdxkI4+ZQuGPcgzJ
-IJzjgb6d884OV1txXBVCcadxpY9gZpSO5w5dn7O21O0u+VtyJX9bRhfW2HOd
-Lsps0duhz3Lt9CTOGbRIkorI5qk8r8tjISG8wJxHyJvuJJ36MW5SRxTzABXz
-htMyCfhUG0m1caVOpqZb0Wnd1amnd60zUCSMTPpEKeS2j5R/d8BdiCUN2LaF
-Ox4HQwuDWI40tmS8GOCmS7FSXlHHuKiLmmKZLMHORrTQoS1thqTis+9Ygkw7
-C5n0rTaafBW0iUE0L7R3hcligeN/z/x+zlKUOrBKAwuPOZKuihrU/AfsEi1C
-RrejcEDHqVDaJ2K0MY5q5DFa5IYUayd2qxpXv27aJBsvAAcvvF03eMLWdF/w
-7A2rQhb9LLLaHFnBJXX8h3GhuaO+4s2m8Zu4oQk5fQbXcTEL54LFV3txGIHI
-OxSlpGNEFCkh1gw7DbfmkeSxzfntGLr3IndVjl7VQ2uGXtXRqvzcxD6skEZ3
-O2zjnczakA1wrI7nUuMVUFzqYzXsskrkKk1oiUnie0psQHJPD0IiisTSDhrd
-pTKf+1VLd1frg9kPsv+yBPL13PBkwrXMg53dfVLRHeO4yRLVRZTibEIqA5/y
-+BMbhxKMVCP1+FyHnNmRa799p7M4iLA1M0YtkwF7ueO0aQdR2OZg2xHJTO2w
-49qud3wnVI/ZqHTTZj4qhSVTqsryIwcASmVo5QF5+mTfeQUT27mPnpQfoQOy
-OBKqnGSEfjx3McRwR8buleIUf4MjHa3BB2Hz73f7P3R4kmku7TcWWXKEDY/o
-Nik/up1Nj5L8CFsdlV2csbGI75RBkj9gaCkP4XQCLX+jA6V4XT79gR6qtRdn
-zg0MoMTwy9qKCSI3jZmYhiD6hCCYN5jU6wYWN/BVNKA2dI8+4PnSNuDA92t0
-fcTYv8uUaehMjgmm3kcZid8udP/oZvyIzMOPREJfaPYapPYR+3dMxl2kR/Tr
-T/L9P3b4azJ1hac8gP7ILvg73edOJYBSX54yCeXO+Evd525FhFJvTk2Eck/0
-Qve5Xf2g1E05mX+5p4o8/n+kVTGCGfjKmLGpUtVxM1zpzEjqXT62SuSi82lx
-/xJuMTE8o+EcLHrjLV8Sfy/n+uGMlWTBVin+kzf1puvZ1qJjqzJNFm9vNdt2
-42/dBEldsQQn6fwui8eTgm0NtjFZ3D7V9oAts8gLdauLV394vy+CUGKe0oiR
-MYXyuakbdWTagNJjEBrULV7A51HGI9mozbtoGOdcjZCJxegGGk4O6SIbRNy4
-B9IqI2vGLOcnet4YNjN+SRdkNlFpIkmHmaPfTIGiaL7I8kWYFLA8OzL7EMO8
-KRiLrj0BBoRQnq/ATMjD7ZHvMCuInOjzy1PYsrwBWj1GFM4FMMv7oL3uQKJA
-42+T509lr6MxoP4tUlVOfhLvKMaL3+HS66ciLFs02JLshAqmRJFmJQJqsgps
-S5QStiPZOYBBfSIez44vjnmuknyiAuVlPgWeTEGsZKHtVm+1f0AWjXGx7vhO
-cICjTJhhEhJgOngyf0SiQ3sZKDhpo0mRIlNOWCmccnROIBcOGRn/A128UXNa
-FXgcF3k0HRFnHy1g6lNCL8bWDaJcj2UmhNjERBCbO/xfTOuAf8uEEPg35YFQ
-f/AuxGs8F4T+SzdXKSDwq5MVYnOHd7J5fvyXTW4l3pSpITZbpIagTtz8EKy/
-x7YQFZgdYpv/ibkhtr2pIRT27liz/BAbJJtVWhzkCkHvMOjtCdHsclvJb1UL
-ykdlGyYwO5UZnC+4e8Dc67Mf9E9OgLn/l4P57v54Yvymg16Nh8N5/t74+nf7
-63AeOE/+Hs4OnRfsJ/C1f1B6w3oE3x/vll6xHsH3g73SK9YjGaJtPBoH8ND4
-Dkp4lDnPktR9aeA8cF9wfzcitc1+s4/B7nzffZQWi77zqN/zvGROPi2me929
-IDcHHaXxoO8+9MZom43iLC+CUVwEy96Ew84wnS19DdMyFQFmuI2Gy1/GCMGA
-w7Ds3QUl8Gn2Li56MKfO8Qhr/MIfyszJgcicbC6l8MCiF00aKAXhen+0A3El
-RxX8e9kmN0Ncdd+mY6NBAYbuHSjlIjNecEJkjTWXJ9igmHz0PR6bj/Mks74E
-aRbAsXeqHw6jQTyDUXY9j8pv8xUYh3Hie1b1/jTNc9+zqvdp6t6HVS2G1zPP
-o+rZ7nseefrOh9YX+UZLyjCiVlVvHuPYD/5fo7n3h0nqf64vT8wtVeFU/EMF
-pf7gJ1VBjOaONJ31jOeW46W5QbkfoRqsvvcqn8lyh9IxsfyL2QepZvWvyJyr
-wP8avI3eCqhvlN4FaDGnjLYbmlxbbVV3Ms4vAar8Bnsw8R7CL5hsAKABxSl3
-f+I+6rjEJq3SkTCE85LwlhSKu/emQme4ku2FX22ji79JmPO7X5FoUvaxdb0Y
-ozEQz2pdqUPVmDhQE25TFFKOI0+gwtxhK3V9VOr6j6uVujM0eIJqLVT2OgDR
-lqZcVAm2c7r9Lln3tOHl0ffYwfdmHij8/ojsQjJnh5nCqRrQ53gdV05OYhpk
-824d+GhCxOpp+oKeLq0lbo3EG4FIvCExrD+UiWPH8hxFEngHh1XAn3yfpycX
-ZkS21d99hFWmto9Yk7pXpUG9dbAUhhVGSNoTHlHbFnikPDImfn+oQm91xirm
-y1iFHa4Z2xy5ZZx/VmS3x/ZwFWxzG1K7pOgPgPJ1EHgfcN57hHUpVsa5p+bd
-DjuZUtTCk64H+wZfXg398i6l/Qoo7q5h2K5dFbydqFwVZGFGqqI4EetUxpE3
-JdBnXaa6VTr0LJJ76G/D2k0vXCtb3bpZfEums8N0hoDHX5YDEXp3e4lF/X5D
-iwfl1NC5i/y9Y7YhYl1v4TZ0W5ll8Sui292HYQ/eyqUV2O33enB0NwnXRXol
-4faF26lDu7979LbA7v7KyN3/18RtG+SiIXo15HKHi2/IreMLaHVelTHsdr8h
-uAbBXF8tyzUsuLLIVU2Uep2ZXzT7BNyyEfkVjrW0JYh+aAUQxlT4FrwSEnXJ
-VC3RjUm2yVws1wQ7/9c4DLQiOuMOz0MAzt1f3Uq3WZNv61BaB7/nd6Pd4PeL
-/objMo5vxj4xVrcAy0XaN+wvxb6RBruSnq9L5zUnebbP1oReBeZKuq4HnnFO
-ZXJuNKy/nWCry0k8Kth/RHfcnPT28j+2jZ584/69/bh/WoTDjGrteUf9U4NR
-hZdE2wljRJ2VC6IWFLnGgIegCVDoltESokOW382uU6B3A5LjGRBagYkFzvW6
-bx3+6fh8uwoX9xm5FisKFokMEyTEy/H5oRcq8kBpCRM0aIwOGLh/UIOP+wx+
-X4xUAEYeNy2hggZtUPJ4d7sSI/cZ+74YAbgqMHKw1xIqaNAGIwd7NURyn8Hv
-i5IKwKSPVWNznq8qRkVBDMXQXr44qS+O4QGMPL0sXSFactSVtbSrwGFbrwKE
-pFJBkBL66ZN99mG32xNCuodCWnYaUacD3SnIy7JwJpdbLGCYqKL3vjkq77VW
-87zEVjWzvGw8S9BDPvTRhNx7AvPsP15hnoxN4vEEa5FQbiyuljSaPHfTazXz
-ixQrsHgxOWiPxiKMM4pmrUHlST0uj+GEfcuOyfFYoJWiXRCtoOP1ngod783V
-L3sMcwOhv8hg4kekrrXhm2F7bL2ZR0nN3N7Q1FR86yLnAVMStudpHu1gnqbF
-cLLIYnKs/TkdoLo5nkQztvX85OdtvRw1hEbBPrihUOvtI0Z2kdDkZeObqwsX
-HxpTGie5ulXrH3T3unuuWr22UfiavvDdLbVegpM0wTRBCaUKouJBnKCcjKKY
-gQHPCkzRpIR1KWlS2AGPUMXcDol2IRymC4zpi25FKfTL04Ag6O8e7pDv9M/h
-bEbZJDFwQfkInZsJmtwUkQOxAvuPJMJ5CgssC6wOOjzDJzu9/BmawPYPh7yK
-t42KRmSzykZSaymX8rg9qTQdQpHL6YOOIQl/30OUhq9yUxlup89bUkZKwlaq
-JrV0ASk2kH14TIIUUdA/BBSQqkKFxCmmUloph7KMd+ljXE0OpRvCzHRDMA/K
-/h4wsBdjdqc60FRGBWk0uw5k1qdUpdTwxAAJ6hNvwlvc8sJw/cq94QQYs4pu
-c6DZJbhWH6MsZVsX7/667V8rkVBRLZTO7llaNNzAec6gL4apfZbrCBiUyT4c
-4hJyHQGX8M28omBthVyTle1FoVgPZT/u7nYPKpCI/vWrIPEiTYJ3Col/bY9E
-OU1JMldqur8k0EWaDXnVW+BJ/e37b5c14Ho5op8Aoqvptd+r4SGfizD7vc9C
-l82I8kk1Ue5+kZ3diCh3iSh3//mJUsXJrILrOpSWCVGCLmslYiAJGQhDoMje
-KzVnL8KVNop4x1g0lDjNDhioC6mbMjpdh9yJGmXwKF1knpFfh6g1wlivlx/z
-1iOF7y2E7y+Dq0UwbtS+z7ahIqoennwk3WglWJEPKn1v2JkqpIi6FVHNSZ+j
-BTRaXFBtLnlzdgJqb2MyUg0FNX2jiWqa8IaetfFlM7xij3UHW78eb4sKp0vu
-nw6fHok6f4iiF3g648HLTucyAXN52m6MvY/y68MCze1QE4vnwccxT3lspCvT
-7flxMVnMrmHeQ1nzKM7Zr+oExjEEi52mwtzg7UnnX8YIw7yQzWM4yN5+Dfit
-C6ZcHblXHFkulqwaWAaSOBDTZReenwUhy8NG14YWXlGYE4+BDbSoSNAnoSyl
-lY0jSuqXx0O0n2Pk24AUC564aJbCrxxq2RbLpIg83jzNP2bLw4R7xNpgTwF1
-q1wSy9wpPg/ul0Xh3mu7U55ra5djCD2Wn+GGApRkO+w6GseJKDDAC9EqfNIO
-dvJrz7N0DIvC82ilJNQQ2WhKNra7bmMUdKBcF9CSEnPaabl9ZtOlYcfrRw6+
-2hQ7YsbN0GMzw3Vgxwm0rpaD9A7PESuvn6gB6UN6fAnbsiIAOEnMwg5oo7wZ
-Ptj8od7mcnnDxCuElhwJtjGgGzUEPiXZP5P9b/366OeP3qsyK7R83XBsDZ/P
-vKOWA9etoUWOqCOr6nMlBCsXLVcqpqpdvozzHR6xV+dvX1+yN5dvX7IXyQRL
-fNOGQ97HmSLRwUXV0fEFRxXGfuryT6tzTsPntBbNdgqAeyDb8BNrVmy9FqWY
-wM1EaXD1whQomJBHlgobGV5MZby0Cu4qNy+jc89UtGVoK0a8DqOREdha8Cfc
-dVm6I/FL4aSQ2UMqzmI8wTIPWd682LRLosqqYZ5sfyVeacdC12RQ3xxt7tgp
-mw0frIp837fLU9DvqPH5xYnTyxZ878ID/H6FaQhjrsjwg9smbKGJvoZV0G7q
-YufE/DHF0AeRufhUhgJzfZxGlR1sOuBuelLPu47mdTS6NrfxLx3Ap8lZEu3g
-CxCtVivqqdZQgqsI1tjtZtWLpSSLVS8cghWNBWHyKg08d4OkTwOgTdNtwE+g
-Jx4CLVOmOgGWCNSN7fsXDL+WRCocx3+frNVfSuGr4qcEYplCHX/+b/7JLsXO
-TIpdtCTZ8xqSNco4KTo5Nt3Gq6jQeOVHdg7U563+4RIfVcGoWH6/j/s3WtC0
-YKUfMikCU2bW2OrPZHYcspTZJm5VLNQA0PF3OSsYZUbE7KZiKFlFlVfyZaIY
-PRWHMQ+5wOJgOlPugWnkfBZOMvvdx6ZfGAH0zTJPeCkvfkU6tBZkwEvDPDI7
-YkZHtIjk4xayeRZ/QLuNmVYN86pi+dQpJnS6M5dTLgpfIgNzlKa7bgP/FT5V
-mYHk6fRMl8sLb8LMs5xXooqePnDtdvfN21KFQydj3Mp7yMKhSODL0butnX5n
-1i6S5ZbCQpWM4FuJTLGU3dNmiwrv5liqshiWfgLSjGX1HZ6CnptkZUvyTaVS
-vWRpc6lTQWrET3wd62Tl7zMXSeShU17iqJKE1FUwjMdoL3vKZ/GJ/rtI8NEG
-6DUbteLS4b5A0tBkh/F1JQWpv7tPOlIdrOO2sB54YH3VHtZXFqx9DP4iWLse
-CZJkHhADkXhTgDB8/lOv209m1XBsiTXfllYqoN+LNAbW9Q5piSk1gJRC6AzO
-Q5IcgCLTKU/vfA2ih+seyz2xn5CTIx4SdvvA7+mmH1OPRar2OSXz9rL7Vsze
-78adRXMqBhbpbNmj+DqLDEdunvRbuHN7US9TI1rKXKIjzyQnSlQWO/oezeYy
-1u/T51oRUSTkfZLeJFRADYukIxxCqcRfZftFQq95yE3RV7t9sbtkssdGHwIc
-ug29Ae2WeqgDpeEiOFujxVIshU7gFkUA/x3YOWGQacrzoNtugBVpq9Cuk416
-N7uaKK8ntdHrdmfh7YaHGQ2f1/MiGgLvc57XQtEQ5bpBa5zbwAgEk8u1wqxC
-qUSxg1l+yYCdPMK0q81wTG8+LI45XGFRRMlC6Gy1CDdzxjZCODZYCeEVkK2E
-/eYoJwWuiRBrgtahCLgdREuwaiXWbYRWanEPvLqgrYRWs5MmyB1ez5qgtkY1
-0BMgqGd1Q7XCJ7x/D2xyYOpx6CBPolR0UI8+lSC5naTbX02WjOIP0XJRt99S
-1O2vS9QZ4FXKOondavw3lHX5sB3K+z6tG2+0m9B0+S787eXptnHIu5uTbshB
-P2KPu0/Zi6C/t2MqWahc//ro/OePDdTenvIqforBMSHWXRkMojznRWKveemH
-jHGbnuFdaX22XnVH0HSbBeytfx7WUdCL5aabNR+utE0Bj612JzYwIqqa7M3+
-YUtKOVyN/COsbYN5nZfu0P5hyy3aP1zXHnWA9OxTidqlK1G7T+Vt9yuZ352+
-0nW3SoTtq7D7W9V8RJ5r1VjbtSleC70vdsziRngHoaoayjnRQEba719VRUTd
-U8hrAFrVEMlZUw3NS77IPq4j2cM4KrAsrnLR9BacVKWHWGWNRNrkIriQA+Op
-uyg74XAi7tDGhBQkahmJEofccoTmRdP1zK0Y6qQoN4x8oquF9nSxCrNJXjaN
-wpFRTteiYulKAvxO/VCZfVeStI8IBM+gTtORyuUtYShz1DUmOm6a6rj1Dadv
-KOvWoPqOU+KKkD/P4tRIz2RcGinm4cXoW9kOFlu74uv5nciaCHfsVLQ3LSVb
-Z5cnp9tLl2Bvt/f4SHg8VfnmGAvkQwo54QRvs7RIB+m0tA5b5AG0bSDmk8Vt
-vLuxkt0gnWk+ICrZwoLpQraSbfANeWe8bXEbpx6GAoeuw7BWKDpyCadbzgcF
-5zd3oNq3NTXJqwYSBaoq2VRd33SR24BLKX5awayacSnZi2BWD8Clvozrgxh8
-MEnjQeRhkt5tyftSOYJljmtj7zNecdxIaE7LiLzA8iTjHxLbmyKtSIDetqiD
-YNG0rW73Ef+fAm2Hbdqz+wPb3JBFOo/sXPYb25vWQP75iFn9J2DYKEOmSzHg
-fsCJakaCn0/G33xb0MTMV6oGox1cLm0r6rPbw5R5FvWwPtGBn9rrZQMcOedP
-5iIPPIs8+EyLPFjrIp8sX+RB80U+EVewhnTEe4EFFVKME/jj86/0agu9RGAB
-462UVXwoesfksLLQ9u9LArnV0lEMyQ6W6cyVYkh24NOZm4ohJXhMafQ1iSH5
-4mdKkq8EnqdcT4XMe6UqpROT5sVxd1hUDLrLZR5RiXDKtdMNt+KQX78M9B+n
-8FOTALvcVyVPfa1ZTuytQQ+qNvp4ybtn7lW4Y09znz9ku/v8X6AlfkFN3odS
-rfk9iGGihMHnp7vPLpaX0F1lzVa2PrpLZkB2cTcCstvtGVfZ/CMLwexodxnK
-rIEz5sYqKdPkm78L5WCS1ugGMvWfftWrIvyuzkf1wkIMw334aBNSrkFJa781
-IdVL7gAIg1JjSag2OdHgwlXQ3i9VZzT8VBxz6sAhkNp4rJdXptIp3Z4Sfvy7
-hGBo6RxbxaLlx7aCVbnK6o/JZT6VFoIWqrwOwTTOC7xSkUGMD7suOS0MpgO4
-78oQFilHnwa+3NxLmfj5Z1vG+xyL254qV4n+sLFQjkD6p1F1yrKmrqpppeDR
-MZ7u8Yu7xmTRlBIeGuLovufHEpzWrYvvZ9OcKXsx7l6M66Smp0nVS8UNzLLT
-pGzvtW36T5Pku+05OwupmiZFCF1l5mxqJavxHvcuVnfD+KE9VlsYgqZfpzA2
-LHBgkiYhhKrzbpTKJhiU7N/RG+cwidliRnpkBHRU3OANqA5lyc3N6duareOM
-/VuSzrfNooz9HYi6klbKCxNNtDj+ksXO2vBgImtZhMta33RZc9fAi95j6VWL
-4QTSyd1bgWIHE9WQLLBnKCot80XSLXOOT+4aj+73wgUXH2pmgZ/zcuMYM5VN
-BwvOZqwgpooWdKxlP7qo9+Pz+4pNsHZSEsFMX5SiwtsHoijK9bDZZX/8kcEZ
-2Itp+4RL2beDWZTn4dgRnufhrbui1P01ninIixtjXcilgdJ1GNxaLbTTQfcL
-bIPyLFpsg3LjZdug3KJqG3iJoGobWGCdjaSjEWa/8sywYp3MPuSS+VaJRkAv
-lPIoZhc2Vuo6/D3t4Qb6XIP78CXuN9ofCHVlZX4Rb2mlpiZs2jgUiMiqMPdr
-d83v5HUb2Yuhgm4v8wNyR/R6A8kulimpdVq07KOBlupXT5XWuerVOwJtqq6f
-6er9CwTymv5KdloAIcfEw1qfmfsdEMtGFoNbHudiyGuOXl0Oso+MRHKeHX1d
-Z6mbOh9e1faSFUbC4YcoK+Kcm0N1D7Mf+9KAOovCJJdRvpmdbq+8axPjCoAI
-Xv1CnJUSfHlaBX1EmZM7wUzilfyhj8hVQ0uKasTYVrw39W/9fO0nVOems5oz
-yx6WMIJqDqA2ZzNPwQoO4ILR5pxqbDl+gVFxXbLMZ7CiDKjpOGgdFe2Coko6
-esuG1hmbrauJauFlKkGKmq0bM1mecqnT3JrY40oM8pO7Zpimo+UaOZU6K1fI
-rPe58W0hli2EydYau3kSwwoLnpZZ3oRxFBrHFjkfdeTQkxDma5BBIO1MifUS
-D1S34Qx01B0hFUN+uSiyRVQuke7DtCLBCHJhuJRzflwKXz1ZDNLFdIisWlbL
-7Oo+zhKu3KFxeUcrtdSrVBbyiewgoqmKXL6GeAf1H8aEFeEB+/rslkdFIWL1
-7bUERrxrotRZLPwyzVPhkg9qcTNMLiXrtWXOu3fuPOaeXmqFu469J82igQ3a
-VUaUy9LXqZ2SSbdaGSjJ05lPhZ21U2Ebpgtqrnzd815a9/eVLlLDi2Qv9nP/
-BbJ9cV26O3bJwt4HrpD1XntWaD2Y3dm+BnXPRvh5H90pkW1dZ1X2WufugQMC
-X9FjSizkrgpOk7DXzHuvWY8f50q3BuYlt44kL02PAn3FYg2YWyPW3jYWsAGm
-IE+mZmeCgKcCUR5mT/OgkRbiHFdCmx9T1GcteirXmhvEVbbeXfu3Gv+j1+48
-loHu7tKKu+xmu8JcxQbuNcNZi7tOFWf2cHebGiD7UtN8viw4A6D8imMz7nGN
-We9c5/ess7zqDOopu3NWmfu5WwNKC+1Tx9VVw6/O6VnTbm2Um/cKVrf9dgf7
-tRvdv13FfruK/XYV++0q9ttV7LerWPws1zObxiRLVbPJ9Sf5WhoJB04cRbXy
-PmOl0DCvzryu2DBv578vBfjLRoV9Bdexjuf16sGsjSO1KsRHbaRMyEbxLVbx
-LocbSLnk8RW/9zWyhq/atJ2i5Z07WBOInzs5RvObjMEDL3U5OGq1pfbElFiL
-PFjvIlf7ChgRlrTKJ1/5Ki+xYDdf+Qc6vS/b4rIcfeUur5fldW4HrhiHd6sE
-tyGxJfC/S8HdKKi7pfSW7f8lYrq/cFWEr7EMl6lZLI8NXwcf+lKaRo0fRlUw
-+NIcW96Qb6oD4AIlnCn0rPo8yHuH7Yt/5V2+iAFv5HHxRbSS5aHc6yWTz6Wl
-1BBIVdR2ewJJZhZ9nDj0wXZ7Zrz2VjlEW5YkodUmXWl5WrHPTSa+a4jAdIz6
-p9Vnapb6ROigL9VB45Vx4bB18vKVXHlzFA0dwbKlZ7W9oxSREIEr2+oulrrM
-Wk5BW1hfyiCWKuUzmlc5L2hl5J5eCx7NTakIDxDgvrZtUaV3LAvaF1fitOcD
-f6Q9/027SfBy0avE26uCO5lV7udfIOy+NrTd9UeQc11DaHvdVf+3wPfSoObn
-W9j7P1XYu2RkZe+CKnkC7H+ZSYBqfQ0iwGkWDGQeVQzAqDEOOMd5LNsEx/mh
-qBWlnGW4X6lb+ckcg0SyAYET7lS4I2HX3Ok1ukXSjQteLEvrPPkknKoVx7Jw
-izFyhkh5+iIlopJZpJQ1WnTDC6IX0Ww+paLw8K7sBEeDAz76Kf35bQh9cLWQ
-2zByRpWvsICgC6xsHw6KBcB0R8B/xlJWSqRr3MibQUKadv2aZ1FuC2jCPn9c
-7FDac34DGYlQG3nzkDu3jRoaY1GJo0ofYyPxTZqM4jEbhdO8PrKhkfOZx9va
-AGEz5+Aa/ilWI7PkGn7IswyfBRYPtERNf6k/yZXhGafxVAuWvELnQ5dZpSjM
-5gpSskHgzfnu/r7FzRpltTq2iu2V/Os9EPtvuoUy5eAS74Lh0FSk2R30tGjm
-eXmm6A02FxntEKQyIPzoII9l9mbA33fckniwhaidSBpvbn+PjibLB9r4Jl5r
-Vbz0ePsNKBo1UK/ZQCxpBfyC79GqtSToPF06kOrNsvzdBrpSHvE6i9LrP5cx
-dx4Ml5Qamt9SLKyKvQb4W6Ki2hKlCo91b90HgzWU2HByJpS68JzD6puBSsHU
-JpuFIUVdSFmSFY6P9pr4VB2PiChvYznzqg7KyLCPDpKFu8U9PXMWTFSqAL4X
-QBqijN9Qd3rwP1tMPCrLBf355HkmvJaMDje9A6OFxR7qv8RQPw4WGWgLxdb2
-3+ramhzJTbooP/XLjh9RU4ZqcSJ7JYMNEYFThtdf0AU+9oIb2l1jlC2DUjlq
-Czhz6Q7REMaGJFlJf2WYfRTZhOfi5/dMlB4cPABpeuTP10idLcBcN4Xa35sc
-5MtHRV+R77XV9K46GK2zuPY9S2vft7D28rLa0m/eg2h1APCond5j0z1Lq9+n
-uPq9yquX6a6aj/qsExzJyRCVXl1Um2v91q4yu80N/1FeLfvhD+reotMHoui0
-oISKsuCCGNxfa+mBn7d5pV2zYDsehfiUS4WbLAuhcUbM2dbx2XYFj+K4L99c
-1leJlzPyv7TUPmD0J+5nrNrkRKhGPLmeoIe2qglxHsE7xV3AbY+VJHgsNHUj
-MEZCJamDl0IOijQwSiFLqLbeXF6825ajCUunsqqJ1CsIj+Rd8lXZAd3RyRRF
-J6c77O35Kd1tvz19re6geEUmz4y8td4qq8jSJvFUktWrrxobNeH0b25R1Cpz
-QeXSI7IUrsI8TwdxqOx95FwkQt1Sly/HaosyYdPKIi5h6+ogAzfVXbSqOucj
-Kd950kdS+sBoGVDl3EDBUCqBpSlIUGcWc7dNuBS4Lw6PuRXPaZxT9UiyEyX6
-NBqn8QxXk24/LMvq1gyYP66UcsIASuFkiX+ciH+BPnfYn2S0APXGaysYibDO
-EmH9GDnHUZfZ03lAT8DgwfGMw2ZthSkwBzw4AkaC6xiQWLSoEafbuvTd2Mz5
-HHCFgz6aUsl26kwxM4FqPpkQtkZODKT2lnWdmhN+7qk9URf31KBoLSq1qCfd
-vpKehuDxLiaPP/rBZkKv4NVHeTRYzUYN+ynP1WhbqvQE8ozdXm/bWUw9u6pV
-NeaA4TRYMTmgTRuAshE6VfRKVeHFnOb5arORcTenok5zEcMaUalMdkqjb52+
-Ot1mFtuEjWnwxiKd4o6MKqYzmGQpeiUMYGKgeGS5KW4qhY1f1Hxy5/wombWf
-toxuwjK284JcDuDPxUxEQymAmQHw1gkgwTwHWvgAsfLuNuAFetUO5cdC3WIr
-uw3gR+XQRa9vE08Dphle090MEk+KhnCf+MqXels00Fh9u81VYitU1j17hVF4
-DIaBlMly8ehSBZ6TeGy/Om/mgrlXyfpQZvbRa6bnVL14XFrPojAn3Tg21tLF
-vYVyNxeOlJn4Bgg0Wj9LN4HNYfgi69Y55SXiGXcWCceq1fBHNtpqUsDy8yyy
-vMwfOkpjFR+q2JW1t2YnarVO7dUqu4SRZdxSY73cBmYUZvJgQRasB+A6a2c5
-JtSk1GhEmWQMetS2cqV/QN5j0n8jzePggG31sHhXvw8qx8kkxDrWUQY7JR7k
-3EKmJ+ijTVLkjKnixQZoKHg8yLnWN1Iz5nfTvl5Uq4j2Qgmrxgi6+RoP+t4d
-tdc9KLPN+ayCb+IPX4Rx1iFLUN6DcFDoec0sFGFdBw9dw4rL0/dsGRNtecwu
-c6JaNvvWXFucp8VubXzdh9+qeJ9giiqyxW6J49BzWXC+jsBb2AbasFYFoMYQ
-QbqFBpPPwVkfTKtbM3saTivYE/zw5dmTjiszVo/A2lk7ezp9vW72ZNjmvhL2
-JBfVZU96zy5lM/fcheY+XIkXqZTMAUXGcX5kebYvs+3odiubds5VF3w0cqWQ
-wYGmp5wI4kNKM44uQFXC1O47SsdJQLRkXxMlymauDKyrnIhFsgsaQO2gFEHt
-dfssmQGd5ul0QVO7hv1ACTGMpCGxUs/EVrkP78Q9SA0p4cf52QVNnFy84mSQ
-AXgmZ+DuginZfwJKBAO0kuZF8PLFCUuiaJgLf9XoFl2ntWuigVwfHD7xNbye
-tcatGaHEOya+EeYGXri9Hy8R1O1DbF4ZIweSBNAts+vs1gbdz7tLbz0cI1e0
-QAOZwlYtqw/l9ayYI2+9zNjFicF8JGF4cObnkwZxeHdjrYr2TmLsLSFiJXUM
-CORPbhqmWpuhcRnTipw5EoSZ809MDCnuVnDbFRPgF5N0amzTrVE0CNTzegnI
-z5VvunCehHPlE1kUWk2uiIAsor8v4jndRuClCJw0Z0CBPhmobixncU4aL2i+
-dLEtNQIhT2XKzzJ70MLlOlwMg7KVWSD4YM+gjBGegUkrjsex6UfsmBOeD9sv
-wnMFRo2I0bhQVz2miNE/695EDCRCRjwpv5tdp1O6rqBIJy3fMgvZIM/4q0ij
-0CyCmeD1M5svppxw5UMzw3WhEqcvZtf8RneIJgPYrHJkXJMx3nFyiznluS5y
-IzhsFuINUFpe5Fk0jEGiGeCgOs5oMdBN3+iCzwr2nhgEaZnJ25nIIy3S6TRI
-R6P2NLCneYE+5PVLm70xHdBxRUIjNsfWdQTqIjFiEe1E5S56iKW+gblY+41M
-0htx8oHZCyTkkxCvcm8HkeVrD2/hHqD177Kz0Y89ChtATyUYfnoHC8KjXKra
-QJM+p1qxojSCc1u/3/v/JHtRLZG/8FCreOi9awD2J6PLvHUcdDLW8eTjCnzP
-yoMuc4rlVpZCGSg2FJcpZnSRzDOJ78ssw2YhFJzvTQprMUvHURKli5y9ubo0
-s7mLQOVJ+EHs+3AWmdzLMroBlHyoqmomMCa6dgwm3GsiJnTfURDHfBoOYDsk
-0S1nroh15/iKXfObPKHCDBeRTBsCR/YZKY/TcG5OeyZktaHypgmuZkaDjaew
-SbCoiumbpC+BJxjzZaFGUN6CktaT5yQaABeFY2WMkjFFirlhY3LRkOeQLPCs
-UBltKu8/LlY4/J8QEUzgeGhSCw6Sfm2OI7LByrzhWNXHAYnsgQ0HQP62ojg7
-9LEyn9W8McAApgbID6/SH74GeK8UMMJw9PwFHFJQbPJ9CvMxuC0wD1wLrC+U
-ZqAfFzxppUfbAD6GR6wghcNd5Wmvlb5Gaq/0zkPJIM6f6iSnaJpLUOOIlstw
-U+DTC2Ew5FXvre3iRMjWbBt5FOLFKiIWPO72hs/5yVCWzDDYjAAIHYEVaxkt
-MngpF3Wcmg2/rY+1wOycEym7dKxAkVwEjrrYOKsNRUSh5LsmDnUXcGqGQ/NP
-rP/0cfcJu/r5Y+OMI2/OXgZ7vd5f3wW9frd3hFYeHonG9a7jcRbRV0Yvedzv
-FgVoA+umIPK4kUs4j8L31srwk5nQwlAqjDPXeocvAGjI7S1K0wtr0pi7GuoN
-wwwhgBHLSiihoFA8DAJpFra0ChM7j6rs0CJ/nJg7tIHPFsSg+4Cua4nhIWmh
-cOzz4pyqlBOfiYNWeiUasSnCa67ldODTjowsHLQSzouK2fyZGMdfTNLSI9Vb
-0u+LTQuV+fvo5mEdc/4c/IXhKJgWeDBdDGWKEp7TRvge2jcWfqxU3OZxtx3E
-Lffmexjc2V6QDcL9qn0jRd1Pw9WPbD7Xd03C1WqicXVIz5d2DTQDiUk+L3cV
-NEWl7V1WG1picrl3Rvi+tLlh0I008yl/V4VmMwez5X9tOt+LsJ008c/jm0tj
-nUtjde6GYoFGYp7BcEl0hLAE8RZC690aBaAqgZoagCjEf4zkRdummywdp7k6
-pcuYVB2oC32grj48z+GAOosopMvIMqDPYXZWlbIa6JlOlcvh54Fb6BLrgdtZ
-Y+76feetp1FtzWg/CRNCT1UfFMqC5Kw0V1F3jGVgd/dfcW2m1+31+oZqW8n6
-VVDzKnyewpOrGbmOi16yYdqw5PtsJGG2r4LGp6/Ztw3oTb/Gayi500CnnS+k
-NkbyRGR3ISbm1SMduMLbtcIldlJbuEq3Mw+Erzi5J1gPg672YBVpET4AUPLy
-P7s1qlDcODkF5PWKE3qIhhGnfBFWXzAFu7XJKzmLucuI29VIRwSHcxnFF3mS
-osQIwVDdqVgWMpSiesN1Xz4tHW5nBpWZiRys1EvqdQ5k/dtZFA4RJfrdpVN3
-B1iGBQX9Q2HiIYNu1hdgYxClkRu4KBU/LWvFetq6i2968HpDe1wBVMG4XM/C
-an8MntJATUCaLnhXnqhAPQ8jPLBxVKBjUjKbUeT1xZsr5cJwoxKimXSnO9Dk
-1ooj2pykEWvEJgHR7oOyBldaNlzbdv43znrb/ilrX+9lsvchp0jDLJ8gh9Q8
-xq84QeekuqCFNHT3Skp7q4mK51W8izJgb79evrlAaHRa9m12teCag0k2mpUF
-YY5MnIitqUzxtm4kXYxk8MfTaSpi5s+jYpLW7Eh9Wlt2cLcids3S6FPl/gR7
-C/66TheUl3Ck0/Hpk6g4o/DYxJDs0ttLyieYTIjuSnFotDdaNVLVNud3XLr0
-gjTgLnJZVpwXJJ9JL4Q4yQvgKLZaQKTf5pjeMmicI00PQEhDse9eNDmo82xh
-wno7WGUZO6xi50zVTI5TVb2OZsAXWw/rLYqm6MOUt54Mvp9Ww6ILwypYrN0P
-AWoV5WQRS/dHhEUduPNIaYtxV0QznYVDu9INMyT3SGJ33KEAnUatTSDvIdS9
-KM8TSpH5Yo+Vg+Tzbe7W6bZ1cGRzNRcvsXPTbYczt0iTUUvfvqrRtr2kciSX
-5ejrb7yi9ZipDQSRtmlQJ89ta0NQRUDo7oFnnRxUELo5bmxO0tKG9aTXiO7G
-SG17rexg8m3DvcRatXGeZAHQYhbCqTobu0YI8xZ2mfeBqmvb26hd5WOY0XAY
-yzwIfFQOPDzn1FuIq38yi3hv1oVhi2h/MIkG7yXvlv6UQ61JGPmQjbPSxTu2
-9QrTmNRkU8GlMnZMu5Wykgs7K0GnVn3ZqsewVkfNJRiv7T5c9mmgB1Ehc6pa
-4HlkiQYpSqdfCCy9iEO8rx9yzwhafB5vCWdLnxzUsKPEyYuHAJ/33G4WIdDO
-mKxN8xRUOrQmGcddaX2CF1JBS+g+p5u7K/Wp86nzv+HT+e2IfQdTCO5g3/KE
-k6BTTqMfNyQtXlEWHorU4VWZNjp5usgGETkzwdZ8DzrujxsoaTeY8UsC4/+4
-QRWcpqT88pobP+32dveD3mHQ63e6OOgGbKfvMH5nQab3E+EzJw7pHZKIuYju
-iblJfIqLOSpkOl2Z7lqkFOIpun77TYYEPe4+6cB6PzsLTrsEDpzKoZcgGw0O
-93pPruP806cuDgRsqwTuhjlzpbCGbIhBSwSL8C/MOzA8aNoqfziGCuXIaD/E
-IXUSoGo+ROUE9CBS52FHF+kgneY73FMxzDsXL65O3ly8BPCfvXt5crC71//0
-iRTNdy8uzV8Oe3s9ABsP3CCGvN13VPdsq78t/CpTKswVIkYxp5k2VdCkO0Lc
-X17+LMbZ293f/fRph129vpQj7+0d4BOsdvqnX85OxOOnvR4AxCMDt3b5cB0x
-3GyBucNZuIDlSgphgBEoF0WkcN3pDC1u3Al5+LDI0qmIDtu6OD4534bx/g3B
-eIyo6YiaZbl0lklIxslyY2IReLh0CLwTSwJnTCI5zToKrQAnz3AYYsZw40Sf
-L65lulvYfMrl0duJxLjO4sPDu1EDgZmLKfspSgwiTnXA5Xd4AiyOaVWvTS55
-QrdM6M7q5K3PInmfxGMBcbQOH403lkPDG3GB9XLYMI348Te6BeYC5JHccQLn
-g1A8Oo50AzsU577j/ipVLMOokoMiEVG2rndvT/Ju5zgnGqe099AVdpekppDP
-JQeI83xhZ2oqHKTRkKjGiilrP1vA8DmfKn9JVqEzyt3h4zBzKvRhNb90sKBt
-k0/SxXQolcw7wZQzoCnMCUcZJCWoA4tZdZGRnR1fHJeYGD0kzypQ/nKR6Wox
-H8oQB558kG7fonGM2hpnd/zos5EAGxI/3HUMB8eNsxdXL9mfz1+zd+LXDT5T
-sScfHxweAvugDSE9jay5HnW4EOAy4pd3Z0dskSVHyAWPyCqWH93OpkdJfoSc
-+qjEHUVDMXoILI0SLg+KI24KPHtx+UqGRACYR+zi0fEPwqdHYgJGpVuShCaC
-UgPd26Muh8yPOo4Mwf818kwakSiiZ5wm2AV2rlEpmWxvFziXhVdqpC04RhNC
-b9dCG/Z6xKpwc46Kd0iUBhsOZ/OMXRgtabKrof0trGp8e8Sm7mqItT6i5A9/
-ho/AZRAE7DocvEc6xeUBjXQ+hRmyS9COZyG7yiJUYL8jXaCAL5+E/IWTDLCY
-+FYWU8iVpkLN8VV5ErPVBi0muyDiIylCHqPwMnOGg9AyvR5ltA3VmiBQqSOe
-W3GEYTKwFKSuJSJ7PmzamwR4QshpIovHk0JqeuUNjBcUYhFB6A7iOADhIJik
-bylNfR+w7VbZ5JGifwDsqopTzxgzDXTqhXkWp8g68Hc67h6afVPBOqdUp+58
-S/W+/UxqdvD8aAsrCqnQl3/wl3mVIRyG/2U1GJgNRO8D1WAgG/jhiuYGSICN
-NlBVlof04asO2soCguWOfLOYpPMV8bqly2vlCzSZifF103/oDvi72/YvpQUy
-PvZamT3hWE5HAvxS2anvV1n00qdMBaW6PEt3wPItoPYA/00PYYBOltmAHI9N
-N5RqkiHvLqMRDx1TW65/YL0b3i57txoDnl3K3yGcij+X9CD3U2rNv8kGMYYb
-jMa+VaxpQSOX25R4kgGSNl4hwpZM2fxppn+a1WLD3pdLt1rFJnNgMj4meO67
-M++7qpJm6t2Gqb0BRf/fs/8Sf/2ttJersOV5x0GbnjJdart72V4d5367/IIH
-RvvtSjA9r1UtsK8m9b8Ir/BU3dYzN5i/wakdjjywf6lnLHZNdD1SK4nbUrK6
-64D1WY3t0pKbsVUYGluJp1lFSBsoArroZkkdqK25uR6loForsPnAcq1gqVrw
-j6VqgUmVCj264KzDk5azcKMbBzEWRI3YuafFEqbOPx7WrrpqzOBVC9aMfzZh
-9gZySiyf6fZ1jL/qtTr2b7RZLgTcl6tEQVWFRrX9stQt7fdvBpWVfoUJiBIu
-f7OJDt4UP/gJmD68EESp4Ra23PagXzipeYkTQTPrWTjDWr9VtPc4EH4vX/Kw
-PKd1lQd26XXVwhv+8Mz3vmQqlgtATce++IR1dLw8gMA7CiuNMvaMIobw+FvL
-tVReTI3bhrdN2/r8vFdv22pcx2NaU25FW9oLnrC2qn3hebWCC+LLTh0Qcx+5
-v9X04q+9UaYOpgmkok31IKvuV9Z6y7L2u5a12F+s/d5dtftVdjBrsYnZ/fZx
-TfMmW4rdbzfXNG87+kp72irg4VUzstSu8lGhZjSmbQV7c9pWTRoQn9t9A9q+
-R/etaVu1l58a2uaflWm7vvlS6jKbr0Db9c3bjt6Wts3mbjXRak3W0jXdgpzf
-V7STaxmQP+SSAocNx/aIz6rh5afp8P5yePosXNJoXTW2rq6Z7qZGpntFOrWp
-kOCsTlD7q1tpQOwSUYzxwlCdqhpG5qnEI+xLJwuPYQRaVr1tfgwrk2ZVbpGU
-kkVAZmNw2vmqkTxb0k7XuIAjlayHwM9U/zDeocfP/B2p9yqxbAJZV8TgWQWQ
-RkZ5gFJlHHfAVM+frRtMJ/c3fsopv014dYpphFemIHbhlc9tLoh9tgS4MkGw
-sfp+GpWJV+uINE8yo4Uvt6nb2ubHFexfI8ifiNTBlv+lZ6XRqrGmPqX1NpKL
-ViHCR5ae1Jml5ip9l4kKkdWwDum+dp4sgKUuypqEC6tMvlYe3U8iVi61CpB9
-0Fo5zVq0M1OEVWHIJkk3LZSvld1iWfIgTVaZKmooqMpNlOMZzKSVNulhloid
-70tLtDSJhpaAfg3bhbys88qLj1XbNtCNWZlqKzMrmCiqPWksOVosB37J4aFF
-B6uhoL3O31bJb6vVt1Xj2+ntS0PeNS1XqGS+6ykXG8+cgT3C251gsybGHJ+V
-pmc0aRPe/tAzbh5Te7QEP22RUwtNKc7SuM/0hTbWOP04ATcGQp3gvEr+5UbG
-eV5sGvhluEyUIqFwDvZZwH1JnvwaQ7/CBNzAI+Oy3o0CokNhkpVa6zgVk2bs
-MBWDedpiuRw68qz+NSNKQwJUjmsQvozfYe0uSrhNqTXRO/Jp7+lj9tt3IhF3
-gMEAwufxg0gnFw6HGDN3Y3lmK3dE7p5t+hfzwKTNkhPhpume2sXcIFSwFu+P
-AR7o/3oxznnkAvenf/pYxSVoF1cEhPrR0HDP/mtMH2jFRvlAEC6OnY644x1M
-QI2UmXjNu3ffo4P57v54gg/NYiIBG87z9/jv38W/w3kg//x7ODuUj8Sf8C+G
-+Mln/G/44/Gufsj/hj8O9vRD/rdOHAwkiZos/sHvlsWXJFWPB/Iv9Ug9sdJu
-QKPsY7A731d/p8WiL//u98zHBFpaTPe6e0FOXY3SeNBX3ypir+G1OANCHcVF
-UPkKbPNhOqv+fRqFOZ5AMZyp5i3OG2i4ypcEU6h/CREtpTYVZg8E35YJRgPM
-xhFjOexA5pTm7xP6gftRsvSAe15y/OinpvdXPqgmdb3ZViR123RVaWDqlM1V
-ncBhlYGjpQXEcei/SpAFhvpv/G38zpE4Bg5rfSm9QYaAwGdpCKzDifWt9A5q
-V4FH4GrY9s2/zfb5kP9XPataI80AV1sij7eU8zSaWw8mqf1d+5d1gkpfgyW0
-oBfdshzAd/vmI2hylOuUTj76eBK4pxr9pKT0+n9yFUX/W7YKhxC5ilWnrGWU
-lRNHi0H8OGqCfKRlv0sp1UIrvc7TKQZ2bIEERHkIr2/L+I06spHCySvExEMu
-sz4K5kLJ9klYmHnCfV6oAF9eA55kVpUObjpCCmfi9frVapM9VlQxmIydtsrT
-eL0XjcHFNGtctz1gZNEs/VAGAlQqXsokGv64QSGvPHbzeIBpU6bRcExx7xxa
-DPaT1U0RUAzy42kWMT4JS+Hh4zjDZEsDjAjDTA/vSX96l8IYRefXeFqA/iXj
-YrkoSGl+WfQhBs5DfafseJjFYcJegvwRmdevQLt7G4GYka1hHNweBN5wkcl4
-ax7AiS1kRBRgGWRhSpV3ukITVL/dAILmWQSbSWUCeQ/7akhJkP4fLhbIbE68
-AQA=
+H4sIAAAAAAAAA+19a3fbRpLod/6KXuXcIyoj0KRelpXNOLJkO9q1ZI+lbGZm
+75w9EAmSWJMABwAtyxnf33J/y/1lt6r63WiAAEXbmWx0ZmKJ7Ed1dXU9uusR
+BEFnmI7iZHLClsU4OO50iriYRSfsLJ3P04T95fTqJTsPi5Dd3C+inI3TjL0K
+76OM9dnrRREPwxm7ioq7NHuXdzrh7W0WvT9hr/pWf+raGaXDJJzD0KMsHBdB
+HMF8w2E4XwTZePik/2Q/uI3zYBYWUV500ts8nUXw6wnDrzr58nYe53mcJgUM
+dsIunt+86OCskyxdLgDcs9PLN+xn+ADWwl7ih50hDDVJs/sTlhejTrzITliR
+LfNir99/0t/rdPIiTEb/Fc7SBAa8BwgX8Qn7zyId7rI8zYosGufw2/2c/zKE
+BUVJkf8Nlrkspml20mEsgP8zxpd1HWWTOGXPollaFDF9kWaA16v0XRzSn1mK
+mI1GcZFm9EE0D+MZgEc9e7e85w8JdujBfM4EFwXAyp4tc2PwH5fhXRTXjh5j
+t94tdPthSq09Q5/DbsCeAuyzKGsD+og6IujQsRLy53kxheFfRextuvwYD+mr
+OIHNfd5zPqV5X2dhMonMeSIaoQeTUNMfUmrhmeo0hkWyl8tUj/ZiWSyzCBbO
+bqLhNEln6SSG3TZGD7HTZJn2kCh/mOCHNDScjaTI4ttlUd7uH8N0HocJ++s0
+SibeDRGDf8QGU966ZgfCJI5m7N9jc7Cfkvh9lOVxcc/SMZy7ZBjmRWRvQA8p
+/oeZ/K4XDnvLd87gL8PbDEaP4JdZPL+NMj99iiEnonVvolpX72ySxcMUDlwM
+RFw3KG/YEw0rxzufZsv38N90dF+H0xE2c3fLHulZDNwnSoEb/CVNEz3Y85u3
+F+ZQt/f3y+SHCLa5l0W9d5kzzFtgcdmI/Uc8C2dFqIc5u7k5M4fJqF3vPW/3
+w7Aohj0iMnOwv6RLgOdVFOlxrsN5vhR7Loa6x1azKOoVHypX9x/xsEBWnC6i
+jzVYf0/NejNsVonztynuccouw+SjzbrO4nyYWquc8zY/DPEbz1gvYSSghhB4
+5UyP82/LJF7YdDuZ8EY//Df/rpdERaeTpDBDAUSPp+3i5qfg5r9e9o6Ojk6o
+qxBNf6Q/GDubhlk4BJqPcxBEOR6RRToLs/gjDAGyZ56OImBQ+QKPEPwN0C6i
+JA8BIzkD1o8dsmgY0RljxTQsdJOIJF3dcFsEhRYFarEXCYCUUB8QjjdwkFB0
+wCqHfBw41IIeRzAPsKfoNluG2T3b6w8G9DmekCiPk3F6wpHA3kZc/Iz4EIQT
+jpIwm0TFCZsWxSI/efTo7u6uFxfLXpwUj2Btj26Ct8/PAtleYfTJQW9g4XTr
+ehENiwwAnmTxiMv5n88vWbhYzATgwK3P8aNxFv19GSXDe2q6MTS8BkoFOgQs
+7PUbYwHX0Q4PooeJib01MHGGH92F72FZyaSYbhYV50CUc46L/n4bXOy1xsWe
+hYtjBxfypJ3OYe3jOBqx+XIGZ20aJgkIqxEclcjEwih+H+dyLYw3XsyiD6iT
+mfhjdzG0hvUAm2NytJSrk6JvjDgbh0MhqDeA1av0vcTq4Lg5Vo9bY/XYwurj
+/hMLpxdqYURaoNbIlYN2Gib5AlRPlnCVelNLB/4btTpYAHSrRfP2xpIdQnp9
+89MBA0V7EmRROJzq3d3UCq+jRSF3t9Uye3u7YKtkWTyBz5dz1o6d0ADOyvet
+lb9A8r8FMn99c8WeDfr9l148fA4q39trg4f9XTjm8BkaOWtgYd/AwpPDJ454
+eV1F4Wwxvc/pqxlZlZtHyL8tZ/etjjxB32r9soda/+NDmwbS7A6VyCjL4MQP
+gdpAwuBkyADQsgUlAw5ofg8K/HxjC9cCtd/4QADk7VZO7Y11O/teu/JpPJmy
+27gIMtS3SLf4bMiQVNBYnNJabNbQTg7QABZyHrs61w2eBlQ+I1I8YWpkFJVS
+tUaeIjqzaBHBWjOQ0lKgjOPbLDKQOgxxAoHaz6HA7jVWYAkdLRH62EFov2/j
+8wVYwCwcAvMAdT7FdedDsN7hDMCC5jGsJmfdl70xNNthAXuT3sFXuVT3EO9o
+aeMHoOzwxW4MSZIAnzRHkDi2zfFDHV5fvPivg37/r29trQM0uAhZOx/+dJJF
+9CejplWLVHybr5azbCQ+ONfLubG6yzADaeYVvQBPQJME/UGvXwlI5VLTeIyT
+oa356G4R4I0MNH+0XMzScJQ/sof/L6D+5TAa7fUWo3GngxB4DMrj/mObcF5G
+CUA8ZONlMhQ7iguKCyCNJZwgMBRNPW0ejeJQSrDNUUiYrDpF18uFwB6jVbgi
+Wy3wsWPTnDqrqdQ4N8cVWi/n8V7VcqDdvq1Eb0nC5LwMzm4eTxIy6oFnAquD
+uYBMgVjyeBRlnEt+Fov9qMnaaAGdThAELLzNC7y16HRupnHORulwSY1G0RjA
+zlkIQM9mQkrCTg35PfoIr+Dx6jvfZbCiBPAAE+52cMV0BQ7LzUF7IjqlS3fq
+gXcWM8TELEwmy3AS9djNNOLyBoelEe1BdgGUDA7MCAz9dE7j3S7jWRHEiTHw
+SlBCIDRU5pIRjATM+Bb+nCOlwZ+39wjYchaJWxeCUvEa+bwAmzeOJ0u+ebS1
+OTCNqDMMF+FtPOOzApMHxhPm7GctL6/BuhxOYR73gYJ1f75+fZXv4GCdMcrR
+AO12sLdR4hojnEuJe2lK3C6qKDvqpPTcLVRvFuztizN6tsCVgliehUPsr7aG
+L57FeN8EjBD2fcQtYmQqd9BDzE7IiZPhbDlCyhiNYkGiNfvArG3ocaKbx6PR
+LOp0vkFSz2B2Iq8Okq69hFh83YQQJZ3gKCtJpYczRYq0+AAWqDgMEg0/yopo
+cFCTWKXeg4oMaj2KwkGZGo/5I8JzgwV0b57vsDEoRsD5ciSUu2g2w3+TNAlu
+nuuvulFv0ttV9giOI20UhxJJYwAqMt/CJEOVxAGYxBEIulwcbtDLlgXyIy5P
+DLwL7MilIXHjjT+OICfgixe6CQxFR93eOkEnnpOAA1Uehl9+eQr0ejQ42v/0
+Cf6w7gjhE9wk+9O9T5926WP3COE0bU+RmP7x0ZPjT59wgBIEPQ+dwlnI6awg
+Wjh6Y64JA9U454zoDIfQ55PPiScUhmeozYDoz+iNahTBgZwhY4k48cnTiCMQ
+A6JXQKkSWOc5gYHvgdGCkjKKAHXieidfzucoLThJ/PILXnhNohyfO2l1VVzE
+hNLmJDFuN/w3Z3jss6i477GLorPI0vcxsQqbj3hg1YwnFnwGpuI8PEMMICbx
+vOrTvsDh0mUOaqwg51047bAVszy196NTvx+9TiW+y7hh/GQ4Eq1M/XhEQdVT
+813pC7TLMAHBR63wITsvUuAylkIkjydt4L8AIo73D/Zo+m++Yc/pzTPGk5OC
+mdq9IbaURfP0PRdlyOx5o51O54+8lYBCf3XCCTgX/DTOBXuT4yyyGKklZYvl
+rTTrSqQhNg32AuggmqYzYKfsfThbSkEKTG+kBqZGQrCM0fiJP8Kfojk0RgCL
+eE7cyJyVQ5rgMjjlQj/oAFxT0BHaVSBslmKDcWJk3Dh5NAKg38yiMOfc7J46
+jEGQpHdIuAIqOkInIJvYn+GHBcEfqV2YC9aPeEuWdI3F70gBoIvgHDv8BX5W
+doBdhOb0PhgUAAx6GBw/fnwULBeowQGjgZH+Cj+tRuLOCoLTB6DNhHGGKwmK
+dIGPyvcBHn4cXGBArNZiI6RCSkxyZ4fSQd2m6ehCrB/Q6duW55Z2E9sYO2YM
+yfG0y5a5VDg4/tEIYt37KMwCkKTFNBiF9zt6q+aoq89gt8bxB31cCzDNcoOr
+4d/Aie6mMahcU+DzQGdRwiZoPIVCr1tgSxIO1CBP56gTkCICZ+mGzHDCFbWB
+s8JV807nIhGiHnTGD0VJQu7yxUB/tsVvCvtbgLcxvdzRYesspmmRgs4ubhLF
+sw3/Q0pyoSB7jLtOpUnEuq9vrnZQZbD4hHHli/JQfwCGDHzQseUmGGsoS0Fu
+LBZpzk8pQoK2RpFxU4aENb7/E8xKxMDsuwLpeMyAHrD57J4vP+Njwch8pQPW
+fTXYIdZRwtc8vOfsGvjDEoFACk+JDZefHgrDV0IqR0OAPsqCW6AZ4P5ZOIpT
++QeydKAP0FCQ4gmZufwuKoa9HXMNUg8ibgKDejQiYv1vcYW4PKEkHBwcKY2E
+Pjg8RhVFL+NddE+Lzvn6hJjAoTQhYXdJTJIYcQQQnHhbhAfHETc5G4YJII00
+3XSZGJLi8ZPDvhDiEc0OuANRuHX50/XN1i7/l129pt/fPv/TTxdvn5/j79c/
+nr56pX7piBbXP77+6dW5/k33PHt9efn86px3hk+Z9VFn6/L0L1t8aVuv39xc
+vL46fbVVlpJEP9wWQ5MXRDoe2zDviLVzlD07e/P//u/gQKxwbzB4QoohCcbB
+4wNiAVHCZ0sTIET+J+D0vgNMH5gMjoICA0w19D4C6Q70mU/Tu4TBLoEG8K9P
+Z3gfGRw9/WOHOMMbIGbgPdCPnM2u8K39KpyDcYpIv0hcboDeBnRCaJeSdCTM
+CU4GhqaQ3v43auvSuljQPLBOzSHJDQwvqfl3KArSYUwMTXJb7E2X13BEkpGi
+EGXQSsWm8w+5EP7zD0vn8v78gxN5lAwj6F1EnN+Lr4QAMz4r9f7f/wnbgkLx
+b9B91i93N8WIZ3IQdyiDO7+csG+K8DYQCMr5Tcv3W2/k34hdDw742rY+oXEp
+bRXuKnjJV33GL+zy6gsPE0djeiYgc8+yfHbLi+nxAaXynWuWhoZNyUBBYWCY
+7kBzF8po5sd3qzTFlqMu5446Q5Bn0TInc5TThBoU9BvYD5ycBjvpnLBThhzR
+anivXoEJTLJnXFGDJ+9or3+oeN+/cIvpCXGe4d1oHgynQb4YNpvoLA0z/31H
+x7bUzshSE+/zAXJ2OjP1IAJEo7YQ0easmKdTnodvbzIcT1pMY9DEVUqPAuwM
+2uELwAvl2fISxOESfX+gd/fq7MXLHQY8oHLlai+k+j8V+jWxR1K5CQgcSfEb
+UsctVUKa3EDLR729w5c/flSLzGdpEdzFI1DdJhq21iu+hmHYzziMvcTrn2GF
+uLzd2vWd1C8PRmm2usFeT64uWkUieLPENQf5MMNePD9jXfm0+JyeFs/U0yJf
+h3UjlqmLJ5gRBU8gfJ7bTGoMyO1bIT5uwRhH9fcRSTQ+sH3Fjv6jaP+jhYFP
+UDY8+qEv4EYIcseNQGYc8DySN3nzqJimo7xqn49JmbUhJB5IenolWKBU8MH4
+rUE8JpFWMN1VsvEqNZquyNF2UmpwcJenSTDLh3xWP4E3uPYFQTK/HYUB/56d
+4fUxcGu6/gpeXZ/taKcDrYMzdct8X4WpYzrxGlx9zFYBTT4hwUs8kBWw6RZr
+Q3i8jxd6AOFFgUcOMAE4AqueUwc/wBnJTdBt4wT+AFUNtBCQZ3zH8mm8AFWx
+uEMjD8GugJUA9IG1WwZq/+DxQN4e0vaJPaAP7EXr3qhyIPXCTt+7O2AIRLFg
+dsrvrpOcM/OIm47bZbraps7bVTu47Qp0cSw4UKG6/zZbqHtwY1QcykVF/e0E
+V0901MUG1RN9oQfqCRhemXj1ClBbNmhWteNaFZxvvsoxGu74ahYm0i9W2Ibv
+o2SUZjuaLZG/LJE82pbczdYkWm5zLHCMMlu4FuxqrweSENnpOtcweZLVLimL
+QNvNyTCCZQi2scOuiU/DcEGSxniNg+sExhnmS3KuwHX0ewOWzJE00xldhAFX
+TEYkoKt5HHkwIGCLfNQUMOGloJxSz4WXQvfN9flO3VT9Ps4EdPRSvbBsjozU
+qw1QET9O4S2qbiDnigAIAVd3I843o+8YBWywu2rFUXOFCX+O78gNFaactBj4
+zZma7xH/PTLN8mOwy/EckYUggSULNNd8R1GqMRjBoAbUDgR4L3pNN9T8S1qN
+uHqYp8QX6B67xyyETNPFF0IFzFRavng1kevv1K+fj9B2vWTkGG0CegTXxK2Q
+TzLHhFvadyZOjPk7zkMfN+qqzQ5CsjsWijfZAZgdv2bH48O7Huz197leaxNK
+bN4fRSUz8vaeHmOhIaHCEBsSpZ1FmIVzDI3KG+PROkfRYiUO+VqxaV6BoM5q
+SdMUOFM0+o+6gaSVVM7tCUXlHUHlbI0D37EPvLuTmuQ9u1R98E1CFOq2pAlS
+dfltGb/Yp2WChArfA66IXBNhVw6FXSkjJuKoMTWcoBpj3cppmbgPsgclotJ5
+dtcAhBS/0XsM7pLXJvPvB/KSFoSdfNrBb0A86kHdwe4Zv/wzPkBrletCnsbB
+AHHo+eIPAwJKTuSjOoOftqE3iabW9ObjqjU0tkm2Wlp7C/ZagRuTqOnS128y
+NBR063OOBsyttALO5z4Xe8MLKw9f84I4TOe3ikz0UzeevCompYUajWDSaB6h
+qCiEaePTpZybTPfr3Q65ui7o8cZxQ2GgdichyDwV3kYKHrtN6U34QzQKnNHx
+euRdC5ml8CZO5loYY84ZaYEl7OnFD3zxK8FMg3O7EkFl7ag5ivT8fkzp738l
+CKtlECtRhb0tTDU4aVEFEeE3XxUphukcmH6PXvRYd3Beo5uecukFGF+Qo1Fn
+CwVfvrUjnDf4GPxhVLs783tLFaJA1jtKwZ+nkXiXcxVnrg9EH1CBjwu6W1Ae
+RxnIS3wbBPUpXE7QcAc4hPfjLApBHxjTg3ai+vObhCKaL9BfwnCByPACg/35
+TYhGNykusNkL4Im5vCfFG64ShOGw4N4OCCpd2j//EKJbOj0ogjB3EWihXg/F
+H4W5Voi7rJbD7OV0apfDXyXJcUsZHPJFzPQdJHn3tPUtiHwtdzrSE008DshO
+EU17IiVGmI3c6yC1ZnmFqR5NiYD8dxAUCUnDmvdF5bsmHwVzd4QEHZyMWyqO
+OnEYyeHEGjpHLwR+D+W74G6NO4DcouHVp24W5+S7Ehb82h9QQ9ep2uFjFs9j
+7T4oY141DPjSmQBp5dwnwjjFFv1sZnnuew4/GQyxa7gj8QiZ5ZylwyEsmjv6
+AEG/vrmOGXcVU8CRW4rYHTwFgqBtVqCNYzg/wxAOEPlC8+MEMA+XHGX6jV4Z
+BcFtuBxRwJgwetLZLEjHY3VhApwLjmuWxXBs5Uui3g2HpRZLfCzhDLjRnYW5
+H7wzF82S/SgnXAFKPAe0IWjz8AP9Ljopq2fXdElG00TbQ6Kp8dyHj730Nh4A
++yJUegWBNlMVXYondYMsqRHu42xmrmo75ycapgJGGs6K+4De91aTvmhuPAfK
+cDX1lXgCki77Z1Ng0nBwh+xcJ2nonuG15hsz8cIl0ozZ5M1l3dXn0dER9721
+BjknwYBXqq/SPO++OX+1Q7ejeJ/zihQH3Cb+21vStn75xhTPnU7ZIK95l+fU
+yR3QSIGTN7q5x1TOtfshigoDJvWmhTIOn1re7DDcRzaBzUp4Q1AolNnORQae
+TSG71YM+k7cH3deX1zvskkKYzkToPV0Rs+7l2Uvh52Yts73QEf5QOZxyAwdd
+DuRqVLjuN3yduPa7WGgOEl8pdzTCkyORgb6qmPYlhJnA0A/ILQ16A9uB4TCr
+R0gvoiSsWTfuRT28GahuwsEepRFndeKMQ5d7tv+WT4ISKs12eoLM6AmYcz5o
+YQes2HSBLnl4VOAfHJu7P6N3buiMjVmioo75MPIY+fMaCoGrZiKk9lx4+k/d
+65y4UsqLOAHx7FbEk2W6zI3u3HgZqmwtHznnQTFYdUHF3UNpXnpT4be77pCw
+8+lQCtfQA/Ay0ddW0IQ7hzkEJ2jVNiU811lSsxT7iluoPHbIlflCi23KDsL1
+f2yzW425PckqqrGNTJoPxseV+TKkdOu6DkAU34TdcFwXw0ZcsbrXRM1+WchH
+TfvsOxfsaFaBNHK/5KOQbkA6N49HDlF9A5IAVhXjSyyg6f/Ajwi9m9FzMvue
+DQ4e02PaH1jCvi0vTz28wZzJfIcPAUo71+63k+0SaRpwhTm9nU8AkO4izWN8
+Rd4Fa2cS8t8Azv6Os3vnjXdv0Gr3zr275zpL1e6eoTd85d0b48Y92R/0+71+
+v89e/vixyf5Bsy+2gSLxxmb2kPRgxY5abREaeHKPdsl5ZiSZiDGioeaRO9au
+IBoQBcJbygv6zq7MZFULiz08uqEZ4wtfM//4lvfFbgWN8egt0zGbO4yZRJdb
+zdGlWCj8XOzw6JQwF+/OuU1t1z8Duc2ButDFrExRNSR5BZ3I7W5dOhTANqJD
+7lAyrxzoWMjJRI01yShnA1oa6FbBYL/QZyxlg0q55BywXb48nBmRU7pBKEVq
+cEwbl1rUbCbc1rj5rB8xRLyQcPIY0wWO28YkLuXmKACSoQhap+Xa9QotUEUV
+aQEuE3GBniajp/KoYKC4kkeGqxNXzOuwZn5lI81MofBHOYZkEM7RoG/nvLPL
+1VacV4VQ3GtcaRPMjNLxvKFrO6urXnfJ35Ir+TsyurDmPtcZoswWvQP6bq6d
+kYSdQZskqYjuPJXndXkuJITnmPMIedO9pFM/xk3qiGIeoGK+cFpXAj7VRlJt
+XKmTqeVWDFr3dOoZXesMFAkjkz5RCrmdE+XfHXAXYkkD9t3CPY+DoY1BLEca
+WzJeDHDTo1gpr6hjXNRFTbFMN8HOQbTQoW/aDEnFV9+xBJl2FjLpWx002RS0
+iWG0KLR3hcligeN/y/x+zlKUOrDKCxYecyRdFTWo+Xc4JN4IGcOOwyGZU6G8
+n4jxjnFcI4/xRm5EsXbitKp5dXPzTrLxBnDwwg+bBk/cNT0UPPvAqpBFP4us
+vo6s4JI6/sN40NxVf+LLpvGdeKEJOX0Gt3ExDxeCxVd7cRiByLsUpaRjRBQp
+IdaMexp+m0eSx77Ob8fQvQ+563L0qhFaM/Sqgdbl5yb2YYc0utthG99kNoZs
+gGN9PJc6r4Hi0hjrYZdVIldpQiuuJL6lxAYk9/QkJKJILO3ipbtU5nO/aume
+am2YfSfHL0sg38gNLROuZR7t7h2Siu5cjpssUT1EKc4mpDLwKY8/sWGUYKQa
+qceXOuTMjlz75RudxUGErZkxapkM2Msdp007iMK+DrYdkczUDrvu3fWuz0L1
+XBuVXtrMj0phyZSqsvyRAwClMrTygDx5fOg0wcR27kePyx+hA7IwCVVOMkI/
+2l0MMdyRsXulOMVfwKSjPXgv7vwHvcF3HZ5kmkv7rWWWnGDHE3pNyk8+zGcn
+SX6CvU7KLs7YWcR3yiDJ7zC0lIdwOoGWv5BBKZrLT7+jD9XeC5tzCwMoMfyy
+tmKCyE1jJqYhiD4hCOYLJo26hcUNfBUNqA+9ow95vrQtMPh+jm5PGPtXmTIN
+nckxwdS7KCPx24PhH91NHtH18COR0Be6vQKpfcL+FZNxF+kJffuDbP/HDm8m
+U1d4ygPoHzkEb9N75lQCKI3lKZNQHow36j1zKyKURnNqIpRHoga9Z3b1g9Iw
+5WT+5ZEq8vj/kXbFCGbgO2PGpkpVx81wpTMjqbZ8bpXIRefT4v4l/MbE8IwG
+O1iMxnu+IP5ezvXDGSvJgm4p/pN39abr2dGio1uZJov3t7rtuPG3boKkntiC
+s3Rxn8WTacG6wx1MFndItT3gyCzzQr3q4tMfvu+LIJSYpzRidJlC+dzUizoy
+bUDpKQgNGhYf4PMo45Fs1OdtNIpzrkbIxGL0Ag2WQ7rMhhG/3ANpldFtxjzn
+Fj3vDIcZ/0iXdG2i0kSSDrNAv5kCRdFimeXLMClge3Zl9iGGeVMwFl17AgwJ
+oTxfgZmQh99HvsWsIHKhz67P4cjyDnjrMaZwLoBZvgcd9IYSBRp/2zx/KnsV
+TQD1b5CqcvKTeEsxXvwNl5qfi7Bs0aEr2QkVTIkizUoE1HQrsCNRStiO5OAA
+Bo2JeLw4vTrluUryqQqUl/kUeDIFsZOFvrd6o/0DsmiCm3XPT4IDHGXCDJOQ
+ANPBk/kjEh3ay0DBSQdNihSZcsJK4ZSjcwK5cMjI+O/o4Y26067Ax3GRR7Mx
+cfbxEpY+I/RibN0wyvVcZkKIbUwEsb3L/8W0Dvi7TAiBv1MeCPULH0I047kg
+9G+6u0oBgX86WSG2d/kg25enf9nmt8TbMjXEdovUEDSImx+CDQ5YF1GB2SF2
++K+YG2LHmxpCYe+eNcsPsUWyWaXFQa4Q9I+D/pEQzS63lfxW9aB8VPbFBGan
+MoPzBXcPmPt89p3+ygkw939ztNg7nEyN73TQq/HhaJG/M/78u/3naBE4n/w9
+nB87DexP4M/BUamF9RH8vb9XamJ9BH8fHZSaWB/JEG3jo0kAHxp/gxIeZc5n
+Seo2GjofuA3c741IbXPc7GOwtzh0P0qL5cD5aND3NDIXnxazg95BkJuTjtN4
+OHA/9MZom53iLC+CcVwEq1qCsTNK5yubYVqmIsAMt9FodWOMEAw4DKvaLimB
+T7O2uOnBggZHE9b4hn8oMycHInOyuZXCA4samjRQCsL1fmkH4kqOKvj3qkNu
+hrjqsU3HRoMCDN07UMpFZjRwQmSNPZcWbFBMP/o+npgf50lm/RGkWQBm70x/
+OIqG8Rxm2fN8VG7Nd2ASxonvs6r2szTPfZ9Vtaelez+s6jG6nXs+ql7toecj
+z9j5yPpDtmhJGUbUqhrNczn2nf/baOH9Ypr6P9ePJ+aRqnAq/q6CUr/zk6og
+RvNEms56xueW46V5QLkfoZqsfvQqn8nygNIxsfyNOQapZvVNZM5V4H8NWqO3
+AuobpbYALeaU0feGJtdWR9VdjPNNgCq/wR5MvIfwDSYbAGhAccrdr7iPOm6x
+SatkEoZgLwlvSaG4e18qdIYr2V/41TZ6+JuGOX/7FYkm5Rjd2+UELwPRVutJ
+HarmigM14TZFIeU80gIV1x22UjdApW6wX63UXeCFJ6jWQmWvAxDv0pSLKsF2
+Sa/fpds9ffHy6Fsc4FszDxT+/YjuhWTODjOFUzWgz/A5rpycxLyQzXt14OMV
+IlZP0w/09GgtcWsk3ghE4g2JYf1DmTh2Lc9RJIG3YKwC/mR7np5cXCOy7mDv
+EVaZ2jlhTepelSb11sFSGFYYIWlPeERtW+CR8siY+P2uCr3VGauYL2MVDrhh
+bHPklnH+RZHdHtujdbDN75DaJUX/DCjfBIEPAOf9R1iXYm2ce2re7bKzGUUt
+PO55sG/w5fXQL99S2u+A4u4ahp3aXcHXicpdQRZmpCqKE7FPZRx5UwJ90W2q
+26Vjzya5Rn8b1m564VrZ6jbN4lsynV2mMwTsf10OROjd6ycW9fsvWjwop47O
+W+RvHbMNEet6C7eh28osi78iut37POzBW7m0AruDfh9Md5NwXaRXEu5AuJ06
+tPubR28L7B6ujdzD/5m4bYNcvIheD7nc4eJ35NbxBbx1Xpcx7PV+R3ANgrm+
+WpZrWHBlmauaKPU6M39o9gm4VTPyJxxra0sQfdcKIIyp8G14JSTqkalaohuL
+bJO5WO4JDv4/wxhoRXTGG56HAJy3v7qdbrMnv+9DaR/8nt+NToPfL/p3HJdx
+fDfxibG6DVgt0n7H/krsG2mwK+n5tmSvOcmzfXdN6FVg7qTreuCZ51wm58aL
+9TdT7HU9jccF+/fonl8nvbn+9x1jJN+8f28/75+W4SijWnveWf/UYFbhJdF2
+wRhRZ+WCqAVF7jHgIWgCFLpltITomOX389sU6N2A5HQOhFZgYoFLve/d4z+d
+Xu5U4eIhM9diRcEikWGChHg5vTz2QkUeKC1hgg6N0QETD45q8PGQyR+KkQrA
+yOOmJVTQoQ1K9vd2KjHykLkfihGAqwIjRwctoYIObTBydFBDJA+Z/KEoqQBM
++lg1vs7zVcWoKIihGNqL52f1xTE8gJGnl6UrRCtMXVlLuwoc1n0ZICSVCoKU
+0E8eH7L3e72+ENJ9FNJy0IgGHepBQV6WhTO53GIBw0QVvfetUXmvtVrnNfaq
+WeV141WCHvJ+gFfI/cewzsH+GutkbBpPpliLhHJjcbWk0eK5m16rlV+lWIHF
+i8lhezQWYZxRNGsNKs/qcXkKFvYHdkqOxwKtFO2CaAUdr/9E6Hivb346YJgb
+CP1FhlM/InWtDd8K22Pr9SJKatb2mpam4luXOQ+YkrA9S/NoF/M0LUfTZRaT
+Y+2P6RDVzck0mrPus7Mfd/R21BAaBfvggUKtd4AY2UNCk4+Nr2+uXHxoTGmc
+5OpVbXDUO+gduGr1xmbhe/rc97bUegvO0gTTBCWUKoiKB3GCcjKKYgYGtBWY
+okkJ60rSpLADHqGKuR0S7UI4SpcY0xd9EKXQr88DgmCwd7xLvtM/hvM5ZZPE
+wAXlI3RpJmhyU0QOxQ4cPpII5ykssCywMnR4hk92fv0jdIHjH454FW8bFY3I
+Zp2DpPZSbuVpe1JpOoUil/PPOock/EMPURq+yk1luJ0+b0UZKQlbqZrUyg2k
+2ED2fp8EKaJgcAwoIFWFColTTKW8pRzJMt6lH+NpciTdEOamG4JpKPtHwMBe
+jNmd6UBTGRWk0ew6kFk/pSqlhicGSFCfeBPe4pYXhutX7g0nwJhVdJsDzS7B
+vfoYZSnrXr39645/r0RCRbVROrtnadPwAOc5g7EYpvZZrSNgUCZ7f4xbyHUE
+3MLXi4qCtRVyTVa2F4ViPZS939vrHVUgEf3r10HiVZoEbxUS/9oeiXKZkmRu
+1HJ/SmCINBvxqrfAkwY7Dz8uG8D1akQ/BkRX0+ugX8NDvhRhDvpfhC6bEeXj
+aqLc+yonuxFR7hFR7v3zE6WKk1kH13UoLROiBF3WSsRAErogDIEi+y/Vmr0I
+V9oo4h1j0VDiNDMwUBdSL2VkXYfciRpl8DhdZp6ZX4WoNcJcr1abeZuRwg8W
+wg+XwdUiGA/qwHe3oSKqPj/5SLrRSrAiH1T6XrMLVUgRdSuimrMBRwtotLih
++rrk9cUZqL2NyUh1FNT0O01U04Q39KyNL5vhFXuqB+j+fLojKpyueH86fnIi
+6vwhip6jdcaDl53BZQLm8rLdGHsf5deHBZrHoSYWz4OPU57y2EhXpvtzczFZ
+zm9h3SNZ8yjO2c/KAuMYgs1OU3Hd4B1J51/GCMO8kN1jMGQ//BrwWxdMuT5y
+bziyXCxZNbAMJHEgZqsePL8IQlaHjW4MLbyiMCceAxt4oyJBn4aylFY2iSip
+Xx6P8P4cI9+GpFjwxEXzFL7lUMu+WCZF5PHmaf4xWx4m3CPWBmcKqFvlkljl
+TvFlcL8qCvdBx53yXFunHEPosfwMvyhASbbLbqNJnIgCA7wQrcInnWAnv/Yi
+SyewKTyPVkpCDZGNV8nGcdd9jIIOlOsCelJiTjstt+/adGXY8eaRg02bYkes
+uBl6bGa4Cew4gdbVcpDa8Byx8vmJOpA+pOeXsK0qAoCLxCzsgDbKm+GDzR/q
+bW6XN0y8QmjJmeAYA7pRQ+BLkuMzOX7350c/fvQ+lVmh5ZuGozt6NvfOWg5c
+t6YWOaJOrKrPlRCsXbRcqZiqdvkqznd8wl5evnl1zV5fv3nBnidTLPFNBw55
+H2eKRAdXVabjc44qjP3U5Z/W55yGz2ktmu0UAA9AtuEn1qzYei1KMYGbidLg
+5rkpUDAhjywVNja8mMp4aRXcVe5eRueBqWjL0FaMeB1FYyOwteCfcNdl6Y7E
+H4WTQmYPqbDFeIJlHrK8fbVtl0SVVcM82f5KvNKOha7JoL493t61UzYbPlgV
++b4/rE5Bv6vm5w8nzihd+LsHH+DfN5iGMOaKDDfctuEITfUzrIJ2Wxc7J+aP
+KYbei8zF5zIUmOvjNKscYNsBd9uTet51NK+j0Y25jX/tAD5NzpJoh1+BaLVa
+UU+1hhJcRbDGaTerXqwkWax64RCs6CwIk1dp4LkbJH0aAG2bbgN+Aj3zEGiZ
+MpUFWCJQN7bvf2D4tSRS4Tj+22St/lIKvyp+SiCWKdTx5//dP9ml2LlJscuW
+JHtZQ7JGGSdFJ6em23gVFRpNvmeXQH3e6h8u8VEVjIrt9/u4/04Lmhas9EMm
+RWDKzJq7+guZHYduyuwrblUs1ADQ8Xe5KBhlRsTspmIqWUWVV/Jlohg9FYcx
+jVxgcbCcGffANHI+CyeZw96+6RdGAP1+M094KW9+RTq0FmTAS8M8MgdixkC0
+ieTjFrJFFr/HexszrRrmVcXyqTNM6HRvbqfcFL5FBuYoTXfdAf4r/FRlBpLW
+6YUulxfehZlnO29EFT1tcO31Ds3XUoVDJ2Pc2mfIwqFI4MvRu6OdfufWKZLl
+lsJClYzgR4muYim7p80WFd7NuVRlMSz9BKQZy+o7PAU9v5KVPck3lUr10k2b
+S50KUiN+4texT1b+PnOTRB465SWOKklIQwWjeIL3ZU/4Kj7Rf5cJfrQFes1W
+rbh0uC+QNHTZZXxfSUEa7B2SjlQH66QtrEceWF+2h/WlBesAg78I1p5HgiSZ
+B8RAJN4UIIye/dDvDZJ5NRxdsec78pYK6PcqjYF1vUVaYkoNIKUQBgN7SJID
+UGQ64+mdb0H0cN1jtSf2Y3JyRCNhbwD8nl76MfVYpGqfUzJvL7tvxez9btxZ
+tKBiYJHOlj2Ob7PIcOTmSb+FO7cX9TI1oqXMJTryTHKiRGWxo7+j+ULG+n36
+UjsiioS8S9K7hAqoYZF0hEMolfit7L9MqJmH3BR9tTsXeysWe2qMIcCh19A7
+0G5phDpQGm6CczRabMVK6ARuUQTw74GdEwaZpjwPuu0OWJG2Cu062aj3sKuF
+8npSW/1ebx5+2PIwo9Gzel5EU+B7zrNaKBqiXHdojXMbGIFgcrlWmFUolSh2
+MMsfGXCQR5h2tRmOqeXnxTGHKyyKKFkKna0W4WbO2EYIxw5rIbwCsrWw3xzl
+pMA1EWJN0DoSAbfDaAVWrcS6jdBKPR6AVxe0tdBqDtIEuaPbeRPU1qgGegEE
+9bxuqlb4hPYPwCYHph6HDvIkSsUA9ehTCZLbSbrD9WTJOH4frRZ1hy1F3eGm
+RJ0BXqWsk9itxn9DWZeP2qF84NO68UW7CU2X38LfXJ/vGEbe/YJ0Qw76Cdvv
+PWHPg8HBrqlkoXL986PLHz82UHv7yqv4CQbHhFh3ZTiM8pwXib3lpR8yxu/0
+DO9K66f7sjeGrjssYG/867BMQS+Wmx7WfLTWMQU8tjqd2MGIqGpyNgfHLSnl
+eD3yj7C2DeZ1XnlCB8ctj+jgeFNn1AHSc04lalfuRO05la/dL2V+d/qTnrtV
+Imxfhd1fqtYj8lyrzvpem+K10Pti1yxuhG8QqqqhXBNNZKT9/llVRNQjhbwG
+oFUNkZw11dS85Isc4zaSI0yiAsviKhdNb8FJVXqIVdZIpEMuggs5MJ66i3IQ
+DifiDu+YkIJELSNR4pDfHOH1oul65lYMdVKUG5d8Yqil9nSxCrNJXjaLwrFR
+TteiYulKAvxOfVGZfVeStI8IBM+gQdOxyuUtYShz1A0mOm6a6rj1C6dvKuvV
+oPqNU+KKkL/I4tRIz2Q8Ginm4cXoG9kPNlu74uv1ncmaCPfsXPQ3b0q6F9dn
+5zsrt+Bgr79/IjyeqnxzjA3yIYWccII3WVqkw3RW2ocueQDtGIj5ZHEb72ms
+ZDdIZ5oPiEq2sGG6kK1kG/xA3hutLW7j1MNQ4NBzGNYKRUcu4XTL+aDg/OYJ
+VOe2piZ51USiQFUlm6obmx5yG3ApxU8rmFUzLiVHEczqM3Cpr+P6ICYfTtN4
+GHmYpPdY8rFUjmCZ49o4+4xXHDcSmtM2Ii+wPMn4D4ntbZFWJEBvW9RBsGha
+t9d7xP+nQNtl2/bq/sC2t2SRzhM7l/3WzrY1kX89YlX/ARg2ypDpUgx4HnCh
+mpHgzyfjd34saGFmk6rJ6ASXS9uK+uz2NGWeRSNsTnTgT+3zsgGOXPMnc5OH
+nk0efqFNHm50k89Wb/Kw+SafiSdYQzriu8CSCinGCfzy5Xd6vY1eIbCA8VbK
+Kj4VtTE5rCy0/duSQG61dBRDcoBVOnOlGJID+HTmpmJICR5TGv2axJBs+IWS
+5CuB5ynXUyHzXqpK6cSkeXHcXRYVw95qmUdUIpxy7XTDrTjkr18G+s0p/KlJ
+gF0eq5KnvtIsJ/bWoAdVG3285Nsz9yrctZd5yD9ke4f8X6Al/kBN3odSrfkt
+iGGihOGXp7svLpZX0F1lzVa2ObpL5kB2cS8CstvrG0/Z/EcWgtnV7jKUWQNX
+zC+rpEyTLX8TysE0rdENZOo/3dSrIvym7KN6YSGm4T58dAgp16CktV+akOo1
+dwCESamzJFSbnGhy4Spon5cqGw1/KsycOnAIpDYe6+WdqXRKt5eEP/5TQjC0
+dI6tYtHyx74Fq3KV1T8ml/lU2gjaqPI+BLM4L/BJRQYxft59yWljMB3AQ3eG
+sEg5+jTw5e5eysSff7ZtfIhZ3NaqXCf6w8ZCOQLpn0bVKcuauqqmlYJHx3i6
+5hd3jcmiGSU8NMTRQ+3HEpzWq4vva/M6U45ivL0Yz0lNrUk1SsULzCprUvb3
+3m36rUny3fbYzkKqpkkRwlCZuZpayWq0497F6m0Yf+iM1RaGoOXXKYwNCxyY
+pEkIoeq8WhUu1U8wSNp/tLcuYTXz5ZwUyggIqrjDp1Ad05Kbp9R3RlsHHPvP
+Jhm6zcKN/QOIApNW7gsTX7RL/trFzibxqCJrf4Tv2sD0XXM3w4veU+lei3EF
+0tvdW4piFzPWkFCwVyhKLvNN0j1zjk/uI49++MIXFz/UXAN/LsudY0xZNhsu
+Ob+xopkqepB9y753Ue/H57cVp2HjpCSimr4qRYUfPhNFUdKH7R774/cMjGEv
+pm1Tl9JwB/Moz8OJI0Uvww/ujtLwt2hckDs3Br2QbwPl7TDYttpoZ4DeVzgG
+5VW0OAblzquOQblH1THwEkHVMbDAuhhLjyNMg+VZYcU+mWPILfPtEs2A7ijl
+WcwhbKzUDfhbOsMNFLsGD+Mr/HC0YxAqzeoeRrTS2k1N/LRhHYgQqzD3q3nN
+H+d1HzmKoYvurHIIcmf0ugXJIVZpq3XqtByjgbrq11OV+rnuGzwCbeqwX+gN
+/itE9JqOS3Z+ACHHxIe1zjMPsxTLty0GtzzNxZS3HL26LuQAGYnkPLv63c5S
+N3VivKrjJUuNhKP3UVbEOb8X1SPMvx/Im9R5FCa5DPfN7Lx75VObGG8BRPDq
+G+KslOnL0ysYIMqcJApmNq/kDwNErppaUlQjxrbmA6r/6OcbN1WdJ89qzixH
+WMEIqjmAOpzNXAYrOIALRhuD1Thy/CWj4t1klfNgRT1Q04PQbzPaJUaVmPQW
+Eq27frYeK6qlmKkNKbK23tBkwcqVbnQb4pNrccpP7uZh4o6Wm+XU7ly9VWYp
+0K3fd2TVjpiMrrEHKLGwsOAZm+UjGUehYcjI9SgjRC9C3GyDVAL5Z8qwF2hi
+fQjnoLXuCjkZ8ndHkUiicov0GOYFE8wgN4bLPefLlfDVk8UwXc5GyLxlIc2e
+HuMi4eoe3jvvajWXRpXqQz6VA0S0VJHm1xD4YBDAnLAjPJZfW3N5VBQijN/e
+S2DNeyZKnc3CP2Z5Krz1QVFuhsmVZL2xpHoPTqvHXHumVtzrsHzSNRpcT7vq
+ifJm+nXqq3TbW60elCTs3KfUztsptQ0zCTVXxx74ZK3H+5VuUsM3Zi/2c//b
+sv2mXXpWdsnCPgeutPW+iFaoP5j42X4hda0l/HkX3cuXA/1WUDtqnScITgh8
+Rc8psZC7Sjktwt4z75NnPX6c194amFc8SJK8NJ0N9OuLNWFuzVj7EFnAAZiB
+PJmZgwkCnglEeZg9rYNmWgrLroQ2P6ZozFr0VO41vyJXiXz37O9qXJNeuetY
+Bbp7SiueuZudCnMXG3jejOYtnkFfGU+eJc+b88uH2pEaGPut0/x8VczG+eWv
+OWRDE72D+CbuQdV4V4RS/3q64v10lV9flVOf5dJn0KfPl7SSOZxyvwqUSdqp
+jyvFhmOfM3qrhwzvS7A5QrPH4Gb+g80ehF1fwjaPwjW4bPUwXOu+sbHXgIc/
+B1S+B5hIbPRSXP2yV/2219Dr8+GPZRt4NV7n3djfqeLNjD3k9fg3SG8r3pEf
+Tm+t35PrXpQ38aa86lX5Sx+Xh7wur/O+7O9Uc1zWf2XezDvzRl6a13xr/g2d
++NVqdNNobJnMocl7L3mZGqkWzlTvFQ84awXFeU2CTUXFeQf/ben4Xzce7itf
+FZXtmyaWjX0GGJ6BkknpSz7Lm3MSzyWBuwk19ACKu8nd3FYmzbYIY/CeiFVn
+wnYnLbncN4ljhv85c7gmlml+NY3cqxS8tdFTIRvHH7CyezkExZTr3hiCCttr
+3XiO6teNFB9fuPs9AevCWengtCGP9Gbu6Ja/YcmX/8sQhi+0bl3C8EQllUjC
+DU3YAEn4whI8ZVGIJs7+WWhixdtHSzpZi0jWvaxZxT5wWBQZtRykiS5V5+fi
+qlHQtkpxMjQmCcZvUnFqlE6gpfYk+/+PyCbwletx/BoLwNXcXFvuGbXqHbT7
+51XomuRi+Gws+msreLVhT9XZGVbext9UZWKg8hwugMKRyVzjgGdf2GWH4l/p
+SSOSM9j+Tr824d842cIXIKwvrSDWklR14oX1SCqZWxR15lAU2+vbiRe65WwL
+sroQ0QYpqzu/XsLyvfAFpmvjb1WdrCWLM2EsvFD240vjca979uKlpBJzLhNK
+gqmrV7izq2RLiECWL7Kvqm0Wr+8m62JhOYu0qkyEaLEqGEbv3wO9kzwqdN1r
+dhN1AKcpvVxX5suo3NdGOTM+//FsHJhOLjXEhQIniYdaPf9WO1rxWvS+ZB61
+DijXTkWvzKon5rqVVGf2qM/tUZtFoj6PxIMzfLTK8fGpU/2X189Jr71pPo0V
+uKhzJGqPq9ZZNx6cd6Mm80Zd7o2NZ99om3yjbu/LPlL+NBzViTgqU3HUHs6H
+p+NYnZCjelM2nJSjMfOrwbfXE6lK9oHsaH6TRMUJhxEgOwuGMvEzBorV3Ck5
+t0BYZy4Z8a2RdzSIJe7t7paqM+cgdcKAwAnLLNyZcGjuih99QCqPC17dTwvZ
+fBrOFClgHcvlBDlKpOIPkFBRqS5SSnMvhqGbG1ZE8wU+ZlNbOQjOtsiwoCD7
+85sQxuDKr2F/84qnLrCyfzgslgDTPQH/BWvvlRUQ9dxPSNMOqYssyu14AMI+
+/7jYpToN3LEgEiGB8sEwd1wINDTGphIXlpEPhjKTJuN4wsbhLK8PvGrkEuuJ
+ATFA2M45uMalhdXJrBGJP+Tvip8FFru0RNSg0e39TDk2SzzVgiW9ZfjUZf8Y
+UUnS5rDi6godZPYOD9fwMLGqg5aifjwQ+20LoaA5uETHDjANizS7h5GWzfzB
+LxS9weGiu1665CoBwo0faXzahwG/33VreMIRon6iyoV5/D253GS9UxvfxHWt
+Er0eH+QhRc0HqpkNxIpewC/4Ga3aS4LOM6QDqT4sq9s2yGqWR7wwrIxFymVs
+sAfDJS2D1rcSC+tirwH+VqSLsyVKFR7rWj0EgzWU2HBxJpS6UqbD6puBSkkf
+TDYLU3KeoGpIg7Fr74lP+/GIiPIxliuvGsCnTptmh2ThbjViz5oFE5UqgK8B
+SEOU8Vvm27ItJh6V5YL++eT5TDgmGgNueyfGOyN7qv8UU30/XGagLRTdnb/V
+9TU5kuvqKH/qtx1/RBEsKh6M7JWunIgInLrh/gpU8GNvuKHdNUbZKihV+IiA
+M5deTA1hbEiSlfRXhtlHkU14Lv78lonSg4PPQJoe+fNrpM4WYG6aQtvY+FWm
+osVgqu1Du4C6vtxARUoLEOegrqyQx/u/3+/1WXcwwDp5xztgLIHBxh83zds7
+tony0J7uaEHmzr2hW2s9l6ZauT9tIb1KJ/zdeJedzUJ0Ezjs7Yv18/gaD6KV
+AeBRO71m03rbYLw8XxTs8qfrG7KipeEhjGjxIC3Sw8xm6V1u36olKRhJQ7Cl
+l5nlCTJU68XzYQFVHUxczUd9txMcyckIlV4w2i2t3zpV5rC54Qr+Huz6NPv8
+hrqy1HdVpp+93lFvz6QEYwUeYnC/raUHbm/z0uDGygM0hfiSS5XmrMtEw0bM
+Wff0YqeCR3HcG5spl2JOatib9or8jVbeDxjjiZclcyROqEaWC71AD21VE+Ii
+gjbFfcAvJStJ8FRo6kYInYRKUgev3R4UaWDUbpdQdV9fX73dkbOJK1B1qyZS
+RCE8knfJpnIAemmUqdTOznfZm8tzevN/c/5KvZ3xEnKeFXmLU1aWvaZD4il9
+rXdfdTaKWBoefk4V56rrgsqtR2QpXIV5ng7jUN33kU+ayDucunw5VkeUiTut
+LOIStq5wO3BTPUSrMpk+kvLZkz6S0gajdYEq1wYKhlIJLE1Bgjq3mLt9hUvp
+RITxmFtR5oadqmeSgyjRp9E4i+e4m/ReYt2sdufA/HGnlHsKUAonS/zlTPwL
+9LnL/iRDf2g0XgzGSNh3kYjbj7FjjrrMnuwBvQCDB8dzDpt1FGbAHNBwBIwE
+tzEgsWhR1FL39fgaNLvmfAa4wkkf4WCMD6aYmUA1X0wIRyMnBlKb1GWTmhP+
+PFB7oiEeqEHRXlRqUY97AyU9DcHj3UweaPidzYReQtNHeTRc744azlOeq9m6
+qlYO8oy9fn/H2Uy9uqpdNdaAsXFY4j2gQxuAshE6ZT+dCu5qTYt8vdXIELpz
+UVi+iGGPqLYvO6fZu+cvz3eYxTbhYBq8sUhneCKjiuUMp1mKPhRDWBgoHllu
+iptKYeMXNZ/cNT9K5u2XLaMVse72oiCPVPh1ORcBjgpgZgDcPQMkmHaghQ8Q
+K28/BLyiuDqh3CzUPbrZhwC+VP5t1HyHeBowzfCW3maQeFK8CPeJr7yWDzTU
+WH2nzVViK1TWA3uHUXgMR4GUyXLz6FEFPifx2H53Xi8Ec6+S9aHMN6b3TK+p
+evO4tJ5HYU66cWzspYt7C+Vuhi4pM7EFCDTaP0s3gcNhuLDr3jllS+N5wJYJ
+x6rV8Xs27japuPtlNlm+9Y8cpbGKD1WcynpXNLVb5/Zu9cpHHm/GLTXWy21g
+RWEmDQu6wfoMXGfjLMeEmpQajSiTjEGP2lERGJ+R95j030jzODpi3T5WGxwM
+QOU4m4YZaHZRBiclHub8hkwv0EebpMgZS8WHDdBQ0DzIudY3Vivmb9O+UVQv
+cqUvY9WYQXffoKHvPVEHvaMy21zMK/gmfvFVGGcdsgTlfRYOCiNvmIUirJvg
+oRvYcWl9z1cx0ZZmdpkT1bLZN+be4jotdmvj6yH8VoWJBTNUkS12SxyHPkdn
+zmQ5m9UReIu7gTasVQGoMUSQdvHC5Etw1s+m1W2YPY1mFewJvvj67EmHIxq7
+R2Dtbpw9nb/aNHsy7uZ+JexJbqrLnvSZXclmHngKzXO4Fi9SqeMDCqjk/Mjy
+nV91t6P7rX21c6mG4LORK4WMKTU95USEHlKaYboAVYmrdp8pHScB0ZL9TJSo
+O3N1wbqORSxy1tAE6gSlCGq/N2DJHOg0T2dLWtotnAfKa2PkAYqVeiaOykN4
+J55B6ki5ey4vrmjh5OIVJ8MMwDM5A3cXTOn+J6BMT0AraV4EL56fsSSKRrnw
+V40+oJu1dk00kOuDwye+Rrfz1rg1I7H4wMQ3wtzAC7/vx0cE9foQm0/GyIEk
+AfTK7Dr7YIPu592lVp+PkStaoIlMYau21YfyelbMkbdZZuzixGA+kjA8OPPz
+SYM4vKexVkV7KzH2hhCxljoGBPInN+Na7Z2h8RjTipw5EsQ155+YmFK8reCx
+K6bAL6bpzDim3XE0DNTn9RKQ25Wve2BPgl35WFaxV4srIiCL6O/LeEGvEfgo
+ApbmHCjQJwPVi+U8zknjBc2XHralRiDkqUxEXGYPWrjchstRUL5lFgg+OjAo
+Y4w2MGnF8SQ2/Yid64Rno/ab8EyBUSNiNC7UU48pYvTXejQR6YmQEU/K7+e3
+6YyeKyhySsu3zEI2yDPeFGkUukWwEnx+ZovljBOu/NDMu1+ocg7L+S1/0R3h
+lQEcVjkz7skE3zj5jTll3y9yI0J/HuILUFre5Hk0ikGiGeCgOs5oM9BN3xiC
+rwrOnpgEaZnJ15nIIy3S2SxIx+P2NHCgeYE28galw96YDshckdCIw9G9jUBd
+JEYsIqSoLE8fsTQwMBdrv5FpeicsH1i9QEI+DfEp98MwsnztoRWeAdr/HrsY
+f9+nsAH0VILpZ/ewITzupaoPdBlwqhU7SjM4r/WH/f8l2YvqifyFB2fFI+9b
+A7A/GZnmrTejU0RPph/X4HtWdQaZbSG3UpTK0LKReEwxQ45k6llsL3OfmwWb
+cL13KezFPJ1ESZQuc/b65tqsMSHCsafhe3Huw3lkci/r0g2g5FNVVV2COdG1
+YzjlXhMxofuegjgWs3AIxyGJPnDmilh3zFccmr/kCRVmtIxkthkw2eekPM7C
+hbnsuZDVhsqbJribGU02mcEhweJPpm+SfgSeYjCYhRpBeUsqpUGek3gBuCyc
+W8YomVAImRtPJjcNeQ7JAs8OldGmqpHgZoWj/w4RwQSOhya14CDp18YckR3W
+5g2nqo4XSGQPbDgB8rc1xdmxj5X5bs0bAwxgaoD88Cr94dcA740CRlwcPXsO
+RgqKTX5OYT0GtwXmgXuBddDSDPTjgmel9WgbwMfQxApSMO4qrb1W+hqpvdI7
+DyWDsD+VJadomktQw0TLZWgq8OmluDCMe1Fv12ZoTkxtzbGRphAvoROxYL/X
+Hz3jlqEs5GOwGQEQOgIr1jJeZtAoF/Xmmk2/o81aYHaORcquczcVj9gEjrrY
+sNVGIqJQ8l0Th3oIsJrBaP6BDZ7s9x6zmx8/+jOxeHTf1xcvgoN+/69vg/6g
+1z/BWx4eicb1rtNJFtGfjBp53O+WBWgDm6Yg8riRW7iIwnfWznDLTGhhKBUm
+mXt7hw0ANOT2FqXpjTVpzN0N1cK4hhDAiG0llFBQKBqDQJqFLa3CxE6OLAe0
+yB8X5k5t4LMFMegxYOhaYvictFA49/PCTlXKie+Kg3Z6LRqxKcJ7XcvpwKcd
+GflDaCechorZ/JkYx19M0tIz1d+kPxSbFirzd9Hd53XM+XPwF4azYLbv4Ww5
+kslVeO4e4Xtov1j4sVLxmsfddhC33Jvv8+DO9oJsEO5X7Rsp6hMbrn5053N7
+3yRcrSYaV4f0fG3XQDOQmOTzaldBU1Ta3mW1oSUml3trhO/LOzcMupHXfMrf
+VaHZTKdu+V+bzvcibCdN/Ov43aWxzqWxOndDscRLYqtQTlV0hLgJ4j2E1tsd
+B6AqgZoagCjEf4ykSzummyyZ01yd0sWVqgzqQhvU1cbzAgzUeUQhXUaWAW2H
+2XlYymqgZzlVLodfBm6hS2wGbmePuev3vbfuTvVtRvtFmBB6ao2hUBYkZ6Xn
+inoTLFe9d/iSazP9Xr8/MFTbStavgprX4fMUnlzNyHVc9IoD04YlP+QgiWv7
+Kmh8+pr92oDe9Bt8hpInDXTaxVJqYyRPRHYXYmJePdKBK/ywUbjESWoLV+l1
+5jPhK04eCNbnQVd7sIq0CD8DUPLxP/tglJa5c3IKyOcVJ/QQL0accmdYRMUU
+7NYhr+Qs5ikjblcjHREczmUUX+RJihIjBEMNp2JZ6KIU1Ruu+/Jl6XA7M6jM
+TORgpV5SzTmQ9a2zKBwhSnTblUt3J1iFBQX958LE5wy62VyAjUGURkrpolSS
+uawV62XrIX7Xgzcb2uMKoArG5XoWVvtj8JQGagHy6oIP5YkK1OswwgMbRwU6
+V0pmN4q8vnp9o1wY7lRCNJPu9ACa3FpxRJuTNGKN2CUg2v2srMGVlg33tp3/
+jbPftn/Kxvd7lez9nEukaVYvkENqmvFrLtCxVJe0kYbuXklpbzRR8VSL91EG
+7O3n69dXCI3O5r/DbpZcczDJRrOyIMyRiROxNZUp3t6NpItRQ+B0NktFzPxl
+VEzTmhOprbVVhrsVsWuEsgvfKbzhgrMFv92mS8pLONbp+LQlKmwUHpsY0r30
+zoqqGyYTordSnBrvG63KzeqY8zcuXbFDXuAuc5EIkiXcbU16IcRJXgBHsdUC
+Iv02ZnrLoHGOND0BIQ3FvvvQ5KDOc4QJ6+1glZUqsVCls1QzOU5VeUpaAd9s
+Pa23vqGiD1PeerIAf1oPiy4M62Cx9jwEqFWUk0WsPB8R1gLhziOlI8ZdEc10
+Fg7tSjfMkNwjid1xhwJ0GrUOgXyHUO+iPE8oReaLM1YOks93uFun29fBkc3V
+XLzEzku3Hc7cIk1GLX37atk3qMR9Ux7XeP7GJ1rPNbWBINI2DerkWW5tCKoI
+CN090NbJQQWhl+PG10la2rC+9BrRwxipbW/VPZhsbbiXWLs2yZMsAFrMQrCq
+s4l7CWG+wq7yPlB1r/tbtbt8CisajWKZB4HPyoGHzzn1FuLpn65FvC/r4mKL
+aH84jYbvJO+W/pQjrUkYKZINW+nqLeu+xDQmNdlUcKuME9Nup6zkws5OkNWq
+H1v1HNbuqLUEk429h8sxDfQgKmROVQs8jyzRIEXp7CuBpTdxhO/1I+4ZQZvP
+4y3BtvTJQQ07Spy8+Bzg85HbrSIE2pnQbdMiBZUOb5MMc1fePkGDVNASus/p
+7u5Ofep86vwf+On8csK+gSUE93BuecJJ0Cln0fdbkhZvKAsPRerwYl5bnTxd
+ZsOInJngaL4DHff7LZS0W8z4JoH5v9+iwl8zUn555ZAf9vp7h0H/OOgPOj2c
+dAuO0zcYv7Okq/cz4TMnjPQOScRcRPfE/Ep8hps5LmQ6XZnuWqQU4im6fvlF
+hgTt9x53YL+fXgTnPQIHrHIYJcjGw+OD/uPbOP/0qYcTAdsqgbtlrlwprCEb
+YdASwSL8C/MOTA+atsofjqFCOTLa93FIgwSomo9QOQE9iNR5ONFFOkxn+S73
+VAzzztXzm7PXVy8A/KdvX5wd7R0MPn0iRfPt82vzm+P+QR/ARoMbxJB3+I4a
+nnUHO8KvMqV6biFiFHOa6asKWnRHiPvr6x/FPAd7h3ufPu2ym1fXcuaDgyP8
+BIsU/+mnizPx8ZN+HwDikYHdPT5dR0w3X2LucBYuYbuSQlzACJSL2mO472RD
+ixd3Qh5+WGTpTESHda9Ozy53YL5/QTD2ETUdUeoul84yCck4WaVObAIPlw6B
+d2KV74xJJKdZR6EV4OQZDkPMGG5Y9PnyVqa7hcOnXB69g0iM6yw+PLwbNRBY
+uViyn6LEJMKqAy6/yxNgcUyrMn9yyxN6ZUJ3VidvfRbJ9yQeC4izdfhsvLOc
+GlrEBZYCYqM04uZv9AGYC5BHcs8JnE9C8eg40x2cUFz7rvutVLGMS5UcFImI
+snW9fXOW9zqnOdE4pb2HoXC4JDWFfC45QJznSztTU+EgjaZENVYsWfvZAoYv
++VJ5I1m80KiSiB+HmVPYEYtApsMlHZt8mi5nI6lk3gumnAFNYU44yiApQR1a
+zKqHjOzi9Oq0xMToQ/KsAuUvF5mulouRDHHgyQfp9S2axKitcXbHTZ+tBNiQ
++OK+Yzg4bl08v3nB/nz5ir0V327xlYozuX90fAzsgw6E9DSy1nrS4UKAy4if
+3l6csGWWnCAXPKFbsfzkw3x2kuQnyKlPStxRdBSzh8DSKOHysDjhV4EXz69f
+ypAIAPOEXT06/U749EhMwKz0SpLQQlBqoHt71OOQ+VHHkSH4v0aeSSMSRfQZ
+pwl2hYNrVEom298DzmXhlTrpGxyjC6G3Z6ENRz1hVbi5RMU7JEqDA4erecqu
+jJ602PXQ/gZ2Nf5wwmbuboi9PqHkD3+GH4HLIAjYbTh8h3SK2wMa6WIGK2TX
+oB3PQ3aTRajAfkO6QAF/fBLyFywZYDHxB1lMIVeaCnXHptISs9UGLSZ7IOIj
+KUL2UXiZOcNBaJlejzLahmpNEKg0kKwOGYFWf8/VtURkz4dDe5cATwg5TWTx
+ZFpITa98gPGBQmwiCN1hHAcgHAST9G2lqe8Dtt1qkjxS9A+AXVXT6ilj5gWd
+arDI4hRZB35P5u6xOTYV6nMqvOrBu2r0nadSs4PPT7pYi0iFvvyDN+b1iXAa
+/pvVYWh2EKMPVYeh7OCHK1oYIAE22kBVWV/Th686aCvrKZYH8q1imi7WxGtX
+l+zKl3hlJubXXf+hB+Btd+xvShtk/Nh7ZY6EczkDCfBLJau+XWfTSz9lKihV
+6Fl5AlYfAXUG+Hd6CgN0upkNyPHYdEOpJhny7jI68dAxdeQGR1bb8MOqttUY
+8JxS3oZwKn5dMYI8T6m1/iYHxJhuOJ74drGmB81c7lPiSQZI+vIKEbZiyeZX
+c/3VvBYb9rlcedQqDpkDk/Fjgue2nXvbqoqhqfcYpvYBFON/y/5T/Pa30lmu
+wpanjYM2vWR61HbPsr07zvt2uYEHRrt1JZieZlUb7Ku9rDfY+dY8lfVshNVz
+ElbFTNga/IS1YymsPVfxlHX34MhcmSE7Soze5OnD0pf13Mmu9+3bKPzcHG8N
+gd5Gdnv2EivcGshuzzVLyGjIO0v9mnJQq0Drip316SJMnHpdUNQ8+lIvqS0o
+ag1WraCwJjqKQ3L2gCXOtFpVKY/nVVf+sVJjcchdoU0X8i3zxNUyxh6sjDAL
+ukZSx99phfhRPx45ZA7YWCCZnVhjlt9ERKkfP0WYX9cLrZqWdQuyu61ek6d9
+lTyrKjOpTnWWuvUJ/8U43qVvYRmiDs3fbLKFluILP6nTD69mUerYxZ5lWj/p
+Ck8756t/KNDMohzOtNZ3Ff09XpDfykZ+Zmr2rnIjLzVXPbwxHE997SUTsvwY
+agb2BVlsYuDVURDeWVhplolnFjGFx2lc7qVyxWrcN/zQtK/PWX39vq3mddy+
+NeVW9KWz4InNqzoXnqallkw1doqZmOfI/a5mFH8BkTJ1ME0gFX2qJ1n3vLLW
+R5a1P7Wsxfli7c/uusOvc4JZi0PMHnaOa7o3OVLsYae5pnvb2dc601YVkrLK
+wQe3GlWoJY1pW8HenLZVlwbE5w7fgLYfMHxr2lb95U8NbfOftWm7vvtK6jK7
+r0Hb9d3bzt6Wts3ubknUaoXZ0jXdqqLfVvSTexmQU+eKKo0N5/aIz6rp5U/T
+6f01/bSJXdJoXTW2rjibHqZGpntFOvWpkOCsTlD7S3RpQOw6V4zx6ladqkJM
+plXiEfYly8JzWww9q1qbP8YdmGZVbqWX0j2CTCnh9POVVHm6op8u1AEmlSzq
+wG2qfxht6OOn/oFUu0osm0DWVWJ4WgGkkRYfoFRp0x0w1edPNw2mk8Acf8p5
+y014dZ5shFfmUXbhlZ/bXBDHbAlwZZZjY/f9NCqzx9YRaZ5kRg9fgla3t82P
+K9i/RpA/m6qDLX+jp6XZqrGmfkr7bWRIrUKEjyw9+T9L3VUOMhMVIjVjHdJ9
+/TypDEtDlDUJF1aZQa48u59ErIRwFSD7oLUSs7XoZ+Y5q8KQTZJubitfL7vH
+qgxImqwyVZlRUJWb7cczmUkrbXLcrBA735a2aGUmEC0B/Rq2C3lZ55VvMuv2
+baAbszLVVqaHMFFUa2msMC1WA7/CeGgxwHooaK/zt1Xy22r1bdX4dnr7yrh9
+TcsVKpnvzd7FxlNnYo/wdhfYrIuxxqel5Rld2sTof+4VNw8MPlmBn7bIqYWm
+FCxqPP354jNrPJecqCEDoU6EYSX/csP7PA2bRq8Zfh+lcC5cg20LuI2k5dcY
++jUW4EZPGd5JbigTGYVJVuqtg21MmrFjbQzmaYvlcvzL0/pmRqiJBKgcnCEc
+Mr/BAmSUNZzyg6KL55P+k332yzcim3iAEQ3CcfO9yIkXjkYY+HdnuZcrn0ru
+Y246SfPoqu2SJ+S26WPbwwQnVHUX354BHhj/djnJefgFDwp4sq+CK7SfLgJC
+42hoeHjCLeZAtAK8fCAIP81OR7wGD6egRsp0wuarvu+jo8Xe4WSKH5oVUQI2
+WuTv8N+/i39Hi0D++vdwfiw/Er/CvxinKD/jv8Mv+3v6Q/47/HJ0oD/kv+vs
+x0CSqMniL/z9WfyRpOrjofxNfaQ+sXKHQKfsY7C3OFS/p8VyIH8f9M2PCbS0
+mB30DoKchhqn8XCg/qoIIIdmcQaEOo6LoLIJHPNROq/+fhaFOVqgGJNV04rz
+BpquspFgCvWNENFSalN1+UDwbZklNcCUIjHW9A5kYmzentAP3I8yvgfcfZTj
+R39qurDlw2pS14dtTVK3r64qL5g65euqTuCwysDR0gLiOPRfJcgCQ/03fje+
+50icAIe1/ii1oIuAwHfTEFjGifVXqQ1qV4FH4GrYDs3fzf75iP9XfVa1R5oB
+rrdFHkeuTsl5KrD9gTolNzhykusElb4GK2hBb7p1cwB/2y8fQRNTrlOyfLR5
+ErhWjf6kpPT6v3IVRX8rW4VDiFzFqlPWMsrKiaPFIH4cNUF+pGW/SynVQiu9
+zdMZRqd0QQKiPITmOzIIpY5spHDyCjHxIZdZHwVzoYoBJCzMZOc+V1qAL68B
+TzKrSu85HeaFK/G6Lmu1yZ4rqphMBoBbNXa8vpXG5GKZNf7nHjCyaJ6+LwMB
+KhWvxxKNvt+iuF0egHo6xNwvs2g0oeB9Di1GLMoSrQgoRiryXJEYZIX1/PDj
+OMOMUUMMa8N0Fe9If3qbwhxF5+d4VoD+JYN7uShIaX1Z9D4GzkNjp+x0lMVh
+wl6A/BHp429Au3sTgZiRvWEePB4E3miZyaBxHoWKPWRYF2AZZGFK5YN6QhNU
+390BghZZBIdJpTN5B+dqRJmc/j/G7Uj7xMEBAA==
 
 -->
 

--- a/ietf-layer0-types.tree
+++ b/ietf-layer0-types.tree
@@ -56,47 +56,51 @@ module: ietf-layer0-types
                 +-- flexi-n?   flexi-n
                 +-- flexi-m?   flexi-m
   grouping wdm-label-range-info:
-    +-- grid-type?    identityref
-    +-- priority?     uint8
-    +-- flexi-grid
-       +-- slot-width-granularity?   identityref
-       +-- min-slot-width-factor?    uint16
-       +-- max-slot-width-factor?    uint16
+    +-- wdm-label-range
+       +-- grid-type?    identityref
+       +-- priority?     uint8
+       +-- flexi-grid
+          +-- slot-width-granularity?   identityref
+          +-- min-slot-width-factor?    uint16
+          +-- max-slot-width-factor?    uint16
   grouping wdm-label-start-end:
-    +-- dwdm-n?    dwdm-n
-    +-- cwdm-n?    cwdm-n
-    +-- flexi-n?   flexi-n
+    +-- wdm-label
+       +-- dwdm-n?    dwdm-n
+       +-- cwdm-n?    cwdm-n
+       +-- flexi-n?   flexi-n
   grouping wdm-label-step:
-    +-- wson-dwdm-channel-spacing?   identityref
-    +-- wson-cwdm-channel-spacing?   identityref
-    +-- flexi-grid-cfg
-       o-- flexi-grid-channel-spacing?   identityref
-       +-- flexi-ncfg?                   identityref
-       +-- flexi-n-step?                 uint8
+    +-- wdm-label-step
+       +-- wson-dwdm-channel-spacing?   identityref
+       +-- wson-cwdm-channel-spacing?   identityref
+       +-- flexi-grid-cfg
+          o-- flexi-grid-channel-spacing?   identityref
+          +-- flexi-ncfg?                   identityref
+          +-- flexi-n-step?                 uint8
   grouping wdm-label-hop:
-    +-- (grid-type)?
-       +--:(fixed-dwdm)
-       |  +-- (fixed-single-or-multi-channel)?
-       |     +--:(single)
-       |     |  +-- dwdm-n?               dwdm-n
-       |     +--:(multi)
-       |        +-- subcarrier-dwdm-n*    dwdm-n
-       +--:(cwdm)
-       |  +-- cwdm-n?                     cwdm-n
-       +--:(flexi-grid)
-          +-- (single-or-super-channel)?
-             +--:(single)
-             |  +-- flexi-n?              flexi-n
-             |  +-- flexi-m?              flexi-m
-             o--:(super)
-             |  o-- subcarrier-flexi-n* [flexi-n]
-             |     +-- flexi-n?   flexi-n
-             |     +-- flexi-m?   flexi-m
-             +--:(multi)
-                +-- frequency-slots
-                   +-- frequency-slot* [flexi-n]
-                      +-- flexi-n?   flexi-n
-                      +-- flexi-m?   flexi-m
+    +-- wdm-label
+       +-- (grid-type)?
+          +--:(fixed-dwdm)
+          |  +-- (fixed-single-or-multi-channel)?
+          |     +--:(single)
+          |     |  +-- dwdm-n?               dwdm-n
+          |     +--:(multi)
+          |        +-- subcarrier-dwdm-n*    dwdm-n
+          +--:(cwdm)
+          |  +-- cwdm-n?                     cwdm-n
+          +--:(flexi-grid)
+             +-- (single-or-super-channel)?
+                +--:(single)
+                |  +-- flexi-n?              flexi-n
+                |  +-- flexi-m?              flexi-m
+                o--:(super)
+                |  o-- subcarrier-flexi-n* [flexi-n]
+                |     +-- flexi-n?   flexi-n
+                |     +-- flexi-m?   flexi-m
+                +--:(multi)
+                   +-- frequency-slots
+                      +-- frequency-slot* [flexi-n]
+                         +-- flexi-n?   flexi-n
+                         +-- flexi-m?   flexi-m
   grouping transceiver-capabilities:
     +--ro supported-modes!
        +--ro supported-mode* [mode-id]

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -56,7 +56,7 @@ module ietf-layer0-types {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision 2025-08-04 {
+  revision 2025-08-06 {
     description
       "This revision adds the following new identities:
        - cwdm-ch-spc-type;
@@ -1181,7 +1181,7 @@ module ietf-layer0-types {
         type identityref {
           base flexi-slot-width-granularity;
         }
-        default "flexi-swg-12p5ghz";
+        default "l0-types:flexi-swg-12p5ghz";
         description
           "Minimum space between slot widths.";
         reference
@@ -1276,7 +1276,7 @@ module ietf-layer0-types {
       type identityref {
         base flexi-ch-spc-type;
       }
-      default "flexi-ch-spc-6p25ghz";
+      default "l0-types:flexi-ch-spc-6p25ghz";
       status obsolete;
       description
         "Label-step is the nominal central frequency granularity
@@ -1289,7 +1289,7 @@ module ietf-layer0-types {
       type identityref {
         base flexi-ncfg-type;
       }
-      default "flexi-ncfg-6p25ghz";
+      default "l0-types:flexi-ncfg-6p25ghz";
       description
         "Label-step is the nominal central frequency granularity
          (GHz), e.g., 6.25 GHz.";
@@ -1397,7 +1397,7 @@ module ietf-layer0-types {
         type identityref {
           base flexi-slot-width-granularity;
         }
-        default "flexi-swg-12p5ghz";
+        default "l0-types:flexi-swg-12p5ghz";
         description
           "Minimum space between slot widths.";
         reference

--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -1377,74 +1377,78 @@ module ietf-layer0-types {
 
   grouping wdm-label-range-info {
     description
-      "WDM label range related information.
+      "Label range information for WDM.
 
        This grouping SHOULD be used together with the
        wdm-label-start-end and wdm-label-step groupings to provide
        WDM technology-specific label information to the models which
        use the label-restriction-info grouping defined in the module
        ietf-te-types.";
-    uses l0-label-range-info;
-    container flexi-grid {
-      when 'derived-from-or-self(../grid-type, '
-         + '"l0-types:flexi-grid-dwdm")' {
-        description
-          "Applicable only when the grid type is flexi-grid-dwdm.";
-      }
+    container wdm-label-range {
       description
-        "flexi-grid definition.";
-      leaf slot-width-granularity {
-        type identityref {
-          base flexi-slot-width-granularity;
-        }
-        default "l0-types:flexi-swg-12p5ghz";
-        description
-          "Minimum space between slot widths.";
-        reference
-          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                     Grid Dense Wavelength Division Multiplexing
-                     (DWDM) Networks";
-      }
-      leaf min-slot-width-factor {
-        type uint16 {
-          range "1..max";
+        "Label range information for WDM.";
+      uses l0-label-range-info;
+      container flexi-grid {
+        when 'derived-from-or-self(../grid-type, '
+           + '"l0-types:flexi-grid-dwdm")' {
+          description
+            "Applicable only when the grid type is flexi-grid-dwdm.";
         }
         description
-          "A multiplier of the slot width granularity, indicating
-           the minimum slot width supported by an optical port.
-
-           Minimum slot width is calculated by:
-             Minimum slot width (GHz) =
-               min-slot-width-factor * slot-width-granularity.";
-        reference
-          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                     Grid Dense Wavelength Division Multiplexing
-                     (DWDM) Networks";
-      }
-      leaf max-slot-width-factor {
-        type uint16 {
-          range "1..max";
+          "flexi-grid definition.";
+        leaf slot-width-granularity {
+          type identityref {
+            base flexi-slot-width-granularity;
+          }
+          default "l0-types:flexi-swg-12p5ghz";
+          description
+            "Minimum space between slot widths.";
+          reference
+            "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                      Grid Dense Wavelength Division Multiplexing
+                      (DWDM) Networks";
         }
-        must '. >= ../min-slot-width-factor' {
-          error-message
-            "Maximum slot width must be greater than or equal to
-             minimum slot width.";
+        leaf min-slot-width-factor {
+          type uint16 {
+            range "1..max";
+          }
+          description
+            "A multiplier of the slot width granularity, indicating
+             the minimum slot width supported by an optical port.
+
+             Minimum slot width is calculated by:
+                Minimum slot width (GHz) =
+                  min-slot-width-factor * slot-width-granularity.";
+          reference
+            "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                      Grid Dense Wavelength Division Multiplexing
+                      (DWDM) Networks";
         }
-        description
-          "A multiplier of the slot width granularity, indicating
-           the maximum slot width supported by an optical port.
+        leaf max-slot-width-factor {
+          type uint16 {
+            range "1..max";
+          }
+          must '. >= ../min-slot-width-factor' {
+            error-message
+              "Maximum slot width must be greater than or equal to
+               minimum slot width.";
+          }
+          description
+            "A multiplier of the slot width granularity, indicating
+             the maximum slot width supported by an optical port.
 
-           Maximum slot width is calculated by:
-             Maximum slot width (GHz) =
-               max-slot-width-factor * slot-width-granularity
+             Maximum slot width is calculated by:
+                Maximum slot width (GHz) =
+                  max-slot-width-factor * slot-width-granularity
 
-           If specified, maximum slot width must be greater than or
-           equal to minimum slot width.  If not specified, maximum
-           slot width is equal to minimum slot width.";
-        reference
-          "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
-                     Grid Dense Wavelength Division Multiplexing
-                     (DWDM) Networks";
+             If specified, maximum slot width must be greater than or
+             equal to minimum slot width.  If not specified, maximum
+             slot width is equal to minimum slot width.";
+          reference
+            "RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-
+                      Grid Dense Wavelength Division Multiplexing
+                      (DWDM) Networks";
+        }
       }
     }
   }
@@ -1467,39 +1471,47 @@ module ietf-layer0-types {
                  Label Switching Routers
        RFC 7699: Generalized Labels for the Flexi-Grid in Lambda
                  Switch Capable (LSC) Label Switching Routers";
-    leaf dwdm-n {
-      when 'derived-from-or-self(../../../grid-type, '
-         + '"l0-types:wson-grid-dwdm")' {
-        description
-          "Valid only when grid type is a fixed DWDM grid.";
-      }
-      type dwdm-n;
+    container wdm-label {
       description
-        "The given value 'N' is used to determine the
-         nominal central frequency on a DWDM fixed grid.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    leaf cwdm-n {
-      when 'derived-from-or-self(../../../grid-type, '
-         + '"l0-types:wson-grid-cwdm")' {
+        "Label start or label end for WDM.
+
+         The format of the label depends on the type of WDM grid
+         specified in the 'grid-type' leaf defined in the
+         wdm-label-range-info grouping.";
+      leaf dwdm-n {
+        when 'derived-from-or-self(../../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-dwdm")' {
+          description
+            "Valid only when grid type is a fixed DWDM grid.";
+        }
+        type dwdm-n;
         description
-          "Valid only when grid type is a CWDM grid.";
+          "The given value 'N' is used to determine the
+           nominal central frequency on a DWDM fixed grid.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
       }
-      type cwdm-n;
-      description
-        "The given value 'N' is used to determine the nominal
-         central wavelength on a CWDM fixed grid.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    uses flexi-grid-label-start-end {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:flexi-grid-dwdm")' {
+      leaf cwdm-n {
+        when 'derived-from-or-self(../../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-cwdm")' {
+          description
+            "Valid only when grid type is a CWDM grid.";
+        }
+        type cwdm-n;
         description
-          "Valid only when grid type is a flexible DWDM grid.";
+          "The given value 'N' is used to determine the nominal
+           central wavelength on a CWDM fixed grid.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
+      }
+      uses flexi-grid-label-start-end {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:flexi-grid-dwdm")' {
+          description
+            "Valid only when grid type is a flexible DWDM grid.";
+        }
       }
     }
   }
@@ -1525,101 +1537,113 @@ module ietf-layer0-types {
        RFC 8363: GMPLS OSPF-TE Extensions in Support of Flexi-Grid
                  Dense Wavelength Division Multiplexing (DWDM)
                  Networks";
-    leaf wson-dwdm-channel-spacing {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:wson-grid-dwdm")' {
-        description
-          "Valid only when grid type is a fixed DWDM grid.";
-      }
-      type identityref {
-        base dwdm-ch-spc-type;
-      }
+    container wdm-label-step {
       description
-        "The channel spacing (GHz) of a fixed DWDM grid, e.g.,
-         100 GHz, 50 GHz, 25 GHz, or 12.5 GHz.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    leaf wson-cwdm-channel-spacing {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:wson-grid-cwdm")' {
+        "Label step for WDM.
+
+         The format of the label depends on the type of WDM grid
+         specified in the 'grid-type' leaf defined in the
+         wdm-label-range-info grouping.";
+      leaf wson-dwdm-channel-spacing {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-dwdm")' {
+          description
+            "Valid only when grid type is a fixed DWDM grid.";
+        }
+        type identityref {
+          base dwdm-ch-spc-type;
+        }
         description
-          "Valid only when grid type is a CWDM grid.";
+          "The channel spacing (GHz) of a fixed DWDM grid, e.g.,
+           100 GHz, 50 GHz, 25 GHz, or 12.5 GHz.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
       }
-      type identityref {
-        base cwdm-ch-spc-type;
-      }
-      description
-        "The channel spacing (nm) of a fixed CWDM grid, e.g., 20nm
-         (which is the only standardized value).";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                   (LSC) Label Switching Routers";
-    }
-    container flexi-grid-cfg {
-      when 'derived-from-or-self(../../grid-type, '
-         + '"l0-types:flexi-grid-dwdm")' {
+      leaf wson-cwdm-channel-spacing {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:wson-grid-cwdm")' {
+          description
+            "Valid only when grid type is a CWDM grid.";
+        }
+        type identityref {
+          base cwdm-ch-spc-type;
+        }
         description
-          "Valid only when grid type is a flexible DWDM grid.";
+          "The channel spacing (nm) of a fixed CWDM grid, e.g., 20nm
+           (which is the only standardized value).";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                    (LSC) Label Switching Routers";
       }
-      description
-        "The Central Frequency Granularity (CFG) of a flexible DWDM
-         grid (flexi-grid), defined as a multiplier of the Nominal
-         central frequency granularity (NCFG).";
-      uses flexi-grid-label-step;
+      container flexi-grid-cfg {
+        when 'derived-from-or-self(../../../wdm-label-range'
+           + '/grid-type, "l0-types:flexi-grid-dwdm")' {
+          description
+            "Valid only when grid type is a flexible DWDM grid.";
+        }
+        description
+          "The Central Frequency Granularity (CFG) of a flexible DWDM
+           grid (flexi-grid), defined as a multiplier of the Nominal
+           central frequency granularity (NCFG).";
+        uses flexi-grid-label-step;
+      }
     }
   }
 
   grouping wdm-label-hop {
     description
       "Generic label-hop information for DWDM and CWDM labels.";
-    choice grid-type {
+    container wdm-label {
       description
-        "Label for DWDM or CWDM grid.";
-      reference
-        "RFC 6205: Generalized Labels for Lambda-Switch-Capable (LSC)
-                   Label Switching Routers";
-      case fixed-dwdm {
-        choice fixed-single-or-multi-channel {
-          description
-            "Single channel or multichannel.";
-          case single {
-            leaf dwdm-n {
-              type dwdm-n;
-              description
-                "The given value 'N' is used to determine the
-                 nominal central frequency.";
+        "Label hop for WDM.";
+      choice grid-type {
+        description
+          "Label for DWDM or CWDM grid.";
+        reference
+          "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                     (LSC) Label Switching Routers";
+        case fixed-dwdm {
+          choice fixed-single-or-multi-channel {
+            description
+              "Single channel or multichannel.";
+            case single {
+              leaf dwdm-n {
+                type dwdm-n;
+                description
+                  "The given value 'N' is used to determine the
+                   nominal central frequency.";
+              }
             }
-          }
-          case multi {
-            leaf-list subcarrier-dwdm-n {
-              type dwdm-n;
-              min-elements 2;
-              description
-                "The given values 'N' are used to determine the
-                 nominal central frequency for each subcarrier
-                 channel.";
-              reference
-                "ITU-T G.694.1 (10/2020): Spectral grids for WDM
-                             applications: DWDM frequency grid";
+            case multi {
+              leaf-list subcarrier-dwdm-n {
+                type dwdm-n;
+                min-elements 2;
+                description
+                  "The given values 'N' are used to determine the
+                   nominal central frequency for each subcarrier
+                   channel.";
+                reference
+                  "ITU-T G.694.1 (10/2020): Spectral grids for WDM
+                              applications: DWDM frequency grid";
+              }
             }
           }
         }
-      }
-      case cwdm {
-        leaf cwdm-n {
-          type cwdm-n;
-          description
-            "The given value 'N' is used to determine the nominal
-             central wavelength.";
-          reference
-            "RFC 6205: Generalized Labels for Lambda-Switch-Capable
-                       (LSC) Label Switching Routers";
+        case cwdm {
+          leaf cwdm-n {
+            type cwdm-n;
+            description
+              "The given value 'N' is used to determine the nominal
+               central wavelength.";
+            reference
+              "RFC 6205: Generalized Labels for Lambda-Switch-Capable
+                        (LSC) Label Switching Routers";
+          }
         }
-      }
-      case flexi-grid {
-        uses flexi-grid-label-hop;
+        case flexi-grid {
+          uses flexi-grid-label-hop;
+        }
       }
     }
   }


### PR DESCRIPTION
Added prefixes to default statements

Added containers (in line with the TNBI guidelines in https://github.com/ietf-ccamp-wg/transport-nbi/blob/master/guidelines/multi-layer-topology-instance.md): with this change we can get around the pyang compilation issue spotted in https://github.com/mbj4668/pyang/issues/937 and https://github.com/mbj4668/pyang/issues/938